### PR TITLE
docs(clickhouse): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/clickhouse/scaling/vertical-scaling/ch-vertical-ops-cluster-inplace.yaml
+++ b/docs/examples/clickhouse/scaling/vertical-scaling/ch-vertical-ops-cluster-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ClickHouseOpsRequest
+metadata:
+  name: ch-scale-vertical-cluster-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: clickhouse-prod
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "3"
+        limits:
+          memory: "3Gi"
+          cpu: "3"

--- a/docs/examples/clickhouse/scaling/vertical-scaling/ch-vertical-ops-standalone-inplace.yaml
+++ b/docs/examples/clickhouse/scaling/vertical-scaling/ch-vertical-ops-standalone-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ClickHouseOpsRequest
+metadata:
+  name: ch-vertical-scale-standalone-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: clickhouse-prod
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "3"
+        limits:
+          memory: "3Gi"
+          cpu: "3"

--- a/docs/guides/clickhouse/concepts/clickhouseopsrequest.md
+++ b/docs/guides/clickhouse/concepts/clickhouseopsrequest.md
@@ -327,6 +327,8 @@ limits:
 
 Here, when you specify the resource request, the scheduler uses this information to decide which node to place the container of the Pod on and when you specify a resource limit for the container, the `kubelet` enforces those limits so that the running container is not allowed to use more of that resource than the limit you set. You can found more details from [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
+
 ### spec.volumeExpansion
 
 > To use the volume expansion feature the storage class must support volume expansion

--- a/docs/guides/clickhouse/scaling/vertical-scaling/cluster.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/cluster.md
@@ -168,6 +168,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `clickhouse-prod` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on clickhouse.
 - `spec.verticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/clickhouse/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 
@@ -329,6 +330,43 @@ Now, we are going to verify from one of the Pod yaml whether the resources of th
 ```
 
 The above output verifies that we have successfully scaled up the resources of the ClickHouse cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`ClickHouseOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ClickHouseOpsRequest
+metadata:
+  name: ch-scale-vertical-cluster-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: clickhouse-prod
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "3"
+        limits:
+          memory: "3Gi"
+          cpu: "3"
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/scaling/vertical-scaling/ch-vertical-ops-cluster-inplace.yaml
+clickhouseopsrequest.ops.kubedb.com/ch-scale-vertical-cluster-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/clickhouse/scaling/vertical-scaling/overview.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `ClickHouse` resources, the `KubeDB` Ops-manager operator resumes the `ClickHouse` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `ClickHouseOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of ClickHouse database using `ClickHouseOpsRequest` CRD.

--- a/docs/guides/clickhouse/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/standalone.md
@@ -136,6 +136,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `clickhouse-prod` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on clickhouse.
 - `spec.verticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/clickhouse/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 
@@ -259,6 +260,43 @@ Now, we are going to verify from one of the Pod yaml whether the resources of th
 ```
 
 The above output verifies that we have successfully scaled up the resources of the ClickHouse cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`ClickHouseOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ClickHouseOpsRequest
+metadata:
+  name: ch-vertical-scale-standalone-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: clickhouse-prod
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "3"
+        limits:
+          memory: "3Gi"
+          cpu: "3"
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/scaling/vertical-scaling/ch-vertical-ops-standalone-inplace.yaml
+clickhouseopsrequest.ops.kubedb.com/ch-vertical-scale-standalone-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on ClickHouseOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support examples for in-place vertical scaling of ClickHouse clusters and standalone deployments.
  * Documented `Restart` and `InPlace` scaling modes, including automatic fallback behavior when in-place resizing is unavailable.

* **Documentation**
  * Added configuration examples, usage instructions, and Kubernetes requirements for in-place scaling.
  * Clarified default scaling behavior and Pod restart expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->