### PR TITLE
docs(ignite): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/ignite/scaling/vertical-scaling/igops-vscale-inplace.yaml
+++ b/docs/examples/ignite/scaling/vertical-scaling/igops-vscale-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: IgniteOpsRequest
+metadata:
+  name: igops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: ig
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+  timeout: 5m
+  apply: IfReady

--- a/docs/guides/ignite/concepts/opsrequest.md
+++ b/docs/guides/ignite/concepts/opsrequest.md
@@ -199,3 +199,10 @@ A `IgniteOpsRequest` object has the following fields in the `spec` section.
 - `Restart`
 - `RotateAuth`
 - `StorageMigration`
+
+### spec.verticalScaling
+
+`spec.verticalScaling` specifies the desired resources (requests and limits) for the database when `spec.type` is `VerticalScaling`. It consists of the following sub-fields:
+
+- `spec.verticalScaling.node` specifies the desired resources for the Ignite nodes.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.

--- a/docs/guides/ignite/scaling/vertical-scaling/overview.md
+++ b/docs/guides/ignite/scaling/vertical-scaling/overview.md
@@ -52,4 +52,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `Ignite` resources, the `KubeDB` Ops-manager operator resumes the `Ignite` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `IgniteOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of Ignite database using `IgniteOpsRequest` CRD.

--- a/docs/guides/ignite/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/ignite/scaling/vertical-scaling/vertical-scaling.md
@@ -137,6 +137,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on the `ig` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/ignite/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 - Have a look [here](/docs/guides/ignite/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.
 
 Let's create the `IgniteOpsRequest` CR we have shown above,
@@ -292,6 +293,43 @@ $ kubectl get pod -n demo ig-0 -o json | jq '.spec.containers[].resources'
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Ignite database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`IgniteOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: IgniteOpsRequest
+metadata:
+  name: igops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: ig
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+  timeout: 5m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/scaling/vertical-scaling/igops-vscale-inplace.yaml
+igniteopsrequest.ops.kubedb.com/igops-vscale-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on IgniteOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.