### PR TITLE
docs(elasticsearch): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/elasticsearch/scalling/vertical/Elasticsearch-vertical-scaling-combined-inplace.yaml
+++ b/docs/examples/elasticsearch/scalling/vertical/Elasticsearch-vertical-scaling-combined-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ElasticsearchOpsRequest
+metadata:
+  name: vscale-combined-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: es-combined
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        limits:
+          cpu: 1500m
+          memory: 2Gi
+        requests:
+          cpu: 600m
+          memory: 2Gi

--- a/docs/examples/elasticsearch/scalling/vertical/Elasticsearch-vertical-scaling-topology-inplace.yaml
+++ b/docs/examples/elasticsearch/scalling/vertical/Elasticsearch-vertical-scaling-topology-inplace.yaml
@@ -1,0 +1,29 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ElasticsearchOpsRequest
+metadata:
+  name: vscale-topology-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: es-cluster
+  verticalScaling:
+    mode: InPlace
+    master:
+      resources:
+        limits:
+          cpu: 750m
+          memory: 800Mi
+    data:
+      resources:
+        requests:
+          cpu: 760m
+          memory: 900Mi
+    ingest:
+      resources:
+        limits:
+          cpu: 900m
+          memory: 1.2Gi
+        requests:
+          cpu: 800m
+          memory: 1Gi

--- a/docs/guides/elasticsearch/concepts/elasticsearch-ops-request/index.md
+++ b/docs/guides/elasticsearch/concepts/elasticsearch-ops-request/index.md
@@ -169,6 +169,7 @@ It specifies the necessary information required to horizontally scale the Elasti
   - `topology.master` - specifies the desired resources for the master nodes. It takes input same as the k8s [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types).
   - `topology.data` - specifies the desired node resources for the data nodes. It takes input  same as the k8s [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types).
   - `topology.ingest` - specifies the desired node resources for the ingest nodes. It takes input  same as the k8s [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types).
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 > Note: It is recommended not to use resources below the default one; `cpu: 500m, memory: 1Gi`.
 

--- a/docs/guides/elasticsearch/scaling/vertical/combined.md
+++ b/docs/guides/elasticsearch/scaling/vertical/combined.md
@@ -141,6 +141,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `es-combined` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on Elasticsearch.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](overview.md#vertical-scaling-modes).
 
 Let's create the `ElasticsearchOpsRequest` CR we have shown above,
 
@@ -292,6 +293,41 @@ $ kubectl get pod -n demo es-combined-0 -o json | jq '.spec.containers[].resourc
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Elasticsearch combined cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`ElasticsearchOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ElasticsearchOpsRequest
+metadata:
+  name: vscale-combined-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: es-combined
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        limits:
+          cpu: 1500m
+          memory: 2Gi
+        requests:
+          cpu: 600m
+          memory: 2Gi
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/elasticsearch/scalling/vertical/Elasticsearch-vertical-scaling-combined-inplace.yaml
+Elasticsearchopsrequest.ops.kubedb.com/vscale-combined-inplace created
+```
 
 ## Cleaning Up
 

--- a/docs/guides/elasticsearch/scaling/vertical/overview.md
+++ b/docs/guides/elasticsearch/scaling/vertical/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `Elasticsearch` resources, the `KubeDB` Ops-manager operator resumes the `Elasticsearch` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `ElasticsearchOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of Elasticsearch database using `ElasticsearchOpsRequest` CRD.

--- a/docs/guides/elasticsearch/scaling/vertical/topology.md
+++ b/docs/guides/elasticsearch/scaling/vertical/topology.md
@@ -189,6 +189,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `es-cluster` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on Elasticsearch.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](overview.md#vertical-scaling-modes).
 
 Let's create the `ElasticsearchOpsRequest` CR we have shown above,
 
@@ -673,6 +674,51 @@ $ kubectl get pod -n demo es-cluster-master-0  -o json | jq '.spec.containers[].
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Elasticsearch topology cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`ElasticsearchOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ElasticsearchOpsRequest
+metadata:
+  name: vscale-topology-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: es-cluster
+  verticalScaling:
+    mode: InPlace
+    master:
+      resources:
+        limits:
+          cpu: 750m
+          memory: 800Mi
+    data:
+      resources:
+        requests:
+          cpu: 760m
+          memory: 900Mi
+    ingest:
+      resources:
+        limits:
+          cpu: 900m
+          memory: 1.2Gi
+        requests:
+          cpu: 800m
+          memory: 1Gi
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/elasticsearch/scalling/vertical/Elasticsearch-vertical-scaling-topology-inplace.yaml
+Elasticsearchopsrequest.ops.kubedb.com/vscale-topology-inplace created
+```
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on ElasticsearchOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.