### PR TITLE
docs(mssqlserver): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/mssqlserver/scaling/vertical-scaling/mops-vscale-standalone-inplace.yaml
+++ b/docs/examples/mssqlserver/scaling/vertical-scaling/mops-vscale-standalone-inplace.yaml
@@ -1,0 +1,18 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MSSQLServerOpsRequest
+metadata:
+  name: mops-vscale-standalone-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: mssql-standalone
+  verticalScaling:
+    mode: InPlace
+    mssqlserver:
+      resources:
+        requests:
+          memory: "5Gi"
+          cpu: "1000m"
+        limits:
+          memory: "5Gi"

--- a/docs/guides/mssqlserver/concepts/opsrequest.md
+++ b/docs/guides/mssqlserver/concepts/opsrequest.md
@@ -165,6 +165,7 @@ resources:
 Here, when you specify the resource request for `MSSQLServer` container, the scheduler uses this information to decide which node to place the container of the Pod on and when you specify a resource limit for `MSSQLServer` container, the `kubelet` enforces those limits so that the running container is not allowed to use more of that resource than the limit you set. you can found more details from [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
 
 - `spec.verticalScaling.exporter` indicates the `exporter` container resources. It has the same structure as `spec.verticalScaling.mssqlserver` and you can scale the resource the same way as `MSSQLServer` container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 >You can increase/decrease resources for both `MSSQLServer` container and `exporter` container on a single `MSSQLServerOpsRequest` CR.
 

--- a/docs/guides/mssqlserver/scaling/vertical-scaling/ag_cluster.md
+++ b/docs/guides/mssqlserver/scaling/vertical-scaling/ag_cluster.md
@@ -244,6 +244,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `mssql-ag-cluster` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.mssqlserver` specifies the expected `mssql` container resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/mssqlserver/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `MSSQLServerOpsRequest` CR we have shown above,
 

--- a/docs/guides/mssqlserver/scaling/vertical-scaling/overview.md
+++ b/docs/guides/mssqlserver/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After successful updating of the `MSSQLServer` resources, the `KubeDB` Ops Manager resumes the `MSSQLServer` object so that the `KubeDB` Provisioner operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `MSSQLServerOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step-by-step guide on updating resources of MSSQLServer database using vertical scaling operation.

--- a/docs/guides/mssqlserver/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/mssqlserver/scaling/vertical-scaling/standalone.md
@@ -207,6 +207,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `mssql-standalone` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.mssqlserver` specifies the expected `mssql` container resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/mssqlserver/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `MSSQLServerOpsRequest` CR we have shown above,
 
@@ -339,6 +340,42 @@ $ kubectl get pod -n demo mssql-standalone-0 -o json | jq '.spec.containers[0].r
 ```
 
 The above output verifies that we have successfully scaled up the resources of the MSSQLServer.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`MSSQLServerOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MSSQLServerOpsRequest
+metadata:
+  name: mops-vscale-standalone-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: mssql-standalone
+  verticalScaling:
+    mode: InPlace
+    mssqlserver:
+      resources:
+        requests:
+          memory: "5Gi"
+          cpu: "1000m"
+        limits:
+          memory: "5Gi"
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/scaling/vertical-scaling/mops-vscale-standalone-inplace.yaml
+mssqlserveropsrequest.ops.kubedb.com/mops-vscale-standalone-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on MSSQLServerOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.