### PR TITLE
docs(proxysql): document InPlace vertical scaling mode

### DIFF
--- a/docs/guides/proxysql/concepts/opsrequest/index.md
+++ b/docs/guides/proxysql/concepts/opsrequest/index.md
@@ -216,6 +216,7 @@ If you want to scale-up or scale-down your ProxySQL cluster or different compone
 - `spec.verticalScaling.proxysql` indicates the desired resources for ProxySQL standalone or cluster after scaling.
 - `spec.verticalScaling.exporter` indicates the desired resources for the `exporter` container.
 - `spec.verticalScaling.coordinator` indicates the desired resources for the `coordinator` container.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the Pods, while `InPlace` resizes the running Pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any Pod whose Node cannot fit the new resources. Optional; defaults to `Restart`.
 
 
 All of them has the below structure:

--- a/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/proxyops-vscale-inplace.yaml
+++ b/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/proxyops-vscale-inplace.yaml
@@ -1,0 +1,19 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ProxySQLOpsRequest
+metadata:
+  name: proxyops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  proxyRef:
+    name: proxy-server
+  verticalScaling:
+    mode: InPlace
+    proxysql:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"

--- a/docs/guides/proxysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/proxysql/scaling/vertical-scaling/cluster/index.md
@@ -171,6 +171,7 @@ Here,
 - `spec.proxyRef.name` specifies that we are performing vertical scaling operation on `proxy-server` instance.
 - `spec.type` specifies that we are performing `VerticalScaling` on our server.
 - `spec.verticalScaling.proxysql` specifies the desired resources after scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (default, restarts the Pods) or `InPlace` (resizes the running Pods without a restart, falling back to restart if a Node can't fit the new resources). See [Vertical Scaling Modes](../overview/#vertical-scaling-modes).
 
 Let's create the `ProxySQLOpsRequest` CR we have shown above,
 
@@ -209,6 +210,41 @@ $ kubectl get pod -n demo proxy-server-0 -o json | jq '.spec.containers[].resour
 ```
 
 The above output verifies that we have successfully scaled up the resources of the ProxySQL instance.
+
+### In-Place Vertical Scaling
+
+To resize the Pods **without a restart**, set `spec.verticalScaling.mode` to `InPlace` in the
+`ProxySQLOpsRequest`. The operator resizes the running containers via the Kubernetes `pods/resize`
+subresource and only restarts a Pod if its Node cannot accommodate the new resources.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ProxySQLOpsRequest
+metadata:
+  name: proxyops-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  proxyRef:
+    name: proxy-server
+  verticalScaling:
+    mode: InPlace
+    proxysql:
+      resources:
+        requests:
+          memory: "1.2Gi"
+          cpu: "0.6"
+        limits:
+          memory: "1.2Gi"
+          cpu: "0.6"
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/proxyops-vscale-inplace.yaml
+proxysqlopsrequest.ops.kubedb.com/proxyops-vscale-inplace created
+```
+
+Apply it the same way as above; the resources update in place with no Pod restart.
 
 ## Cleaning Up
 

--- a/docs/guides/proxysql/scaling/vertical-scaling/overview/index.md
+++ b/docs/guides/proxysql/scaling/vertical-scaling/overview/index.md
@@ -51,4 +51,24 @@ The vertical scaling process consists of the following steps:
 
 9. After the successful update  of the `ProxySQL` resources, the `KubeDB` Enterprise operator resumes the `ProxySQL` object so that the `KubeDB` Community operator resumes its usual operations.
 
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the `spec.verticalScaling.mode`
+field of the `ProxySQLOpsRequest`:
+
+- **`Restart`** (default): The operator patches the `PetSet` with the new resources and restarts the
+  Pods (one at a time, honoring the database's failover rules) so they come back with the updated CPU
+  and Memory. This works on every Kubernetes cluster.
+- **`InPlace`**: The operator resizes the running containers in place using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no Pod restart, so scaling happens without downtime or failover. If a
+  Node cannot accommodate the new resources (the resize is reported `Infeasible`), the operator
+  automatically falls back to the `Restart` behavior for that Pod.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which is
+> enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is disabled,
+> use `Restart` mode.
+
 In the next docs, we are going to show a step by step guide on updating resources of ProxySQL using `ProxySQLOpsRequest` CRD.


### PR DESCRIPTION
Documents the new `spec.verticalScaling.mode` field (`Restart` default | `InPlace`) on ProxySQLOpsRequest: Vertical Scaling Modes section in the overview, a mode note + In-Place subsection in the guide, and an `-inplace` example OpsRequest YAML.