### PR TITLE
docs(hanadb): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/hanadb/scaling/system-replication-vertical-scaling-inplace.yaml
+++ b/docs/examples/hanadb/scaling/system-replication-vertical-scaling-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: hanadb-cluster
+  verticalScaling:
+    mode: InPlace
+    hanadb:
+      resources:
+        requests:
+          cpu: "2100m"
+          memory: "8448Mi"
+        limits:
+          cpu: "4"
+          memory: "14Gi"
+  timeout: 30m
+  apply: IfReady

--- a/docs/guides/hanadb/concepts/opsrequest.md
+++ b/docs/guides/hanadb/concepts/opsrequest.md
@@ -85,6 +85,10 @@ Each type reads its own sub-spec:
   configuration. `restart` is `auto` (default), `true`, or `false`.
 - `spec.tls` — `{ issuerRef, certificates, rotateCertificates, remove }` for `ReconfigureTLS`.
 - `spec.verticalScaling` — `{ hanadb, coordinator, exporter }` resources for `VerticalScaling`.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the
+  new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the
+  Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod
+  whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 - `spec.volumeExpansion` — `{ hanadb, mode }` where `mode` is `Online` or `Offline`, for `VolumeExpansion`.
 - `spec.horizontalScaling` — `{ replicas }` for `HorizontalScaling` (System Replication only, `>= 2`).
 - `spec.migration` — `{ storageClassName, oldPVReclaimPolicy }` for `StorageMigration`.

--- a/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md
@@ -20,6 +20,26 @@ cluster).
 
 > Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/scaling](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/scaling) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `HanaDBOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 ## Before You Begin
 
 - Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
@@ -76,6 +96,7 @@ Here,
 - `spec.verticalScaling.hanadb.resources` are the desired resources for the `hanadb` container. You can
   also scale the `coordinator` and `exporter` containers via `spec.verticalScaling.coordinator` and
   `spec.verticalScaling.exporter`.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](#vertical-scaling-modes).
 
 ## Verify the Scaling
 
@@ -128,6 +149,43 @@ $ kubectl get pod -n demo hanadb-cluster-0 -o json | jq '.spec.containers[] | se
   }
 }
 ```
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`HanaDBOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: hanadb-cluster
+  verticalScaling:
+    mode: InPlace
+    hanadb:
+      resources:
+        requests:
+          cpu: "2100m"
+          memory: "8448Mi"
+        limits:
+          cpu: "4"
+          memory: "14Gi"
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/scaling/system-replication-vertical-scaling-inplace.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-vscale-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on the HANA OpsRequest: Vertical Scaling Modes section, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an example configuration for performing in-place vertical scaling of a HanaDB deployment.
  * Added support documentation for choosing between restart-based and in-place vertical scaling.
  * Documented automatic fallback behavior when in-place resizing is unavailable.

* **Documentation**
  * Added setup instructions and a complete example for applying in-place resource updates without restarting Pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->