### PR TITLE
docs(mysql): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/mysql/verticalscaling/vertical_scale_group_inplace.yaml
+++ b/docs/examples/mysql/verticalscaling/vertical_scale_group_inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MySQLOpsRequest
+metadata:
+  name: my-scale-group-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: my-group
+  verticalScaling:
+    mode: InPlace
+    mysql:
+      resources:
+        requests:
+          memory: "200Mi"
+          cpu: "0.1"
+        limits:
+          memory: "300Mi"
+          cpu: "0.2"

--- a/docs/guides/mysql/concepts/opsrequest/index.md
+++ b/docs/guides/mysql/concepts/opsrequest/index.md
@@ -168,6 +168,8 @@ Here, when you specify the resource request for `MySQL` container, the scheduler
 
 - `spec.verticalScaling.exporter` indicates the `exporter` container resources. It has the same structure as `spec.verticalScaling.mysql` and you can scale the resource the same way as `mysql` container.
 
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
+
 >You can increase/decrease resources for both `mysql` container and `exporter` container on a single `MySQLOpsRequest` CR.
 
 ### MySQLOpsRequest `Status`

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
@@ -274,6 +274,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` `MySQL` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.mysql` specifies the expected mysql container resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/index.md#vertical-scaling-modes).
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -394,6 +395,36 @@ $ kubectl get pod -n demo my-group-0 -o json | jq '.spec.containers[1].resources
 ```
 
 The above output verifies that we have successfully updated the resources of the `MySQL` group replication.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`MySQLOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MySQLOpsRequest
+metadata:
+  name: my-scale-group-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: my-group
+  verticalScaling:
+    mode: InPlace
+    mysql:
+      resources:
+        requests:
+          memory: "1200Mi"
+          cpu: "0.7"
+        limits:
+          memory: "1200Mi"
+          cpu: "0.7"
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/mysql/scaling/vertical-scaling/overview/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/overview/index.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After successful updating of the `MySQL` resources, the `KubeDB` Ops Manager resumes the `MySQL` object so that the `KubeDB` community operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `MySQLOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step by step guide on updating resources of MySQL database using vertical scaling operation.

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
@@ -169,6 +169,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` `MySQL` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.mysql` specifies the expected mysql container resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/index.md#vertical-scaling-modes).
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on MySQLOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.