### PR TITLE
docs(redis): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/redis/scaling/vertical-scaling/vertical-cluster-inplace.yaml
+++ b/docs/examples/redis/scaling/vertical-scaling/vertical-cluster-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: RedisOpsRequest
+metadata:
+  name: redisops-vertical-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: redis-cluster
+  verticalScaling:
+    mode: InPlace
+    redis:
+      resources:
+        requests:
+          memory: "300Mi"
+          cpu: "200m"
+        limits:
+          memory: "800Mi"
+          cpu: "500m"

--- a/docs/guides/redis/concepts/redisopsrequest.md
+++ b/docs/guides/redis/concepts/redisopsrequest.md
@@ -151,6 +151,7 @@ limits:
 Here, when you specify the resource request for `Redis` container, the scheduler uses this information to decide which node to place the container of the Pod on and when you specify a resource limit for `Redis` container, the `kubelet` enforces those limits so that the running container is not allowed to use more of that resource than the limit you set. you can found more details from [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
 
 - `spec.verticalScaling.exporter` indicates the `exporter` container resources. It has the same structure as `spec.verticalScaling.redis` and you can scale the resource the same way as `redis` container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 >You can increase/decrease resources for both `redis` container and `exporter` container on a single `RedisOpsRequest` CR.
 

--- a/docs/guides/redis/scaling/vertical-scaling/cluster.md
+++ b/docs/guides/redis/scaling/vertical-scaling/cluster.md
@@ -159,6 +159,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `redis-cluster` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.redis` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/redis/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `RedisOpsRequest` CR we have shown above,
 
@@ -209,6 +210,41 @@ $ kubectl get pod -n demo redis-cluster-shard1-1 -o json | jq '.spec.containers[
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Redis cluster database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`RedisOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: RedisOpsRequest
+metadata:
+  name: redisops-vertical-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: redis-cluster
+  verticalScaling:
+    mode: InPlace
+    redis:
+      resources:
+        requests:
+          memory: "300Mi"
+          cpu: "200m"
+        limits:
+          memory: "800Mi"
+          cpu: "500m"
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/redis/scaling/vertical-scaling/vertical-cluster-inplace.yaml
+redisopsrequest.ops.kubedb.com/redisops-vertical-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning up
 

--- a/docs/guides/redis/scaling/vertical-scaling/overview.md
+++ b/docs/guides/redis/scaling/vertical-scaling/overview.md
@@ -53,4 +53,24 @@ The updating process consists of the following steps:
 
 10. After successfully updating of `Redis`/`RedisSentinel` object, the `KubeDB` Enterprise operator resumes the `Redis`/`RedisSentinel` object so that the `KubeDB` Community operator can resume its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `RedisOpsRequest` (and `RedisSentinelOpsRequest`):
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next doc, we are going to show a step-by-step guide on updating of a Redis database using update operation.

--- a/docs/guides/redis/scaling/vertical-scaling/sentinel.md
+++ b/docs/guides/redis/scaling/vertical-scaling/sentinel.md
@@ -202,6 +202,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `sen-sample` RedisSentinel instance.
 - `spec.type` specifies that we are going to perform `VerticalScaling` on our database.
 - `spec.verticalScaling.redissentinel` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/redis/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `RedisSentinelOpsRequest` CR we have shown above,
 
@@ -276,6 +277,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing operation on `rd-sample` Redis database.
 - `spec.type` specifies that we are going to perform `VerticalScaling` on our database.
 - `spec.VerticalScaling.redis` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/redis/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `RedisOpsRequest` CR we have shown above,
 

--- a/docs/guides/redis/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/redis/scaling/vertical-scaling/standalone.md
@@ -142,6 +142,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `redis-quickstart` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.redis` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/redis/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 
 Let's create the `RedisOpsRequest` CR we have shown above,
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on RedisOpsRequest / RedisSentinelOpsRequest: Vertical Scaling Modes section in the overview, mode notes + an In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.