### PR TITLE
docs(druid): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/druid/concepts/druidopsrequest.md
+++ b/docs/guides/druid/concepts/druidopsrequest.md
@@ -324,6 +324,7 @@ If you want to scale-up or scale-down your Druid cluster or different components
 - `spec.verticalScaling.routers` indicates the desired resources for routers of Druid topology cluster after scaling.
 - `spec.verticalScaling.historicals` indicates the desired resources for historicals of Druid topology cluster after scaling.
 - `spec.verticalScaling.middleManagers` indicates the desired resources for middleManagers of Druid topology cluster after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 All of them has the below structure:
 

--- a/docs/guides/druid/scaling/vertical-scaling/guide.md
+++ b/docs/guides/druid/scaling/vertical-scaling/guide.md
@@ -211,6 +211,7 @@ Here,
 - `spec.type` specifies that we are performing `VerticalScaling` on druid.
 - `spec.VerticalScaling.coordinators` specifies the desired resources of `coordinators` node after scaling.
 - `spec.VerticalScaling.historicals` specifies the desired resources of `historicals` node after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/druid/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 > **Note:** Similarly you can scale other druid nodes vertically by specifying the following fields:
 > - For `overlords` use `spec.verticalScaling.overlords`.
@@ -433,6 +434,53 @@ $ kubectl get pod -n demo druid-cluster-historicals-1 -o json | jq '.spec.contai
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Druid topology cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`DruidOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: DruidOpsRequest
+metadata:
+  name: druid-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: druid-cluster
+  verticalScaling:
+    mode: InPlace
+    coordinators:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+    historicals:
+      resources:
+        requests:
+          memory: "1.1Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.1Gi"
+          cpu: "0.6"
+  timeout: 5m
+  apply: IfReady
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/scaling/vertical-scaling/yamls/druid-vscale-inplace.yaml
+druidopsrequest.ops.kubedb.com/druid-vscale-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/druid/scaling/vertical-scaling/overview.md
+++ b/docs/guides/druid/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `Druid` resources, the `KubeDB` Ops-manager operator resumes the `Druid` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `DruidOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of Druid database using `DruidOpsRequest` CRD.

--- a/docs/guides/druid/scaling/vertical-scaling/yamls/druid-vscale-inplace.yaml
+++ b/docs/guides/druid/scaling/vertical-scaling/yamls/druid-vscale-inplace.yaml
@@ -1,0 +1,29 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: DruidOpsRequest
+metadata:
+    name: druid-vscale-inplace
+    namespace: demo
+spec:
+    type: VerticalScaling
+    databaseRef:
+        name: druid-cluster
+    verticalScaling:
+        mode: InPlace
+        coordinators:
+            resources:
+                requests:
+                    memory: "1.2Gi"
+                    cpu: "0.6"
+                limits:
+                    memory: "1.2Gi"
+                    cpu: "0.6"
+        historicals:
+            resources:
+                requests:
+                    memory: "1.1Gi"
+                    cpu: "0.6"
+                limits:
+                    memory: "1.1Gi"
+                    cpu: "0.6"
+    timeout: 5m
+    apply: IfReady


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on DruidOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.