### PR TITLE
docs(postgres): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/postgres/concepts/opsrequest.md
+++ b/docs/guides/postgres/concepts/opsrequest.md
@@ -168,6 +168,8 @@ Here, when you specify the resource request for `Postgres` container, the schedu
 
 - `spec.verticalScaling.exporter` indicates the `exporter` container resources. It has the same structure as `spec.verticalScaling.postgres` and you can scale the resource the same way as `postgres` container.
 
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`. For a distributed deployment, in-place resize is not possible, so `InPlace` degrades to `Restart`.
+
 >You can increase/decrease resources for both `postgres` container and `exporter` container on a single `PostgresOpsRequest` CR.
 
 #### spec.timeout

--- a/docs/guides/postgres/scaling/vertical-scaling/overview/index.md
+++ b/docs/guides/postgres/scaling/vertical-scaling/overview/index.md
@@ -51,4 +51,25 @@ The vertical scaling process consists of the following steps:
 
 9. After successful updating of the `Postgres` resources, the `KubeDB` Ops Manager resumes the `Postgres` object so that the `KubeDB` Provisioner operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `PostgresOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod. For a **distributed** `Postgres`
+  deployment, in-place resize is not possible, so `InPlace` automatically degrades to `Restart`.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step by step guide on updating resources of Postgres database using vertical scaling operation.

--- a/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/index.md
+++ b/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/index.md
@@ -193,6 +193,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `pg` `Postgres` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.postgres` specifies the expected postgres container resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/index.md#vertical-scaling-modes).
 
 Let's create the `PostgresOpsRequest` cr we have shown above,
 
@@ -342,6 +343,43 @@ $ kubectl get pod -n demo pg-0 -o json | jq '.spec.containers[0].resources'
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Postgres.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`PostgresOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources. For a
+**distributed** `Postgres` deployment, in-place resize is not possible, so `InPlace` automatically
+degrades to `Restart`.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: PostgresOpsRequest
+metadata:
+  name: pg-scale-vertical-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: pg
+  verticalScaling:
+    mode: InPlace
+    postgres:
+      resources:
+        requests:
+          memory: "1200Mi"
+          cpu: "0.7"
+        limits:
+          memory: "1200Mi"
+          cpu: "0.7"
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/yamls/pg-vertical-scaling-inplace.yaml
+postgresopsrequest.ops.kubedb.com/pg-scale-vertical-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/yamls/pg-vertical-scaling-inplace.yaml
+++ b/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/yamls/pg-vertical-scaling-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: PostgresOpsRequest
+metadata:
+  name: pg-scale-vertical-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: pg
+  verticalScaling:
+    mode: InPlace
+    postgres:
+      resources:
+        requests:
+          memory: "1200Mi"
+          cpu: "0.7"
+        limits:
+          memory: "1200Mi"
+          cpu: "0.7"


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on PostgresOpsRequest: Vertical Scaling Modes section (incl. the distributed-degrades-to-Restart caveat), a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.