### PR TITLE
docs(qdrant): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/qdrant/scaling/vertical-scaling/vscale-inplace.yaml
+++ b/docs/examples/qdrant/scaling/vertical-scaling/vscale-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: QdrantOpsRequest
+metadata:
+  name: qdops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: qdrant-sample
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+  timeout: 5m
+  apply: IfReady

--- a/docs/guides/qdrant/concepts/opsrequest.md
+++ b/docs/guides/qdrant/concepts/opsrequest.md
@@ -172,6 +172,7 @@ A `QdrantOpsRequest` object has the following fields in the `spec` section:
   - `topology` — the topology constraints for the vertical scaling operation:
     - `key` — the topology key (required).
     - `value` — the topology value (required).
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 #### spec.volumeExpansion
 

--- a/docs/guides/qdrant/scaling/vertical-scaling/overview.md
+++ b/docs/guides/qdrant/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After successful updating of the `Qdrant` resources, the `KubeDB` Ops Manager resumes the `Qdrant` object so that the `KubeDB` Provisioner operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `QdrantOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step-by-step guide on updating resources of Qdrant database using vertical scaling operation.

--- a/docs/guides/qdrant/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/qdrant/scaling/vertical-scaling/vertical-scaling.md
@@ -143,6 +143,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling on `qdrant-sample` Qdrant database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.node.resources` specifies the desired CPU and memory resources for the Qdrant nodes.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/qdrant/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 - `spec.timeout` specifies the timeout for the operation (learn more [here](/docs/guides/qdrant/concepts/opsrequest.md#spectimeout)).
 - `spec.apply` specifies when to apply the operation (learn more [here](/docs/guides/qdrant/concepts/opsrequest.md#specapply)).
 
@@ -184,6 +185,45 @@ $ kubectl get pod -n demo qdrant-sample-0 -o json | jq '.spec.containers[0].reso
 ```
 
 You can see from the above output that the resources of the `qdrant-sample-0` pod have been updated successfully. All pods in the cluster will have the same updated resource configuration.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`QdrantOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: QdrantOpsRequest
+metadata:
+  name: qdops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: qdrant-sample
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+  timeout: 5m
+  apply: IfReady
+```
+
+Let's create the `QdrantOpsRequest` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/qdrant/scaling/vertical-scaling/vscale-inplace.yaml
+qdrantopsrequest.ops.kubedb.com/qdops-vscale-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Next Steps
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on QdrantOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.