### PR TITLE
docs(memcached): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/memcached/scaling/vertical-scaling-inplace.yaml
+++ b/docs/examples/memcached/scaling/vertical-scaling-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MemcachedOpsRequest
+metadata:
+  name: memcached-mc-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: memcd-quickstart
+  verticalScaling:
+    mode: InPlace
+    memcached:
+      resources:
+        requests:
+          memory: "400Mi"
+          cpu: "500m"
+        limits:
+          memory: "400Mi"
+          cpu: "500m"

--- a/docs/guides/memcached/concepts/memcached-opsrequest.md
+++ b/docs/guides/memcached/concepts/memcached-opsrequest.md
@@ -139,6 +139,8 @@ Here, when you specify the resource request for `Memcached` container, the sched
 
 - `spec.verticalScaling.exporter` indicates the `exporter` container resources. It has the same structure as `spec.verticalScaling.memcached` and you can scale the resource the same way as `memcached` container.
 
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
+
 >You can increase/decrease resources for both memcached  container and exporter container on a single MemcachedOpsRequest CR.
 
 ### spec.timeout

--- a/docs/guides/memcached/scaling/vertical-scaling/overview.md
+++ b/docs/guides/memcached/scaling/vertical-scaling/overview.md
@@ -49,4 +49,24 @@ The updating process consists of the following steps:
 
 10. After successfully updating of `Memcached`object, the `KubeDB` Enterprise operator resumes the `Memcached` object so that the `KubeDB` Community operator can resume its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `MemcachedOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step-by-step guide on updating of a Memcached database using update operation.

--- a/docs/guides/memcached/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/memcached/scaling/vertical-scaling/vertical-scaling.md
@@ -140,6 +140,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `memcd-quickstart` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.memcached` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/memcached/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `MemcachedOpsRequest` CR we have shown above,
 
@@ -178,6 +179,43 @@ $ kubectl get pod -n demo memcd-quickstart-0 -o json | jq '.spec.containers[].re
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Memcached database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`MemcachedOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MemcachedOpsRequest
+metadata:
+  name: memcached-mc-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: memcd-quickstart
+  verticalScaling:
+    mode: InPlace
+    memcached:
+      resources:
+        requests:
+          memory: "400Mi"
+          cpu: "500m"
+        limits:
+          memory: "400Mi"
+          cpu: "500m"
+```
+
+Let's create the `MemcachedOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/scaling/vertical-scaling-inplace.yaml
+memcachedopsrequest.ops.kubedb.com/memcached-mc-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on MemcachedOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.