### PR TITLE
docs(mongodb): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/mongodb/scaling/vertical-scaling/mops-vscale-replicaset-inplace.yaml
+++ b/docs/examples/mongodb/scaling/vertical-scaling/mops-vscale-replicaset-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MongoDBOpsRequest
+metadata:
+  name: mops-vscale-replicaset-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: mg-replicaset
+  verticalScaling:
+    mode: InPlace
+    replicaSet:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"

--- a/docs/guides/mongodb/concepts/opsrequest.md
+++ b/docs/guides/mongodb/concepts/opsrequest.md
@@ -605,6 +605,7 @@ If you want to scale-up or scale-down your MongoDB cluster or different componen
 - `spec.verticalScaling.exporter` indicates the desired resources for the `exporter` container.
 - `spec.verticalScaling.arbiter` indicates the desired resources for arbiter node of MongoDB database after scaling.
 - `spec.verticalScaling.coordinator` indicates the desired resources for the coordinator container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 All of them has the below structure:
 

--- a/docs/guides/mongodb/scaling/vertical-scaling/overview.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `MongoDB` resources, the `KubeDB` Ops-manager operator resumes the `MongoDB` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `MongoDBOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of MongoDB database using `MongoDBOpsRequest` CRD.

--- a/docs/guides/mongodb/scaling/vertical-scaling/replicaset.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/replicaset.md
@@ -145,6 +145,7 @@ Here,
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.replicaSet` specifies the desired resources after scaling.
 - `spec.VerticalScaling.arbiter` could also be specified in similar fashion to get the desired resources for arbiter pod.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/mongodb/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 - Have a look [here](/docs/guides/mongodb/concepts/opsrequest.md#specreadinesscriteria) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 Let's create the `MongoDBOpsRequest` CR we have shown above,
@@ -299,6 +300,48 @@ $ kubectl get pod -n demo mg-replicaset-0 -o json | jq '.spec.containers[].resou
 ```
 
 The above output verifies that we have successfully scaled up the resources of the MongoDB replicaset database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`MongoDBOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MongoDBOpsRequest
+metadata:
+  name: mops-vscale-replicaset-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: mg-replicaset
+  verticalScaling:
+    mode: InPlace
+    replicaSet:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+  readinessCriteria:
+    oplogMaxLagSeconds: 20
+    objectsCountDiffPercentage: 10
+  timeout: 5m
+  apply: IfReady
+```
+
+Let's create the `MongoDBOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mongodb/scaling/vertical-scaling/mops-vscale-replicaset-inplace.yaml
+mongodbopsrequest.ops.kubedb.com/mops-vscale-replicaset-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/mongodb/scaling/vertical-scaling/sharding.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/sharding.md
@@ -194,6 +194,7 @@ Here,
 - `spec.VerticalScaling.configServer` specifies the desired resources after scaling for the configServer nodes.
 - `spec.VerticalScaling.mongos` specifies the desired resources after scaling for the mongos nodes.
 - `spec.VerticalScaling.arbiter` could also be specified in similar fashion to get the desired resources for arbiter pod.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/mongodb/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 - Have a look [here](/docs/guides/mongodb/concepts/opsrequest.md#specreadinesscriteria) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 > **Note:** If you don't want to scale all the components together, you can only specify the components (shard, configServer and mongos) that you want to scale.

--- a/docs/guides/mongodb/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/standalone.md
@@ -140,6 +140,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `mops-vscale-standalone` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.standalone` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/mongodb/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 - Have a look [here](/docs/guides/mongodb/concepts/opsrequest.md#specreadinesscriteria) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 Let's create the `MongoDBOpsRequest` CR we have shown above,


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on MongoDBOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.