### PR TITLE
docs(singlestore): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/singlestore/concepts/opsrequest.md
+++ b/docs/guides/singlestore/concepts/opsrequest.md
@@ -335,6 +335,7 @@ If you want to scale-up or scale-down your SingleStore cluster or different comp
 - `spec.verticalScaling.aggregator` indicates the desired resources for aggregator node of SingleStore cluster after scaling.
 - `spec.verticalScaling.leaf` indicates the desired resources for leaf nodes of SingleStore cluster after scaling.
 - `spec.verticalScaling.coordinator` indicates the desired resources for the coordinator container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 All of them has the below structure:
 

--- a/docs/guides/singlestore/scaling/vertical-scaling/cluster/example/sdbops-vscale-inplace.yaml
+++ b/docs/guides/singlestore/scaling/vertical-scaling/cluster/example/sdbops-vscale-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: SinglestoreOpsRequest
+metadata:
+  name: sdbops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: sample-sdb
+  verticalScaling:
+    mode: InPlace
+    aggregator:
+      resources:
+        requests:
+          memory: "2500Mi"
+          cpu: "0.7"
+        limits:
+          memory: "2500Mi"
+          cpu: "0.7"

--- a/docs/guides/singlestore/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/singlestore/scaling/vertical-scaling/cluster/index.md
@@ -178,6 +178,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `sample-sdb` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.aggregator` specifies the desired `aggregator` nodes resources after scaling. As well you can scale resources for leaf node, standalone node and coordinator container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/#vertical-scaling-modes).
 
 Let's create the `SingleStoreOpsRequest` CR we have shown above,
 
@@ -216,6 +217,43 @@ $ kubectl get pod -n demo sample-sdb-aggregator-0 -o json | jq '.spec.containers
 ```
 
 The above output verifies that we have successfully scaled up the resources of the SingleStore database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`SinglestoreOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: SinglestoreOpsRequest
+metadata:
+  name: sdbops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: sample-sdb
+  verticalScaling:
+    mode: InPlace
+    aggregator:
+      resources:
+        requests:
+          memory: "2500Mi"
+          cpu: "0.7"
+        limits:
+          memory: "2500Mi"
+          cpu: "0.7"
+```
+
+Apply it the same way as above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/singlestore/scaling/vertical-scaling/cluster/example/sdbops-vscale-inplace.yaml
+singlestoreopsrequest.ops.kubedb.com/sdbops-vscale-inplace created
+```
+
+The resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/singlestore/scaling/vertical-scaling/overview/index.md
+++ b/docs/guides/singlestore/scaling/vertical-scaling/overview/index.md
@@ -49,4 +49,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `SingleStore` resources, the `KubeDB` Ops-manager operator resumes the `SingleStore` object so that the `KubeDB` Provisioner operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `SinglestoreOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of SingleStore database using `SingleStoreOpsRequest` CRD.


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on SinglestoreOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.