### PR TITLE
docs(percona-xtradb): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/percona-xtradb/concepts/opsrequest/index.md
+++ b/docs/guides/percona-xtradb/concepts/opsrequest/index.md
@@ -255,6 +255,7 @@ If you want to scale-up or scale-down your PerconaXtraDB cluster or different co
 - `spec.verticalScaling.perconaxtradb` indicates the desired resources for PerconaXtraDB standalone or cluster after scaling.
 - `spec.verticalScaling.exporter` indicates the desired resources for the `exporter` container.
 - `spec.verticalScaling.coordinator` indicates the desired resources for the `coordinator` container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 
 All of them has the below structure:

--- a/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/example/pxops-vscale-inplace.yaml
+++ b/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/example/pxops-vscale-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: PerconaXtraDBOpsRequest
+metadata:
+  name: pxops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: sample-pxc
+  verticalScaling:
+    mode: InPlace
+    perconaxtradb:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"

--- a/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/index.md
@@ -137,6 +137,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `sample-pxc` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.perconaxtradb` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/#vertical-scaling-modes).
 
 Let's create the `PerconaXtraDBOpsRequest` CR we have shown above,
 
@@ -175,6 +176,43 @@ $ kubectl get pod -n demo sample-pxc-0 -o json | jq '.spec.containers[].resource
 ```
 
 The above output verifies that we have successfully scaled up the resources of the PerconaXtraDB database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`PerconaXtraDBOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: PerconaXtraDBOpsRequest
+metadata:
+  name: pxops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: sample-pxc
+  verticalScaling:
+    mode: InPlace
+    perconaxtradb:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/example/pxops-vscale-inplace.yaml
+perconaxtradbopsrequest.ops.kubedb.com/pxops-vscale-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/percona-xtradb/scaling/vertical-scaling/overview/index.md
+++ b/docs/guides/percona-xtradb/scaling/vertical-scaling/overview/index.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `PerconaXtraDB` resources, the `KubeDB` Enterprise operator resumes the `PerconaXtraDB` object so that the `KubeDB` Community operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `PerconaXtraDBOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of PerconaXtraDB database using `PerconaXtraDBOpsRequest` CRD.


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on PerconaXtraDBOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.