### PR TITLE
docs(solr): document InPlace vertical scaling mode

### DIFF
--- a/docs/examples/solr/scaling/vertical/combined/scaling-inplace.yaml
+++ b/docs/examples/solr/scaling/vertical/combined/scaling-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: SolrOpsRequest
+metadata:
+  name: slops-vscale-combined-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: solr-cluster
+  type: VerticalScaling
+  verticalScaling:
+     mode: InPlace
+     node:
+       resources:
+         limits:
+           cpu: 1
+           memory: 2.5Gi
+         requests:
+           cpu: 1
+           memory: 2.5Gi

--- a/docs/examples/solr/scaling/vertical/topology/scaling-inplace.yaml
+++ b/docs/examples/solr/scaling/vertical/topology/scaling-inplace.yaml
@@ -1,0 +1,35 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: SolrOpsRequest
+metadata:
+  name: slops-vscale-topology-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: solr-cluster
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    data:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+    overseer:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+    coordinator:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi

--- a/docs/guides/solr/concepts/solropsrequests.md
+++ b/docs/guides/solr/concepts/solropsrequests.md
@@ -165,6 +165,7 @@ spec:
 - `verticalScaling.overseer` - specifies the desired resources for the overseer nodes. It takes input same as the k8s [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types).
 - `verticalScaling.data` - specifies the desired node resources for the data nodes. It takes input  same as the k8s [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types).
 - `verticalScaling.coordinator` - specifies the desired node resources for the coordinator nodes. It takes input  same as the k8s [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types).
+- `verticalScaling.mode` - specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 > Note: It is recommended not to use resources below the default one; `cpu: 900m, memory: 2Gi`.
 

--- a/docs/guides/solr/scaling/vertical-scaling/combined.md
+++ b/docs/guides/solr/scaling/vertical-scaling/combined.md
@@ -149,6 +149,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `solr-cluster` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on Solr.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](overview.md#vertical-scaling-modes).
 
 Let's create the `SolrOpsRequest` CR we have shown above,
 
@@ -296,6 +297,43 @@ $ kubectl get pod -n demo solr-combined-1 -o json | jq '.spec.containers[].resou
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Solr Combined cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`SolrOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: SolrOpsRequest
+metadata:
+  name: slops-vscale-combined-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: solr-cluster
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    node:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+```
+
+Let's create the `SolrOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/solr/scaling/vertical/combined/scaling-inplace.yaml
+solropsrequest.ops.kubedb.com/slops-vscale-combined-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/solr/scaling/vertical-scaling/overview.md
+++ b/docs/guides/solr/scaling/vertical-scaling/overview.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `Solr` resources, the `KubeDB` Ops-manager operator resumes the `Solr` object so that the `KubeDB` Provisioner  operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `SolrOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of Solr database using `SolrOpsRequest` CRD.

--- a/docs/guides/solr/scaling/vertical-scaling/topology.md
+++ b/docs/guides/solr/scaling/vertical-scaling/topology.md
@@ -196,6 +196,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `solr-cluster` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on Solr.
 - `spec.VerticalScaling.data`, `spec.VerticalScaling.overseer` and `spec.VerticalScaling.coordinator` specifies the desired resources for topologies after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](overview.md#vertical-scaling-modes).
 
 Let's create the `SolrOpsRequest` CR we have shown above,
 
@@ -380,6 +381,59 @@ $ kubectl get pod -n demo solr-cluster-overseer-0 -o json | jq '.spec.containers
 ```
 
 The above output verifies that we have successfully scaled up the resources of the Solr topology cluster.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`SolrOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: SolrOpsRequest
+metadata:
+  name: slops-vscale-topology-inplace
+  namespace: demo
+spec:
+  databaseRef:
+    name: solr-cluster
+  type: VerticalScaling
+  verticalScaling:
+    mode: InPlace
+    data:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+    overseer:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+    coordinator:
+      resources:
+        limits:
+          cpu: 1
+          memory: 2.5Gi
+        requests:
+          cpu: 1
+          memory: 2.5Gi
+```
+
+Let's create the `SolrOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/solr/scaling/vertical/topology/scaling-inplace.yaml
+solropsrequest.ops.kubedb.com/slops-vscale-topology-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on SolrOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guides, and an `-inplace` example OpsRequest YAML.