### PR TITLE
docs(milvus): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/milvus/concepts/milvusopsrequest.md
+++ b/docs/guides/milvus/concepts/milvusopsrequest.md
@@ -258,6 +258,8 @@ resources:
     memory: "2Gi"
 ```
 
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
+
 ### spec.horizontalScaling
 
 Used when `spec.type: HorizontalScaling`.

--- a/docs/guides/milvus/scaling/vertical-scaling/guide.md
+++ b/docs/guides/milvus/scaling/vertical-scaling/guide.md
@@ -63,7 +63,10 @@ spec:
   apply: IfReady
 ```
 
-Here, `spec.verticalScaling.node` carries the new resources for the **standalone** workload (use the `node` key for standalone).
+Here,
+
+- `spec.verticalScaling.node` carries the new resources for the **standalone** workload (use the `node` key for standalone).
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/milvus/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/milvus/scaling/vertical-scaling/yamls/vertical-scaling-standalone.yaml
@@ -111,6 +114,45 @@ $ kubectl get milvuses.kubedb.com milvus-standalone -n demo -o jsonpath='{.spec.
 $ kubectl get petset milvus-standalone -n demo -o jsonpath='{.spec.template.spec.containers[0].resources}'
 {"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"2Gi"}}
 ```
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`MilvusOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+`vertical-scaling-standalone-inplace.yaml`
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MilvusOpsRequest
+metadata:
+  name: vertical-scaling-standalone-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: milvus-standalone
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+  timeout: 5m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/milvus/scaling/vertical-scaling/yamls/vertical-scaling-standalone-inplace.yaml
+milvusopsrequest.ops.kubedb.com/vertical-scaling-standalone-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Vertical Scaling Distributed Milvus
 

--- a/docs/guides/milvus/scaling/vertical-scaling/overview.md
+++ b/docs/guides/milvus/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The flow is:
 4. Pods are restarted (evicted and recreated) so they come up with the new resources.
 5. The operator resumes the database and marks the `MilvusOpsRequest` as `Successful`.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `MilvusOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we will see a step-by-step guide on vertically scaling a Milvus database.

--- a/docs/guides/milvus/scaling/vertical-scaling/yamls/vertical-scaling-standalone-inplace.yaml
+++ b/docs/guides/milvus/scaling/vertical-scaling/yamls/vertical-scaling-standalone-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MilvusOpsRequest
+metadata:
+  name: vertical-scaling-standalone-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: milvus-standalone
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+  timeout: 5m
+  apply: IfReady


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on MilvusOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.