### PR TITLE
docs(neo4j): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/neo4j/scaling/vertical-scaling/ops-request-inplace.yaml
+++ b/docs/examples/neo4j/scaling/vertical-scaling/ops-request-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: Neo4jOpsRequest
+metadata:
+  name: neo4j-vertical-scale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: neo4j-test
+  verticalScaling:
+    mode: InPlace
+    server:
+      resources:
+        limits:
+          cpu: 1500m
+          memory: 4Gi
+        requests:
+          cpu: 700m
+          memory: 4Gi

--- a/docs/guides/neo4j/concepts/opsrequest.md
+++ b/docs/guides/neo4j/concepts/opsrequest.md
@@ -305,6 +305,7 @@ spec:
 - Set the operation-specific section that matches `spec.type`, such as `spec.updateVersion`, `spec.verticalScaling`, `spec.volumeExpansion`, `spec.horizontalScaling`, `spec.migration`, `spec.authentication`, `spec.configuration`, or `spec.tls`.
 - `spec.updateVersion.targetVersion` selects the target `Neo4jVersion` for an `UpdateVersion` request.
 - `spec.verticalScaling.server.resources` defines the new CPU and memory requests and limits for Neo4j server Pods.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 - `spec.volumeExpansion.mode` chooses whether storage expansion runs in `Online` or `Offline` mode, and `spec.volumeExpansion.server` sets the new PVC size for the server volume.
 - `spec.migration.storageClassName` selects the destination StorageClass for `StorageMigration`, and `spec.migration.oldPVReclaimPolicy` controls old PV reclaim behavior (`Delete` or `Retain`).
 - `spec.horizontalScaling.server` sets the desired number of Neo4j servers. `spec.horizontalScaling.reallocate.strategy` controls post-scaling reallocation, and `spec.horizontalScaling.reallocate.batchSize` is used with the `incremental` strategy.

--- a/docs/guides/neo4j/scaling/vertical-scaling/overview.md
+++ b/docs/guides/neo4j/scaling/vertical-scaling/overview.md
@@ -41,6 +41,26 @@ For a `Neo4jOpsRequest` with `spec.type: VerticalScaling`, KubeDB Ops-manager:
 5. Waits for pods to become healthy with new resources.
 6. Marks the request `Successful` after reconciliation.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `Neo4jOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 ## Next Step
 
 Follow the detailed guide: [Scale Neo4j Vertically](/docs/guides/neo4j/scaling/vertical-scaling/scale-vertically/index.md).

--- a/docs/guides/neo4j/scaling/vertical-scaling/scale-vertically/index.md
+++ b/docs/guides/neo4j/scaling/vertical-scaling/scale-vertically/index.md
@@ -209,6 +209,38 @@ neo4j-vertical-scale   VerticalScaling   Successful   101s
 
 ---
 
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`Neo4jOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: Neo4jOpsRequest
+metadata:
+  name: neo4j-vertical-scale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: neo4j-test
+  verticalScaling:
+    mode: InPlace
+    server:
+      resources:
+        requests:
+          cpu: "700m"
+          memory: "4Gi"
+        limits:
+          cpu: "1500m"
+          memory: "4Gi"
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
+
+---
+
 ## Understanding the OpsRequest Fields
 
 | Field | Description |
@@ -217,6 +249,7 @@ neo4j-vertical-scale   VerticalScaling   Successful   101s
 | `spec.databaseRef.name` | Name of the target `Neo4j` resource |
 | `spec.verticalScaling.server.resources.requests` | Minimum CPU/memory guaranteed to the pod |
 | `spec.verticalScaling.server.resources.limits` | Maximum CPU/memory the pod is allowed to use |
+| `spec.verticalScaling.mode` | How the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview.md#vertical-scaling-modes). |
 
 > **Tip:** Always set `requests` equal to `limits` for Neo4j in production. This gives the pod a [Guaranteed QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/), preventing it from being evicted under memory pressure.
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on Neo4jOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.