### PR TITLE
docs(zookeeper): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/zookeeper/scaling/zk-vscale-inplace.yaml
+++ b/docs/examples/zookeeper/scaling/zk-vscale-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ZooKeeperOpsRequest
+metadata:
+  name: vscale-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: zk-quickstart
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+  timeout: 5m
+  apply: IfReady

--- a/docs/guides/zookeeper/concepts/opsrequest.md
+++ b/docs/guides/zookeeper/concepts/opsrequest.md
@@ -265,6 +265,7 @@ If you want to scale-up or scale-down your ZooKeeper cluster or different compon
 `spec.verticalScaling` is a required field specifying the information of `ZooKeeper` resources like `cpu`, `memory` etc. that will be scaled. This field consists of the following sub-fields:
 
 - `spec.verticalScaling.node` indicates the desired resources for PetSet of ZooKeeper after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 It has the below structure:
 

--- a/docs/guides/zookeeper/scaling/vertical-scaling/overview.md
+++ b/docs/guides/zookeeper/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `ZooKeeper` resources, the `KubeDB` Ops-manager operator resumes the `ZooKeeper` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `ZooKeeperOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the [next](/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md) docs, we are going to show a step by step guide on updating resources of ZooKeeper database using `ZooKeeperOpsRequest` CRD.

--- a/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
@@ -139,6 +139,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `zk-quickstart` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.verticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](/docs/guides/zookeeper/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
 - Have a look [here](/docs/guides/zookeeper/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.
 
 Let's create the `ZooKeeperOpsRequest` CR we have shown above,
@@ -282,6 +283,45 @@ $ kubectl get pod -n demo zk-quickstart-0 -o json | jq '.spec.containers[].resou
 ```
 
 The above output verifies that we have successfully scaled up the resources of the ZooKeeper standalone database.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`ZooKeeperOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ZooKeeperOpsRequest
+metadata:
+  name: vscale-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: zk-quickstart
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+  timeout: 5m
+  apply: IfReady
+```
+
+Let's create the `ZooKeeperOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/zk-vscale-inplace.yaml
+zookeeperopsrequest.ops.kubedb.com/vscale-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on ZooKeeperOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.