### PR TITLE
docs(cassandra): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/cassandra/scaling/vertical-scaling/cassandra-vertical-scaling-topology-inplace.yaml
+++ b/docs/examples/cassandra/scaling/vertical-scaling/cassandra-vertical-scaling-topology-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: CassandraOpsRequest
+metadata:
+  name: cassandra-vertical-scale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: cassandra-prod
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "2"
+        limits:
+          memory: "4Gi"
+          cpu: "3"
+  timeout: 5m
+  apply: IfReady

--- a/docs/guides/cassandra/concepts/cassandraopsrequest.md
+++ b/docs/guides/cassandra/concepts/cassandraopsrequest.md
@@ -334,6 +334,8 @@ limits:
 
 Here, when you specify the resource request, the scheduler uses this information to decide which node to place the container of the Pod on and when you specify a resource limit for the container, the `kubelet` enforces those limits so that the running container is not allowed to use more of that resource than the limit you set. You can found more details from [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 
+`spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
+
 ### spec.volumeExpansion
 
 > To use the volume expansion feature the storage class must support volume expansion

--- a/docs/guides/cassandra/scaling/vertical-scaling/overview.md
+++ b/docs/guides/cassandra/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `Cassandra` resources, the `KubeDB` Ops-manager operator resumes the `Cassandra` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `CassandraOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of Cassandra database using `CassandraOpsRequest` CRD.

--- a/docs/guides/cassandra/scaling/vertical-scaling/topology.md
+++ b/docs/guides/cassandra/scaling/vertical-scaling/topology.md
@@ -154,6 +154,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `cassandra-prod` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on cassandra.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/cassandra/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `CassandraOpsRequest` CR we have shown above,
 
@@ -294,6 +295,45 @@ $  kubectl get pod -n demo cassandra-prod-rack-r0-0 -o json | jq '.spec.containe
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Cassandra topology cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`CassandraOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: CassandraOpsRequest
+metadata:
+  name: cassandra-vertical-scale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: cassandra-prod
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "2"
+        limits:
+          memory: "4Gi"
+          cpu: "3"
+  timeout: 5m
+  apply: IfReady
+```
+
+Let's create the `CassandraOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/cassandra/scaling/vertical-scaling/cassandra-vertical-scaling-topology-inplace.yaml
+cassandraopsrequest.ops.kubedb.com/cassandra-vertical-scale-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on CassandraOpsRequest: adds a Vertical Scaling Modes section to the overview, a mode note + In-Place subsection to the guide(s), and an `-inplace` example OpsRequest YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support and examples for in-place Cassandra vertical scaling without Pod restarts.
  * Added configurable vertical scaling modes: `Restart` (default) and `InPlace`.
  * In-place scaling automatically falls back to restart-based scaling when required resources cannot be applied.

* **Documentation**
  * Updated Cassandra scaling guides with configuration details, examples, prerequisites, and Kubernetes version guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->