### PR TITLE
docs(kafka): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/kafka/scaling/vertical-scaling/kafka-vertical-scaling-combined-inplace.yaml
+++ b/docs/examples/kafka/scaling/vertical-scaling/kafka-vertical-scaling-combined-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: KafkaOpsRequest
+metadata:
+  name: kfops-vscale-combined-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: kafka-dev
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/kafka/scaling/vertical-scaling/kafka-vertical-scaling-topology-inplace.yaml
+++ b/docs/examples/kafka/scaling/vertical-scaling/kafka-vertical-scaling-topology-inplace.yaml
@@ -1,0 +1,29 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: KafkaOpsRequest
+metadata:
+  name: kfops-vscale-topology-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: kafka-prod
+  verticalScaling:
+    mode: InPlace
+    broker:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+    controller:
+      resources:
+        requests:
+          memory: "1.1Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.1Gi"
+          cpu: "0.6"
+  timeout: 5m
+  apply: IfReady

--- a/docs/guides/kafka/concepts/kafkaopsrequest.md
+++ b/docs/guides/kafka/concepts/kafkaopsrequest.md
@@ -455,6 +455,7 @@ If you want to scale-up or scale-down your Kafka cluster or different components
 - `spec.verticalScaling.node` indicates the desired resources for combined Kafka cluster after scaling.
 - `spec.verticalScaling.broker` indicates the desired resources for broker of Kafka topology cluster after scaling.
 - `spec.verticalScaling.controller` indicates the desired resources for controller of Kafka topology cluster after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 > If the reference kafka object is combined cluster, then you can only specify `spec.verticalScaling.node` field. If the reference kafka object is topology cluster, then you can only specify `spec.verticalScaling.broker` or `spec.verticalScaling.controller` or both fields. You can not specify `spec.verticalScaling.node` field with any other fields at the same time, but you can specify `spec.verticalScaling.broker` and `spec.verticalScaling.controller` fields at the same time.
 

--- a/docs/guides/kafka/scaling/vertical-scaling/combined.md
+++ b/docs/guides/kafka/scaling/vertical-scaling/combined.md
@@ -142,6 +142,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `kafka-dev` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on kafka.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](overview.md#vertical-scaling-modes).
 
 Let's create the `KafkaOpsRequest` CR we have shown above,
 
@@ -287,6 +288,45 @@ $ kubectl get pod -n demo kafka-dev-1 -o json | jq '.spec.containers[].resources
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Kafka combined cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`KafkaOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: KafkaOpsRequest
+metadata:
+  name: kfops-vscale-combined-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: kafka-dev
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+  timeout: 5m
+  apply: IfReady
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/kafka/scaling/vertical-scaling/kafka-vertical-scaling-combined-inplace.yaml
+kafkaopsrequest.ops.kubedb.com/kfops-vscale-combined-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/kafka/scaling/vertical-scaling/overview.md
+++ b/docs/guides/kafka/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `Kafka` resources, the `KubeDB` Ops-manager operator resumes the `Kafka` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `KafkaOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of Kafka database using `KafkaOpsRequest` CRD.

--- a/docs/guides/kafka/scaling/vertical-scaling/topology.md
+++ b/docs/guides/kafka/scaling/vertical-scaling/topology.md
@@ -174,6 +174,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `kafka-prod` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on kafka.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](overview.md#vertical-scaling-modes).
 
 Let's create the `KafkaOpsRequest` CR we have shown above,
 
@@ -374,6 +375,53 @@ $ kubectl get pod -n demo kafka-prod-controller-1 -o json | jq '.spec.containers
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Kafka topology cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`KafkaOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: KafkaOpsRequest
+metadata:
+  name: kfops-vscale-topology-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: kafka-prod
+  verticalScaling:
+    mode: InPlace
+    broker:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+    controller:
+      resources:
+        requests:
+          memory: "1.1Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.1Gi"
+          cpu: "0.6"
+  timeout: 5m
+  apply: IfReady
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/kafka/scaling/vertical-scaling/kafka-vertical-scaling-topology-inplace.yaml
+kafkaopsrequest.ops.kubedb.com/kfops-vscale-topology-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on KafkaOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.