### PR TITLE
docs(hazelcast): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/hazelcast/scaling/vertical-scaling/hz-vscale-up-inplace.yaml
+++ b/docs/examples/hazelcast/scaling/vertical-scaling/hz-vscale-up-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HazelcastOpsRequest
+metadata:
+  name: hz-vscale-up-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: hz-prod
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    hazelcast:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi

--- a/docs/guides/hazelcast/concepts/hazelcast-opsrequest.md
+++ b/docs/guides/hazelcast/concepts/hazelcast-opsrequest.md
@@ -203,6 +203,8 @@ limits:
 
 Here, when you specify the resource request for Hazelcast member, KubeDB will create a new [PetSet](https://github.com/kubeops/petset) and [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) with the new resource requirements and drop the old PetSet and StatefulSet.
 
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
+
 ### spec.volumeExpansion
 
 To expand the storage of the Hazelcast cluster, you have to specify `spec.volumeExpansion` section. This field consists of the following sub-field:

--- a/docs/guides/hazelcast/scaling/vertical-scaling/overview.md
+++ b/docs/guides/hazelcast/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The updating process consists of the following steps:
 
 9. After successfully updating of `Hazelcast` object, the `KubeDB` Enterprise operator resumes the `Hazelcast` object so that the `KubeDB` Community operator can resume its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `HazelcastOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step-by-step guide on vertical scaling of a Hazelcast database using vertical scaling operation.

--- a/docs/guides/hazelcast/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/hazelcast/scaling/vertical-scaling/vertical-scaling.md
@@ -144,6 +144,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `hz-prod` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.hazelcast` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/hazelcast/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `HazelcastOpsRequest` CR we have shown above,
 
@@ -281,6 +282,41 @@ $ kubectl get pod -n demo hz-prod-0 -o json | jq '.spec.containers[].resources'
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Hazelcast database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`HazelcastOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HazelcastOpsRequest
+metadata:
+  name: hz-vscale-up-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: hz-prod
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    hazelcast:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hazelcast/scaling/vertical-scaling/hz-vscale-up-inplace.yaml
+hazelcastopsrequest.ops.kubedb.com/hz-vscale-up-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on HazelcastOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.