### PR TITLE
docs(mariadb): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/mariadb/concepts/opsrequest/index.md
+++ b/docs/guides/mariadb/concepts/opsrequest/index.md
@@ -255,6 +255,7 @@ If you want to scale-up or scale-down your MariaDB cluster or different componen
 - `spec.verticalScaling.mariadb` indicates the desired resources for MariaDB standalone or cluster after scaling.
 - `spec.verticalScaling.exporter` indicates the desired resources for the `exporter` container.
 - `spec.verticalScaling.coordinator` indicates the desired resources for the `coordinator` container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`. For a distributed deployment, in-place resize is not possible, so `InPlace` degrades to `Restart`.
 
 
 All of them has the below structure:

--- a/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/mdops-vscale-inplace.yaml
+++ b/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/mdops-vscale-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MariaDBOpsRequest
+metadata:
+  name: mdops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: sample-mariadb
+  verticalScaling:
+    mode: InPlace
+    mariadb:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"

--- a/docs/guides/mariadb/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mariadb/scaling/vertical-scaling/cluster/index.md
@@ -137,6 +137,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `sample-mariadb` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.mariadb` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/#vertical-scaling-modes).
 
 Let's create the `MariaDBOpsRequest` CR we have shown above,
 
@@ -175,6 +176,45 @@ $ kubectl get pod -n demo sample-mariadb-0 -o json | jq '.spec.containers[].reso
 ```
 
 The above output verifies that we have successfully scaled up the resources of the MariaDB database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`MariaDBOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MariaDBOpsRequest
+metadata:
+  name: mdops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: sample-mariadb
+  verticalScaling:
+    mode: InPlace
+    mariadb:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+```
+
+Let's apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/mdops-vscale-inplace.yaml
+mariadbopsrequest.ops.kubedb.com/mdops-vscale-inplace created
+```
+
+The resources update in place with no Pod restart.
+
+> **Note:** For a **distributed** `MariaDB` deployment, true in-place resize is not possible, so `InPlace` automatically degrades to `Restart`.
 
 ## Cleaning Up
 

--- a/docs/guides/mariadb/scaling/vertical-scaling/maxscale.md
+++ b/docs/guides/mariadb/scaling/vertical-scaling/maxscale.md
@@ -141,6 +141,7 @@ Here,
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `md-replication` database.
 - `spec.VerticalScaling.maxscale` specifies the desired resources of maxscale server after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/mariadb/scaling/vertical-scaling/overview/#vertical-scaling-modes).
 
 Let's create the `MariaDBOpsRequest` CR we have shown above,
 

--- a/docs/guides/mariadb/scaling/vertical-scaling/overview/index.md
+++ b/docs/guides/mariadb/scaling/vertical-scaling/overview/index.md
@@ -51,4 +51,25 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `MariaDB` resources, the `KubeDB` Enterprise operator resumes the `MariaDB` object so that the `KubeDB` Community operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `MariaDBOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod. For a **distributed** `MariaDB`
+  deployment, in-place resize is not possible, so `InPlace` automatically degrades to `Restart`.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of MariaDB database using `MariaDBOpsRequest` CRD.


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on MariaDBOpsRequest: Vertical Scaling Modes section (incl. the distributed-degrades-to-Restart caveat), a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.