### PR TITLE
Add etcd user guides

### DIFF
--- a/docs/examples/etcd/autoscaling/compute/etcd-compute-autoscaler.yaml
+++ b/docs/examples/etcd/autoscaling/compute/etcd-compute-autoscaler.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-compute-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-autoscale
+  opsRequestOptions:
+    apply: IfReady
+    timeout: 5m
+  compute:
+    etcd:
+      trigger: "On"
+      podLifeTimeThreshold: 5m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 600m
+        memory: 1.2Gi
+      maxAllowed:
+        cpu: 2
+        memory: 4Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"

--- a/docs/examples/etcd/autoscaling/compute/etcd.yaml
+++ b/docs/examples/etcd/autoscaling/compute/etcd.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-autoscale
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/autoscaling/storage/etcd-storage-autoscaler-rules.yaml
+++ b/docs/examples/etcd/autoscaling/storage/etcd-storage-autoscaler-rules.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-storage-autoscaler-rules
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-autoscale
+  storage:
+    etcd:
+      trigger: "On"
+      usageThreshold: 60
+      expansionMode: "Online"
+      upperBound: 500Gi
+      scalingRules:
+        - appliesUpto: "50Gi"
+          threshold: "50pc"
+        - appliesUpto: "200Gi"
+          threshold: "25pc"
+        - appliesUpto: ""
+          threshold: "50Gi"

--- a/docs/examples/etcd/autoscaling/storage/etcd-storage-autoscaler.yaml
+++ b/docs/examples/etcd/autoscaling/storage/etcd-storage-autoscaler.yaml
@@ -1,0 +1,15 @@
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-storage-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-autoscale
+  storage:
+    etcd:
+      trigger: "On"
+      usageThreshold: 60
+      scalingThreshold: 50
+      expansionMode: "Online"
+      upperBound: 100Gi

--- a/docs/examples/etcd/autoscaling/storage/etcd.yaml
+++ b/docs/examples/etcd/autoscaling/storage/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-autoscale
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "topolvm-provisioner"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/backup/etcd-archiver.yaml
+++ b/docs/examples/etcd/backup/etcd-archiver.yaml
@@ -1,0 +1,39 @@
+apiVersion: archiver.kubedb.com/v1alpha1
+kind: EtcdArchiver
+metadata:
+  name: etcd-archiver
+  namespace: demo
+spec:
+  databases:
+    namespaces:
+      from: Same
+    selector:
+      matchLabels:
+        archiver: "true"
+  backupStorage:
+    ref:
+      name: s3-storage
+      namespace: demo
+    subDir: etcd-archiver
+  retentionPolicy:
+    name: demo-retention
+    namespace: demo
+  encryptionSecret:
+    name: encrypt-secret
+    namespace: demo
+  fullBackup:
+    driver: Restic
+    scheduler:
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 3
+      schedule: "0 */2 * * *"
+      jobTemplate:
+        backoffLimit: 1
+  manifestBackup:
+    scheduler:
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 3
+      schedule: "0 */2 * * *"
+      jobTemplate:
+        backoffLimit: 1
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/backup/restored-etcd.yaml
+++ b/docs/examples/etcd/backup/restored-etcd.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: restored-etcd
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  init:
+    archiver:
+      recoveryTimestamp: "0001-01-01T00:00:00Z"
+      encryptionSecret:
+        name: encrypt-secret
+        namespace: demo
+      fullDBRepository:
+        name: sample-etcd-full
+        namespace: demo
+      manifestRepository:
+        name: sample-etcd-manifest
+        namespace: demo
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/backup/retentionpolicy.yaml
+++ b/docs/examples/etcd/backup/retentionpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.kubestash.com/v1alpha1
+kind: RetentionPolicy
+metadata:
+  name: demo-retention
+  namespace: demo
+spec:
+  default: true
+  failedSnapshots:
+    last: 2
+  maxRetentionPeriod: 2mo
+  successfulSnapshots:
+    last: 5
+  usagePolicy:
+    allowedNamespaces:
+      from: Same

--- a/docs/examples/etcd/backup/s3-storage.yaml
+++ b/docs/examples/etcd/backup/s3-storage.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.kubestash.com/v1alpha1
+kind: BackupStorage
+metadata:
+  name: s3-storage
+  namespace: demo
+spec:
+  storage:
+    provider: s3
+    s3:
+      endpoint: ap-south-1.linodeobjects.com
+      bucket: kubestash-etcd
+      region: ap-south-1
+      prefix: etcd-demo
+      secretName: s3-secret
+  usagePolicy:
+    allowedNamespaces:
+      from: All
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/backup/sample-etcd.yaml
+++ b/docs/examples/etcd/backup/sample-etcd.yaml
@@ -1,0 +1,22 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: sample-etcd
+  namespace: demo
+  labels:
+    archiver: "true"
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  archiver:
+    ref:
+      name: etcd-archiver
+      namespace: demo
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/backup/trigger-backupsession.yaml
+++ b/docs/examples/etcd/backup/trigger-backupsession.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.kubestash.com/v1alpha1
+kind: BackupSession
+metadata:
+  name: manual-full-backup
+  namespace: demo
+spec:
+  invoker:
+    apiGroup: core.kubestash.com
+    kind: BackupConfiguration
+    name: sample-etcd-archiver
+  session: full-backup

--- a/docs/examples/etcd/custom-configuration/etcd-custom-config.yaml
+++ b/docs/examples/etcd/custom-configuration/etcd-custom-config.yaml
@@ -1,0 +1,23 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-custom-config
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/custom-configuration/etcd-extra-args.yaml
+++ b/docs/examples/etcd/custom-configuration/etcd-extra-args.yaml
@@ -1,0 +1,25 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-extra-args
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          args:
+            - --heartbeat-interval=250
+            - --election-timeout=2500
+            - --max-request-bytes=3145728
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/custom-rbac/etcd-custom-db-two.yaml
+++ b/docs/examples/etcd/custom-rbac/etcd-custom-db-two.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: minute-etcd
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 1
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      serviceAccountName: my-custom-serviceaccount
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  deletionPolicy: DoNotTerminate

--- a/docs/examples/etcd/custom-rbac/etcd-custom-db.yaml
+++ b/docs/examples/etcd/custom-rbac/etcd-custom-db.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      serviceAccountName: my-custom-serviceaccount
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  deletionPolicy: DoNotTerminate

--- a/docs/examples/etcd/custom-rbac/etcd-custom-role.yaml
+++ b/docs/examples/etcd/custom-rbac/etcd-custom-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: my-custom-role
+  namespace: demo
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - etcd-db
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/docs/examples/etcd/gitops/etcd.yaml
+++ b/docs/examples/etcd/gitops/etcd.yaml
@@ -1,0 +1,27 @@
+apiVersion: gitops.kubedb.com/v1alpha1
+kind: Etcd
+metadata:
+  name: ha-etcd
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/maintenance/compact-revision.yaml
+++ b/docs/examples/etcd/maintenance/compact-revision.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-compact-revision
+  namespace: demo
+spec:
+  type: Compact
+  databaseRef:
+    name: etcd-cluster
+  compact:
+    revision: 128000
+  timeout: 5m

--- a/docs/examples/etcd/maintenance/compact.yaml
+++ b/docs/examples/etcd/maintenance/compact.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-compact
+  namespace: demo
+spec:
+  type: Compact
+  databaseRef:
+    name: etcd-cluster
+  compact: {}
+  timeout: 5m

--- a/docs/examples/etcd/maintenance/defragment.yaml
+++ b/docs/examples/etcd/maintenance/defragment.yaml
@@ -1,0 +1,10 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-defragment
+  namespace: demo
+spec:
+  type: Defragment
+  databaseRef:
+    name: etcd-cluster
+  defragment: {}

--- a/docs/examples/etcd/maintenance/etcd.yaml
+++ b/docs/examples/etcd/maintenance/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/maintenance/move-leader-auto.yaml
+++ b/docs/examples/etcd/maintenance/move-leader-auto.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-move-leader-auto
+  namespace: demo
+spec:
+  type: MoveLeader
+  databaseRef:
+    name: etcd-cluster
+  moveLeader: {}
+  timeout: 5m

--- a/docs/examples/etcd/maintenance/move-leader.yaml
+++ b/docs/examples/etcd/maintenance/move-leader.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-move-leader
+  namespace: demo
+spec:
+  type: MoveLeader
+  databaseRef:
+    name: etcd-cluster
+  moveLeader:
+    newLeader: etcd-cluster-1
+  timeout: 5m

--- a/docs/examples/etcd/monitoring/builtin-prom-etcd.yaml
+++ b/docs/examples/etcd/monitoring/builtin-prom-etcd.yaml
@@ -1,0 +1,19 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: builtin-prom-etcd
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/builtin
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/monitoring/prom-config.yaml
+++ b/docs/examples/etcd/monitoring/prom-config.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  labels:
+    app: prometheus-demo
+  namespace: monitoring
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+    - job_name: 'kubedb-databases'
+      honor_labels: true
+      scheme: http
+      kubernetes_sd_configs:
+      - role: endpoints
+      # by default Prometheus server selects all Kubernetes services as possible targets.
+      # relabel_config is used to filter only the desired endpoints
+      relabel_configs:
+      # keep only those services that have the "prometheus.io/scrape" and "prometheus.io/port" annotations
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape, __meta_kubernetes_service_annotation_prometheus_io_port]
+        separator: ;
+        regex: true;(.*)
+        action: keep
+      # KubeDB stats services use the "http" scheme, so drop any service that uses "https".
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: drop
+        regex: https
+      # only keep the stats services created by KubeDB for monitoring purposes, which have a "-stats" suffix
+      - source_labels: [__meta_kubernetes_service_name]
+        separator: ;
+        regex: (.*-stats)
+        action: keep
+      # services created by KubeDB have the "app.kubernetes.io/name" label. keep only those services.
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        separator: ;
+        regex: (.*)
+        action: keep
+      # read the metric path from the "prometheus.io/path: <path>" annotation
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      # read the port from the "prometheus.io/port: <port>" annotation and update the scraping address accordingly
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      # add the service namespace as a label on the scraped metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        separator: ;
+        regex: (.*)
+        target_label: namespace
+        replacement: $1
+        action: replace
+      # add the service name as a label on the scraped metrics
+      - source_labels: [__meta_kubernetes_service_name]
+        separator: ;
+        regex: (.*)
+        target_label: service
+        replacement: $1
+        action: replace
+      # add the pod name as a label, so you can tell which etcd member a sample came from
+      - source_labels: [__meta_kubernetes_pod_name]
+        separator: ;
+        regex: (.*)
+        target_label: pod
+        replacement: $1
+        action: replace
+      # add the stats service's labels to the scraped metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)

--- a/docs/examples/etcd/monitoring/prom-etcd.yaml
+++ b/docs/examples/etcd/monitoring/prom-etcd.yaml
@@ -1,0 +1,24 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: prom-etcd
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/private-registry/etcd-pvt-reg.yaml
+++ b/docs/examples/etcd/private-registry/etcd-pvt-reg.yaml
@@ -1,0 +1,29 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-pvt-reg
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      imagePullSecrets:
+        - name: myregistrykey
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/quickstart/etcd.yaml
+++ b/docs/examples/etcd/quickstart/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    resources:
+      requests:
+        storage: "1Gi"
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+  deletionPolicy: "WipeOut"

--- a/docs/examples/etcd/recommendation/etcd.yaml
+++ b/docs/examples/etcd/recommendation/etcd.yaml
@@ -1,0 +1,32 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-recommendation
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  authSecret:
+    name: etcd-recommendation-auth
+    rotateAfter: 720h
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+    certificates:
+      - alias: server
+        duration: 2160h
+      - alias: client
+        duration: 2160h
+      - alias: peer
+        duration: 2160h
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/reconfigure-tls/etcd-issuer.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcd-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: etcd-ca

--- a/docs/examples/etcd/reconfigure-tls/etcd-new-issuer.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcd-new-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-new-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: etcd-new-ca

--- a/docs/examples/etcd/reconfigure-tls/etcd.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/reconfigure-tls/etcdops-add-tls.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcdops-add-tls.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+    certificates:
+      - alias: server
+        subject:
+          organizations:
+            - kubedb
+          organizationalUnits:
+            - server

--- a/docs/examples/etcd/reconfigure-tls/etcdops-remove.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcdops-remove.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-remove-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    remove: true

--- a/docs/examples/etcd/reconfigure-tls/etcdops-rotate.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcdops-rotate.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-rotate
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    rotateCertificates: true

--- a/docs/examples/etcd/reconfigure-tls/etcdops-update-issuer.yaml
+++ b/docs/examples/etcd/reconfigure-tls/etcdops-update-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-update-issuer
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-new-issuer

--- a/docs/examples/etcd/reconfigure/etcd.yaml
+++ b/docs/examples/etcd/reconfigure/etcd.yaml
@@ -1,0 +1,23 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  configuration:
+    tuning:
+      quotaBackendBytes: 2147483648
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/reconfigure/etcdops-reconfigure.yaml
+++ b/docs/examples/etcd/reconfigure/etcdops-reconfigure.yaml
@@ -1,0 +1,16 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: etcd-quickstart
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: revision
+      autoCompactionRetention: "1000"
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/etcd/recover-from-quorum-loss/etcd.yaml
+++ b/docs/examples/etcd/recover-from-quorum-loss/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/recover-from-quorum-loss/etcdops-recover-quorum.yaml
+++ b/docs/examples/etcd/recover-from-quorum-loss/etcdops-recover-quorum.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-recover-quorum
+  namespace: demo
+spec:
+  type: RecoverFromQuorumLoss
+  databaseRef:
+    name: etcd-cluster
+  recoverFromQuorumLoss: {}
+  timeout: 30m
+  apply: Always

--- a/docs/examples/etcd/restart/etcd.yaml
+++ b/docs/examples/etcd/restart/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/restart/ops.yaml
+++ b/docs/examples/etcd/restart/ops.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: etcd-quickstart
+  timeout: 5m
+  apply: Always

--- a/docs/examples/etcd/restore/etcdops-restore.yaml
+++ b/docs/examples/etcd/restore/etcdops-restore.yaml
@@ -1,0 +1,18 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-restore
+  namespace: demo
+spec:
+  type: Restore
+  databaseRef:
+    name: etcd-cluster
+  restore:
+    fullDBRepository:
+      name: etcd-full-repo
+      namespace: demo
+    encryptionSecret:
+      name: encrypt-secret
+      namespace: demo
+  timeout: 30m
+  apply: Always

--- a/docs/examples/etcd/rotate-auth/etcd.yaml
+++ b/docs/examples/etcd/rotate-auth/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/rotate-auth/rotate-auth-generated.yaml
+++ b/docs/examples/etcd/rotate-auth/rotate-auth-generated.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-rotate-auth-generated
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: etcd-quickstart
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/etcd/rotate-auth/rotate-auth-user.yaml
+++ b/docs/examples/etcd/rotate-auth/rotate-auth-user.yaml
@@ -1,0 +1,15 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-rotate-auth-user
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: etcd-quickstart
+  authentication:
+    secretRef:
+      kind: Secret
+      name: etcd-quickstart-user-auth
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/etcd/scaling/horizontal-scaling/etcd.yaml
+++ b/docs/examples/etcd/scaling/horizontal-scaling/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/scaling/horizontal-scaling/etcdops-hscale-down.yaml
+++ b/docs/examples/etcd/scaling/horizontal-scaling/etcdops-hscale-down.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-hscale-down
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: etcd-cluster
+  horizontalScaling:
+    replicas: 3
+  timeout: 20m
+  apply: IfReady

--- a/docs/examples/etcd/scaling/horizontal-scaling/etcdops-hscale-up.yaml
+++ b/docs/examples/etcd/scaling/horizontal-scaling/etcdops-hscale-up.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-hscale-up
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: etcd-cluster
+  horizontalScaling:
+    replicas: 5
+  timeout: 20m
+  apply: IfReady

--- a/docs/examples/etcd/scaling/vertical-scaling/etcd.yaml
+++ b/docs/examples/etcd/scaling/vertical-scaling/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/scaling/vertical-scaling/etcdops-vscale-inplace.yaml
+++ b/docs/examples/etcd/scaling/vertical-scaling/etcdops-vscale-inplace.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: etcd-cluster
+  verticalScaling:
+    mode: InPlace
+    etcd:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "3Gi"
+        limits:
+          cpu: "1"
+          memory: "3Gi"
+  timeout: 10m
+  apply: IfReady

--- a/docs/examples/etcd/scaling/vertical-scaling/etcdops-vscale.yaml
+++ b/docs/examples/etcd/scaling/vertical-scaling/etcdops-vscale.yaml
@@ -1,0 +1,21 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-vscale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: etcd-cluster
+  verticalScaling:
+    mode: Restart
+    etcd:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+  timeout: 10m
+  apply: IfReady

--- a/docs/examples/etcd/storage-migration/etcd.yaml
+++ b/docs/examples/etcd/storage-migration/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "longhorn-single"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/storage-migration/etcdops-storage-migration.yaml
+++ b/docs/examples/etcd/storage-migration/etcdops-storage-migration.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: etcd-cluster
+  migration:
+    storageClassName: longhorn-single-migrated
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/etcd/storage-migration/longhorn-single-migrated.yaml
+++ b/docs/examples/etcd/storage-migration/longhorn-single-migrated.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single-migrated
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fsType: ext4
+  dataLocality: disabled
+  dataEngine: v1

--- a/docs/examples/etcd/storage-migration/longhorn-single.yaml
+++ b/docs/examples/etcd/storage-migration/longhorn-single.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fsType: ext4
+  dataLocality: disabled
+  dataEngine: v1

--- a/docs/examples/etcd/tls/etcd-issuer.yaml
+++ b/docs/examples/etcd/tls/etcd-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: etcd-ca

--- a/docs/examples/etcd/tls/etcd-tls.yaml
+++ b/docs/examples/etcd/tls/etcd-tls.yaml
@@ -1,0 +1,22 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-tls
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/update-version/etcd.yaml
+++ b/docs/examples/etcd/update-version/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.5.21"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/update-version/etcdops-update-version.yaml
+++ b/docs/examples/etcd/update-version/etcdops-update-version.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-update-version
+  namespace: demo
+spec:
+  type: UpdateVersion
+  databaseRef:
+    name: etcd-cluster
+  updateVersion:
+    targetVersion: "3.6.4"
+  timeout: 20m
+  apply: IfReady

--- a/docs/examples/etcd/volume-expansion/etcd.yaml
+++ b/docs/examples/etcd/volume-expansion/etcd.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/etcd/volume-expansion/etcdops-volume-exp-offline.yaml
+++ b/docs/examples/etcd/volume-expansion/etcdops-volume-exp-offline.yaml
@@ -1,0 +1,14 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-volume-exp-offline
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: etcd-cluster
+  volumeExpansion:
+    mode: Offline
+    etcd: 3Gi
+  timeout: 20m
+  apply: IfReady

--- a/docs/examples/etcd/volume-expansion/etcdops-volume-exp-online.yaml
+++ b/docs/examples/etcd/volume-expansion/etcdops-volume-exp-online.yaml
@@ -1,0 +1,14 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-volume-exp-online
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: etcd-cluster
+  volumeExpansion:
+    mode: Online
+    etcd: 2Gi
+  timeout: 20m
+  apply: IfReady

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,6 +21,7 @@ Guides to show you how to perform tasks with KubeDB:
 - [DocumentDB](/docs/guides/documentdb/README.md). Shows how to manage DocumentDB using KubeDB.
 - [Druid](/docs/guides/druid/README.md). Shows how to manage Druid using KubeDB.
 - [Elasticsearch](/docs/guides/elasticsearch/README.md). Shows how to manage Elasticsearch & OpenSearch using KubeDB.
+- [Etcd](/docs/guides/etcd/README.md). Shows how to manage etcd using KubeDB.
 - [Hazelcast](/docs/guides/hazelcast/README.md). Shows how to manage Hazelcast using KubeDB.
 - [Ignite](/docs/guides/ignite/README.md). Shows how to manage Ignite using KubeDB.
 - [Kafka](/docs/guides/kafka/README.md). Shows how to manage Kafka using KubeDB.

--- a/docs/guides/etcd/README.md
+++ b/docs/guides/etcd/README.md
@@ -94,7 +94,7 @@ as healthy while at least `N/2+1` members answer.
 
 - [Quickstart Etcd](/docs/guides/etcd/quickstart/quickstart.md) with KubeDB Operator.
 - Secure your cluster with [TLS/SSL](/docs/guides/etcd/tls/overview.md) and reconfigure it later with [ReconfigureTLS](/docs/guides/etcd/reconfigure-tls/overview.md).
-- Tune etcd with [custom configuration](/docs/guides/etcd/reconfigure/overview.md).
+- Tune etcd with [custom configuration](/docs/guides/etcd/custom-configuration/using-config.md).
 - Scale your cluster [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/overview.md) or [vertically](/docs/guides/etcd/scaling/vertical-scaling/overview.md).
 - [Backup & Restore](/docs/guides/etcd/backup/kubestash/overview/index.md) etcd using KubeStash.
 - [Restore a snapshot in place](/docs/guides/etcd/restore/overview.md) into an `Etcd` cluster that already exists.

--- a/docs/guides/etcd/README.md
+++ b/docs/guides/etcd/README.md
@@ -35,6 +35,8 @@ aliases:
 | Storage Class Migration                                                            |   &#10003;   |
 | Move Raft Leadership / Defragment / Compact                                        |   &#10003;   |
 | Backup/Recovery: Instant, Scheduled ([KubeStash](https://kubestash.com/))          |   &#10003;   |
+| In-place restore into an existing cluster                                          |   &#10003;   |
+| Recovery from a permanent Raft quorum loss                                         |   &#10003;   |
 | Persistent Volume                                                                  |   &#10003;   |
 | Builtin Prometheus Discovery                                                       |   &#10003;   |
 | Using Prometheus operator                                                          |   &#10003;   |
@@ -51,8 +53,11 @@ A few notes on the table above:
   `spec.configuration.tuning` (`quotaBackendBytes`, `autoCompactionMode`,
   `autoCompactionRetention`, `snapshotCount`). etcd's `--config-file` is mutually exclusive
   with the individual command line flags KubeDB has to set for cluster bootstrap, so a
-  free-form config file is intentionally not supported. See
-  [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specconfiguration).
+  free-form config file is intentionally not supported. Anything the tuning knobs do not cover can
+  still be passed as a raw etcd flag through `spec.podTemplate.spec.containers[name=etcd].args`,
+  which is appended after the operator's own flags. See
+  [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specconfiguration) and
+  [Extra etcd flags](/docs/guides/etcd/custom-configuration/using-config.md#extra-etcd-flags).
 - **Backup/Recovery** is snapshot based only. etcd has no WAL-shipping style continuous
   archiving primitive that can be streamed out of the cluster, so there is no point-in-time
   recovery between two full snapshots. See
@@ -91,6 +96,8 @@ as healthy while at least `N/2+1` members answer.
 - Tune etcd with [custom configuration](/docs/guides/etcd/reconfigure/overview.md).
 - Scale your cluster [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/overview.md) or [vertically](/docs/guides/etcd/scaling/vertical-scaling/overview.md).
 - [Backup & Restore](/docs/guides/etcd/backup/kubestash/overview/index.md) etcd using KubeStash.
+- [Restore a snapshot in place](/docs/guides/etcd/restore/overview.md) into an `Etcd` cluster that already exists.
+- [Recover from a permanent quorum loss](/docs/guides/etcd/recover-from-quorum-loss/overview.md) when a majority of members is gone for good.
 - [Rotate the authentication credential](/docs/guides/etcd/rotate-authentication/overview.md) of the etcd `root` user.
 - [Restart](/docs/guides/etcd/restart/restart.md) the members with a leader-aware rolling restart.
 - Autoscale [compute](/docs/guides/etcd/autoscaler/compute/overview.md) and [storage](/docs/guides/etcd/autoscaler/storage/overview.md) resources.

--- a/docs/guides/etcd/README.md
+++ b/docs/guides/etcd/README.md
@@ -1,0 +1,106 @@
+---
+title: Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-readme-etcd
+    name: Etcd
+    parent: etcd-etcd-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+url: /docs/{{ .version }}/guides/etcd/
+aliases:
+  - /docs/{{ .version }}/guides/etcd/README/
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+## Supported Etcd Features
+
+| Features                                                                           | Availability |
+|------------------------------------------------------------------------------------|:------------:|
+| Clustered (single Raft cluster)                                                    |   &#10003;   |
+| Single member cluster (`replicas: 1`)                                              |   &#10003;   |
+| Authentication & Authorization (etcd RBAC, `root` user)                            |   &#10003;   |
+| Custom Configuration (tuning knobs only)                                           |   &#10003;   |
+| Externally manageable Auth Secret                                                  |   &#10003;   |
+| Reconfigurable Health Checker                                                      |   &#10003;   |
+| TLS: Add, Remove, Update, Rotate ( [Cert Manager](https://cert-manager.io/docs/) ) |   &#10003;   |
+| Automated Version update                                                           |   &#10003;   |
+| Automatic Vertical Scaling                                                         |   &#10003;   |
+| Automated Horizontal Scaling (learner add & promote)                               |   &#10003;   |
+| Automated Volume Expansion                                                         |   &#10003;   |
+| Storage Class Migration                                                            |   &#10003;   |
+| Move Raft Leadership / Defragment / Compact                                        |   &#10003;   |
+| Backup/Recovery: Instant, Scheduled ([KubeStash](https://kubestash.com/))          |   &#10003;   |
+| Persistent Volume                                                                  |   &#10003;   |
+| Builtin Prometheus Discovery                                                       |   &#10003;   |
+| Using Prometheus operator                                                          |   &#10003;   |
+| Autoscaler (compute & storage)                                                     |   &#10003;   |
+| Recommendation Engine                                                              |   &#10003;   |
+| GitOps                                                                             |   &#10003;   |
+| Grafana Dashboards                                                                 |   &#10007;   |
+| Continuous Archiving / Point-In-Time Recovery                                      |   &#10007;   |
+| Multi-cluster / Disaster Recovery topology                                         |   &#10007;   |
+
+A few notes on the table above:
+
+- **Custom Configuration** for etcd is limited to the typed tuning knobs exposed through
+  `spec.configuration.tuning` (`quotaBackendBytes`, `autoCompactionMode`,
+  `autoCompactionRetention`, `snapshotCount`). etcd's `--config-file` is mutually exclusive
+  with the individual command line flags KubeDB has to set for cluster bootstrap, so a
+  free-form config file is intentionally not supported. See
+  [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specconfiguration).
+- **Backup/Recovery** is snapshot based only. etcd has no WAL-shipping style continuous
+  archiving primitive that can be streamed out of the cluster, so there is no point-in-time
+  recovery between two full snapshots. See
+  [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md).
+- **Monitoring** does not deploy an exporter sidecar. etcd serves its own Prometheus metrics
+  natively, so KubeDB points the stats Service and the ServiceMonitor straight at etcd.
+- No Grafana dashboards ship with KubeDB for etcd yet.
+
+## Life Cycle of an Etcd Object
+
+An `Etcd` object goes through the following phases, reported in `status.phase`:
+
+| Phase          | Meaning                                                                                                            |
+|----------------|--------------------------------------------------------------------------------------------------------------------|
+| `Provisioning` | The KubeDB operator has accepted the object and is creating the offshoot resources (PetSet, Services, Secrets, RBAC). |
+| `DataRestoring`| The seed member's volume is being restored from a KubeStash snapshot before the cluster is bootstrapped.            |
+| `Ready`        | All members are up, the Raft cluster has quorum and the client endpoint is accepting connections.                   |
+| `Critical`     | The client endpoint is reachable, but not every member is ready (for example a learner is still catching up).       |
+| `NotReady`     | The client endpoint is not reachable — quorum has been lost or every member is down.                                |
+| `Halted`       | `spec.halted` is `true`: every offshoot resource except the PVCs has been deleted.                                  |
+| `Unknown`      | The phase could not be computed.                                                                                   |
+
+In the normal path, an `Etcd` object moves `Provisioning` → `Ready`. When the cluster is
+bootstrapped from a snapshot (`spec.init.archiver`), the operator restores the ordinal-0 volume
+first, so the object passes through `DataRestoring` before the first member is ever started.
+
+The phase is derived from the object's conditions — `ProvisioningStarted`, `ReplicaReady`,
+`AcceptingConnection`, `Ready` and `Provisioned`. The health checker keeps them up to date by
+calling etcd's own `Status()` and `MemberList()` RPCs on the client port and treating the cluster
+as healthy while at least `N/2+1` members answer.
+
+## User Guide
+
+- [Quickstart Etcd](/docs/guides/etcd/quickstart/quickstart.md) with KubeDB Operator.
+- Secure your cluster with [TLS/SSL](/docs/guides/etcd/tls/overview.md) and reconfigure it later with [ReconfigureTLS](/docs/guides/etcd/reconfigure-tls/overview.md).
+- Tune etcd with [custom configuration](/docs/guides/etcd/reconfigure/overview.md).
+- Scale your cluster [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/overview.md) or [vertically](/docs/guides/etcd/scaling/vertical-scaling/overview.md).
+- [Backup & Restore](/docs/guides/etcd/backup/kubestash/overview/index.md) etcd using KubeStash.
+- [Rotate the authentication credential](/docs/guides/etcd/rotate-authentication/overview.md) of the etcd `root` user.
+- [Restart](/docs/guides/etcd/restart/restart.md) the members with a leader-aware rolling restart.
+- Autoscale [compute](/docs/guides/etcd/autoscaler/compute/overview.md) and [storage](/docs/guides/etcd/autoscaler/storage/overview.md) resources.
+- Detail Concept of [Etcd Object](/docs/guides/etcd/concepts/etcd.md).
+- Detail Concept of [EtcdVersion Object](/docs/guides/etcd/concepts/etcdversion.md).
+- Detail Concept of [EtcdOpsRequest Object](/docs/guides/etcd/concepts/etcdopsrequest.md).
+- Detail Concept of [EtcdAutoscaler Object](/docs/guides/etcd/concepts/etcdautoscaler.md).
+- Detail Concept of [EtcdArchiver Object](/docs/guides/etcd/concepts/etcdarchiver.md).
+- Detail Concept of [AppBinding Object](/docs/guides/etcd/concepts/appbinding.md).
+
+## Next Steps
+
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/README.md
+++ b/docs/guides/etcd/README.md
@@ -73,7 +73,6 @@ An `Etcd` object goes through the following phases, reported in `status.phase`:
 | Phase          | Meaning                                                                                                            |
 |----------------|--------------------------------------------------------------------------------------------------------------------|
 | `Provisioning` | The KubeDB operator has accepted the object and is creating the offshoot resources (PetSet, Services, Secrets, RBAC). |
-| `DataRestoring`| The seed member's volume is being restored from a KubeStash snapshot before the cluster is bootstrapped.            |
 | `Ready`        | All members are up, the Raft cluster has quorum and the client endpoint is accepting connections.                   |
 | `Critical`     | The client endpoint is reachable, but not every member is ready (for example a learner is still catching up).       |
 | `NotReady`     | The client endpoint is not reachable — quorum has been lost or every member is down.                                |
@@ -82,7 +81,9 @@ An `Etcd` object goes through the following phases, reported in `status.phase`:
 
 In the normal path, an `Etcd` object moves `Provisioning` → `Ready`. When the cluster is
 bootstrapped from a snapshot (`spec.init.archiver`), the operator restores the ordinal-0 volume
-first, so the object passes through `DataRestoring` before the first member is ever started.
+before the first member is ever started, so the object simply stays in `Provisioning` for longer;
+the restore's own outcome is reported on the `SuccessfullyDataRestored` condition rather than as a
+phase.
 
 The phase is derived from the object's conditions — `ProvisioningStarted`, `ReplicaReady`,
 `AcceptingConnection`, `Ready` and `Provisioned`. The health checker keeps them up to date by

--- a/docs/guides/etcd/_index.md
+++ b/docs/guides/etcd/_index.md
@@ -1,0 +1,12 @@
+---
+title: Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-etcd-guides
+    name: Etcd
+    parent: guides
+    weight: 10
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/autoscaler/_index.md
+++ b/docs/guides/etcd/autoscaler/_index.md
@@ -1,0 +1,12 @@
+---
+title: Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling
+    name: Autoscaling
+    parent: etcd-etcd-guides
+    weight: 90
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/autoscaler/compute/_index.md
+++ b/docs/guides/etcd/autoscaler/compute/_index.md
@@ -1,0 +1,12 @@
+---
+title: Compute Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling-compute
+    name: Compute Autoscaling
+    parent: etcd-autoscaling
+    weight: 91
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/etcd/autoscaler/compute/compute-autoscale.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-autoscaling-compute-description
     name: Autoscale Compute Resources
     parent: etcd-autoscaling-compute
-    weight: 15
+    weight: 20
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---

--- a/docs/guides/etcd/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/etcd/autoscaler/compute/compute-autoscale.md
@@ -1,0 +1,471 @@
+---
+title: Etcd Compute Resource Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling-compute-description
+    name: Autoscale Compute Resources
+    parent: etcd-autoscaling-compute
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Autoscaling the Compute Resources of an Etcd Cluster
+
+This guide shows you how to use `KubeDB` to autoscale the compute resources (cpu and memory) of
+an etcd cluster.
+
+## Before You Begin
+
+- At first, you need a Kubernetes cluster, and the `kubectl` command-line tool must be configured
+  to communicate with your cluster.
+
+- Install the `KubeDB` Provisioner, Ops-manager and Autoscaler operators in your cluster
+  following the steps [here](/docs/setup/README.md).
+
+- etcd support is behind an alpha feature gate. Make sure the operators are installed with
+  `Etcd=true` enabled (Helm value `featureGates.Etcd=true`), otherwise the `Etcd` and
+  `EtcdAutoscaler` CRDs are not reconciled.
+
+- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdAutoscaler](/docs/guides/etcd/concepts/etcdautoscaler.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Compute Resource Autoscaling Overview](/docs/guides/etcd/autoscaler/compute/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout
+this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd)
+> folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd
+
+In this section, we deploy a three member etcd cluster with version `3.6.4`. In the next section
+we set up autoscaling for it using the `EtcdAutoscaler` CRD. Below is the YAML of the `Etcd` CR
+that we are going to create.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-autoscale
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/autoscaling/compute/etcd.yaml
+etcd.kubedb.com/etcd-autoscale created
+```
+
+Now, wait until `etcd-autoscale` has the status `Ready`.
+
+```bash
+$ kubectl get etcd -n demo
+NAME             VERSION   STATUS   AGE
+etcd-autoscale   3.6.4     Ready    2m
+```
+
+Let's check the resources of the `etcd` container in one of the member pods,
+
+```bash
+$ kubectl get pod -n demo etcd-autoscale-0 -o json | jq '.spec.containers[] | select(.name=="etcd") | .resources'
+{
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "500m",
+    "memory": "1Gi"
+  }
+}
+```
+
+And the resources recorded on the `Etcd` object itself,
+
+```bash
+$ kubectl get etcd -n demo etcd-autoscale -o json | jq '.spec.podTemplate.spec.containers[0].resources'
+{
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "500m",
+    "memory": "1Gi"
+  }
+}
+```
+
+You can see from the outputs above that the resources are the ones we assigned while deploying
+the etcd cluster. We are now ready to apply the `EtcdAutoscaler` CRO.
+
+### Compute Resource Autoscaling
+
+#### Create EtcdAutoscaler Object
+
+To set up compute resource autoscaling for this etcd cluster, we create an `EtcdAutoscaler` CRO
+with the desired configuration. Below is the YAML of the `EtcdAutoscaler` object that we are
+going to create,
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-compute-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-autoscale
+  opsRequestOptions:
+    apply: IfReady
+    timeout: 5m
+  compute:
+    etcd:
+      trigger: "On"
+      podLifeTimeThreshold: 5m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 600m
+        memory: 1.2Gi
+      maxAllowed:
+        cpu: 2
+        memory: 4Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing compute resource autoscaling on the
+  `etcd-autoscale` database.
+- `spec.compute.etcd.trigger` specifies that compute resource autoscaling is enabled for the
+  `etcd` container. The default is `Off`.
+- `spec.compute.etcd.podLifeTimeThreshold` specifies the minimum lifetime for at least one of the
+  pods before a vertical scaling is initiated. The default is `15m`.
+- `spec.compute.etcd.resourceDiffPercentage` specifies the minimum resource difference, in
+  percent, that is worth acting on. The default is `50`. If the difference between the current
+  and the recommended resources is smaller than this, the Autoscaler operator ignores the update.
+- `spec.compute.etcd.minAllowed` specifies the minimum resources the recommender may recommend.
+  The default is no minimum.
+- `spec.compute.etcd.maxAllowed` specifies the maximum resources the recommender may recommend.
+  The default is no maximum. Setting this is strongly recommended so that a transient spike
+  cannot recommend an unschedulable pod.
+- `spec.compute.etcd.controlledResources` specifies which resources are controlled by the
+  autoscaler. The default is `["cpu", "memory"]`.
+- `spec.compute.etcd.containerControlledValues` specifies which resource values are controlled,
+  `RequestsAndLimits` or `RequestsOnly`. The default is `RequestsAndLimits`.
+- `spec.opsRequestOptions` holds the options that are copied onto the `EtcdOpsRequest` the
+  autoscaler creates. See
+  [spec.timeout](/docs/guides/etcd/concepts/etcdopsrequest.md#spectimeout) and
+  [spec.apply](/docs/guides/etcd/concepts/etcdopsrequest.md#specapply).
+
+> **Note:** `spec.compute` also has an `etcd`-sibling field, `nodeTopology`, which snaps the
+> recommendation to the node groups of a `NodeTopology` object. Keep in mind that the resulting
+> `EtcdOpsRequest` carries no placement fields in its spec — see the
+> [caveat in the overview](/docs/guides/etcd/autoscaler/compute/overview.md#a-note-on-node-topology).
+
+Let's create the `EtcdAutoscaler` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/autoscaling/compute/etcd-compute-autoscaler.yaml
+etcdautoscaler.autoscaling.kubedb.com/etcd-compute-autoscaler created
+```
+
+#### Verify autoscaling is set up successfully
+
+Let's check that the `etcdautoscaler` resource was created successfully,
+
+```bash
+$ kubectl get etcdautoscaler -n demo
+NAME                      AGE
+etcd-compute-autoscaler   3m
+
+$ kubectl describe etcdautoscaler etcd-compute-autoscaler -n demo
+Name:         etcd-compute-autoscaler
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  autoscaling.kubedb.com/v1alpha1
+Kind:         EtcdAutoscaler
+Metadata:
+  Creation Timestamp:  2026-02-11T09:12:44Z
+  Generation:          1
+  Resource Version:    41822
+  UID:                 1b0f2d6c-8c30-4b0b-9d4a-2d2c9d51f0a1
+Spec:
+  Compute:
+    Etcd:
+      Container Controlled Values:  RequestsAndLimits
+      Controlled Resources:
+        cpu
+        memory
+      Max Allowed:
+        Cpu:     2
+        Memory:  4Gi
+      Min Allowed:
+        Cpu:                     600m
+        Memory:                  1.2Gi
+      Pod Life Time Threshold:   5m0s
+      Resource Diff Percentage:  20
+      Trigger:                   On
+  Database Ref:
+    Name:  etcd-autoscale
+  Ops Request Options:
+    Apply:    IfReady
+    Timeout:  5m0s
+Status:
+  Checkpoints:
+    Cpu Histogram:
+      Bucket Weights:
+        Index:              0
+        Weight:             10000
+      Reference Timestamp:  2026-02-11T09:15:00Z
+      Total Weight:         0.8733542386168607
+    First Sample Start:     2026-02-11T09:12:41Z
+    Last Sample Start:      2026-02-11T09:18:06Z
+    Last Update Time:       2026-02-11T09:18:38Z
+    Memory Histogram:
+      Bucket Weights:
+        Index:              11
+        Weight:             10000
+      Reference Timestamp:  2026-02-11T09:18:00Z
+      Total Weight:         0.7827734162991002
+    Ref:
+      Container Name:     etcd
+      Vpa Object Name:    etcd-autoscale
+    Total Samples Count:  6
+    Version:              v3
+  Conditions:
+    Last Transition Time:  2026-02-11T09:19:07Z
+    Message:               Successfully created EtcdOpsRequest demo/etcdops-etcd-autoscale-vft8xm
+    Observed Generation:   1
+    Reason:                CreateOpsRequest
+    Status:                True
+    Type:                  CreateOpsRequest
+  Vpas:
+    Conditions:
+      Last Transition Time:  2026-02-11T09:13:12Z
+      Status:                True
+      Type:                  RecommendationProvided
+    Recommendation:
+      Container Recommendations:
+        Container Name:  etcd
+        Lower Bound:
+          Cpu:     600m
+          Memory:  1.2Gi
+        Target:
+          Cpu:     600m
+          Memory:  1.2Gi
+        Uncapped Target:
+          Cpu:     540m
+          Memory:  1073741824
+        Upper Bound:
+          Cpu:     2
+          Memory:  4Gi
+    Vpa Name:      etcd-autoscale
+Events:            <none>
+```
+
+So the `EtcdAutoscaler` resource was created successfully.
+
+In the `Status.Vpas.Recommendation` section you can see the recommendation the operator generated
+for the `etcd` container. The Autoscaler operator continuously watches that recommendation and,
+when it differs from the running resources by more than `resourceDiffPercentage`, creates an
+`EtcdOpsRequest` to move the cluster onto it.
+
+#### Watch the generated EtcdOpsRequest
+
+Let's watch the `etcdopsrequest` objects in the `demo` namespace. After a while you should see an
+autoscaler-created one appear. Note the `etcdops-` name prefix — that is how the Autoscaler
+operator names the requests it generates.
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME                             TYPE              STATUS        AGE
+etcdops-etcd-autoscale-vft8xm    VerticalScaling   Progressing   45s
+```
+
+Let's wait for the ops request to become successful.
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME                             TYPE              STATUS       AGE
+etcdops-etcd-autoscale-vft8xm    VerticalScaling   Successful   3m
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed to scale
+the cluster. Note the owner reference back to the `EtcdAutoscaler` — that is what tells you this
+request was generated rather than hand-written.
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcdops-etcd-autoscale-vft8xm
+Name:         etcdops-etcd-autoscale-vft8xm
+Namespace:    demo
+Labels:       app.kubernetes.io/component=database
+              app.kubernetes.io/instance=etcd-autoscale
+              app.kubernetes.io/managed-by=kubedb.com
+              app.kubernetes.io/name=etcds.kubedb.com
+Annotations:  <none>
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-02-11T09:19:07Z
+  Generation:          1
+  Owner References:
+    API Version:           autoscaling.kubedb.com/v1alpha1
+    Block Owner Deletion:  true
+    Controller:            true
+    Kind:                  EtcdAutoscaler
+    Name:                  etcd-compute-autoscaler
+    UID:                   1b0f2d6c-8c30-4b0b-9d4a-2d2c9d51f0a1
+  Resource Version:        41903
+  UID:                     6d2c1a55-0f61-4a3e-9c1b-2b9b0f6e0d77
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:  etcd-autoscale
+  Timeout:  5m0s
+  Type:    VerticalScaling
+  Vertical Scaling:
+    Etcd:
+      Resources:
+        Limits:
+          Cpu:     2
+          Memory:  4Gi
+        Requests:
+          Cpu:     600m
+          Memory:  1.2Gi
+    Mode:  Restart
+Status:
+  Conditions:
+    Last Transition Time:  2026-02-11T09:19:07Z
+    Message:               Vertical Scaling is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-02-11T09:19:15Z
+    Message:               Successfully updated the petset resources
+    Observed Generation:   1
+    Reason:                UpdateEtcdPetSet
+    Status:                True
+    Type:                  UpdateEtcdPetSet
+    Last Transition Time:  2026-02-11T09:19:16Z
+    Message:               Successfully updated the Etcd resources
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-02-11T09:21:41Z
+    Message:               Successfully restarted the etcd members with the new resources
+    Observed Generation:   1
+    Reason:                VerticalScale
+    Status:                True
+    Type:                  VerticalScale
+    Last Transition Time:  2026-02-11T09:21:42Z
+    Message:               Successfully vertically scaled the etcd cluster
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:                    <none>
+```
+
+The generated request uses the default vertical scaling mode, `Restart`. The Ops-manager operator
+patches the PetSet template and then rolls the member pods one at a time, moving the Raft
+leadership off the leader before restarting it and waiting for quorum in between, so the cluster
+keeps serving clients throughout. The mode is not configurable from the `EtcdAutoscaler`; if you
+want the resize applied without recreating pods, create an `EtcdOpsRequest` with
+`spec.verticalScaling.mode: InPlace` by hand instead — see
+[Vertical Scaling](/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md).
+
+#### Verify the new resources
+
+Now let's verify from the Pod and from the `Etcd` object that the resources were updated.
+
+```bash
+$ kubectl get pod -n demo etcd-autoscale-0 -o json | jq '.spec.containers[] | select(.name=="etcd") | .resources'
+{
+  "limits": {
+    "cpu": "2",
+    "memory": "4Gi"
+  },
+  "requests": {
+    "cpu": "600m",
+    "memory": "1.2Gi"
+  }
+}
+
+$ kubectl get etcd -n demo etcd-autoscale -o json | jq '.spec.podTemplate.spec.containers[0].resources'
+{
+  "limits": {
+    "cpu": "2",
+    "memory": "4Gi"
+  },
+  "requests": {
+    "cpu": "600m",
+    "memory": "1.2Gi"
+  }
+}
+```
+
+The output above confirms that the compute resources of the etcd cluster were autoscaled.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdautoscaler -n demo etcd-compute-autoscaler
+kubectl delete etcd -n demo etcd-autoscale
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Storage Autoscaling of an Etcd cluster](/docs/guides/etcd/autoscaler/storage/storage-autoscale.md).
+- Detail concepts of the [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/autoscaler/compute/overview.md
+++ b/docs/guides/etcd/autoscaler/compute/overview.md
@@ -1,0 +1,106 @@
+---
+title: Etcd Compute Autoscaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling-compute-overview
+    name: Overview
+    parent: etcd-autoscaling-compute
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Compute Resource Autoscaling
+
+This guide gives an overview of how the KubeDB Autoscaler operator autoscales the compute
+resources (cpu and memory) of an etcd cluster using the `EtcdAutoscaler` CRD.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdAutoscaler](/docs/guides/etcd/concepts/etcdautoscaler.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## How Compute Autoscaling Works
+
+The autoscaling process consists of the following steps:
+
+1. A user creates an `Etcd` Custom Resource Object (CRO).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CRO.
+
+3. When the operator finds an `Etcd` CRO, it creates the `PetSet` and the related resources
+   (Secrets, Services, RBAC, and so on) that back the etcd members.
+
+4. To set up autoscaling for that cluster, the user creates an `EtcdAutoscaler` CRO with the
+   desired configuration.
+
+5. The `KubeDB` Autoscaler operator watches the `EtcdAutoscaler` CRO.
+
+6. The `KubeDB` Autoscaler operator generates a recommendation for the `etcd` container using a
+   modified version of the Kubernetes
+   [official VPA recommender](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/pkg/recommender).
+   The recommender keeps a decaying CPU and memory histogram per container and reports the
+   recommendation under `status.vpas[].recommendation` on the `EtcdAutoscaler`.
+
+7. If the generated recommendation does not match the current resources of the etcd container,
+   the `KubeDB` Autoscaler operator creates an `EtcdOpsRequest` of type `VerticalScaling` to
+   move the cluster to the recommended resources.
+
+8. The `KubeDB` Ops-manager operator watches that `EtcdOpsRequest` CRO.
+
+9. The `KubeDB` Ops-manager operator then scales the etcd container vertically, as specified in
+   the `EtcdOpsRequest` CRO.
+
+## The generated EtcdOpsRequest
+
+This generation relationship is the important part to understand: **the autoscaler never edits
+the `Etcd` object directly.** Every change it wants to make is expressed as an
+`EtcdOpsRequest`, which is then executed by the Ops-manager operator exactly as if you had
+written it by hand. Concretely, the autoscaler:
+
+- Names the request with the `etcdops-` prefix plus a random suffix, for example
+  `etcdops-etcd-autoscale-vft8xm`.
+- Sets an owner reference back to the `EtcdAutoscaler`, so `kubectl describe` on the request
+  shows which autoscaler produced it, and deleting the autoscaler garbage-collects it.
+- Sets `spec.type: VerticalScaling` and fills in `spec.verticalScaling.etcd.resources` with the
+  recommendation, merged with the resources already set on the `etcd` container of the database.
+- Copies `spec.timeout`, `spec.apply` and `spec.maxRetries` from
+  `EtcdAutoscaler.spec.opsRequestOptions`, when that block is present.
+
+Two behavioral details follow from the implementation:
+
+- Only `spec.verticalScaling.etcd` is ever populated. `EtcdVerticalScalingSpec` also has an
+  `exporter` field for structural parity with the other KubeDB databases, but etcd exposes its
+  Prometheus metrics natively on its own metrics listener and KubeDB deploys **no exporter
+  sidecar** for it — so there is no exporter container for the autoscaler to size.
+- A new request is only created when its `spec` differs from the last request the same
+  autoscaler created. An identical recommendation does not produce a stream of duplicate
+  requests.
+
+## A note on node topology
+
+`EtcdAutoscaler.spec.compute.nodeTopology` lets the recommendation be snapped to the node groups
+(or machine profiles) of a `NodeTopology` object, so the autoscaler will not recommend a size no
+node in the pool can actually accommodate.
+
+Be aware of the limitation here, though: `EtcdVerticalScalingSpec.Etcd` is an
+`ContainerResources` — unlike the `PodResources` used by some other KubeDB databases, it carries
+no node-selection or topology fields. So **the generated `EtcdOpsRequest` does not carry
+placement hints in its spec.** When `nodeTopology` is configured, the chosen node group is only
+communicated through the machine-profile annotation the autoscaler stamps onto the ops request's
+metadata. Do not expect node-affinity-aware placement of the etcd pods to be driven from the
+generated request itself; this is a known apimachinery-level gap.
+
+In the next doc, we show a step-by-step guide for autoscaling the compute resources of an etcd
+cluster using the `EtcdAutoscaler` CRD.
+
+## Next Steps
+
+- [Autoscale the compute resources of an Etcd cluster](/docs/guides/etcd/autoscaler/compute/compute-autoscale.md).
+- [Storage Autoscaling Overview](/docs/guides/etcd/autoscaler/storage/overview.md).

--- a/docs/guides/etcd/autoscaler/storage/_index.md
+++ b/docs/guides/etcd/autoscaler/storage/_index.md
@@ -1,0 +1,12 @@
+---
+title: Storage Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling-storage
+    name: Storage Autoscaling
+    parent: etcd-autoscaling
+    weight: 92
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/autoscaler/storage/overview.md
+++ b/docs/guides/etcd/autoscaler/storage/overview.md
@@ -1,0 +1,93 @@
+---
+title: Etcd Storage Autoscaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling-storage-overview
+    name: Overview
+    parent: etcd-autoscaling-storage
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Storage Autoscaling
+
+This guide gives an overview of how the KubeDB Autoscaler operator autoscales the storage of an
+etcd cluster using the `EtcdAutoscaler` CRD.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdAutoscaler](/docs/guides/etcd/concepts/etcdautoscaler.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## How Storage Autoscaling Works
+
+The autoscaling process consists of the following steps:
+
+1. A user creates an `Etcd` Custom Resource (CR).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CR.
+
+3. When the operator finds an `Etcd` CR, it creates the `PetSet` and the related resources.
+   Each ordinal of the PetSet gets a PersistentVolume from the volume claim template, which is
+   where the etcd member's data directory (the bbolt backend and the WAL) lives.
+
+4. To set up storage autoscaling for that cluster, the user creates an `EtcdAutoscaler` CRO with
+   the desired configuration.
+
+5. The `KubeDB` Autoscaler operator watches the `EtcdAutoscaler` CRO.
+
+6. The `KubeDB` Autoscaler operator continuously reads the PVC usage of the database's pods from
+   Prometheus and compares it against `spec.storage.etcd.usageThreshold`.
+   - If the usage exceeds the threshold, the operator computes a new size and creates an
+     `EtcdOpsRequest` of type `VolumeExpansion` to expand the storage.
+
+7. The `KubeDB` Ops-manager operator watches that `EtcdOpsRequest` CRO.
+
+8. The `KubeDB` Ops-manager operator then expands the volumes of the etcd members as specified in
+   the `EtcdOpsRequest` CRO.
+
+## Why storage autoscaling matters more for etcd
+
+etcd is unusually sensitive to a full disk. Two properties are worth keeping in mind:
+
+- The backend database file never shrinks on its own. Deleting keys, and even compacting the
+  keyspace history, only marks pages as reusable inside the file — the file keeps its size until
+  it is defragmented. See [Maintenance Overview](/docs/guides/etcd/maintenance/overview.md).
+- When the backend grows past `--quota-backend-bytes` (`spec.configuration.tuning.quotaBackendBytes`),
+  etcd raises a cluster-wide `NOSPACE` alarm and the cluster goes read-only until the alarm is
+  cleared.
+
+Storage autoscaling gives the volume headroom; it does not by itself reclaim space inside the
+backend file. The two are complementary — use autoscaling for the volume, and
+`Compact` + `Defragment` for the backend file.
+
+## The generated EtcdOpsRequest
+
+As with compute autoscaling, the autoscaler never edits the `Etcd` object directly. When the
+usage threshold is crossed it creates an `EtcdOpsRequest`:
+
+- Named with the `etcdops-` prefix plus a random suffix, for example
+  `etcdops-etcd-autoscale-w7q2rk`.
+- Owned by the `EtcdAutoscaler` through an owner reference.
+- With `spec.type: VolumeExpansion`, `spec.volumeExpansion.etcd` set to the newly computed size,
+  and `spec.volumeExpansion.mode` copied from `spec.storage.etcd.expansionMode`.
+- With `spec.timeout`, `spec.apply` and `spec.maxRetries` taken from
+  `EtcdAutoscaler.spec.opsRequestOptions`, when that block is present.
+
+The request is only created when the newly computed size is actually **larger** than the current
+`spec.storage.resources.requests.storage` of the `Etcd` object; storage is never scaled down.
+
+In the next doc, we show a step-by-step guide for autoscaling the storage of an etcd cluster
+using the `EtcdAutoscaler` CRD.
+
+## Next Steps
+
+- [Autoscale the storage of an Etcd cluster](/docs/guides/etcd/autoscaler/storage/storage-autoscale.md).
+- [Compute Autoscaling Overview](/docs/guides/etcd/autoscaler/compute/overview.md).

--- a/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
@@ -1,0 +1,390 @@
+---
+title: Etcd Storage Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaling-storage-description
+    name: Autoscale Storage
+    parent: etcd-autoscaling-storage
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Storage Autoscaling of an Etcd Cluster
+
+This guide shows you how to use `KubeDB` to autoscale the storage of an etcd cluster.
+
+## Before You Begin
+
+- At first, you need a Kubernetes cluster, and the `kubectl` command-line tool must be configured
+  to communicate with your cluster.
+
+- Install the `KubeDB` Provisioner, Ops-manager and Autoscaler operators in your cluster
+  following the steps [here](/docs/setup/README.md).
+
+- etcd support is behind an alpha feature gate. Make sure the operators are installed with
+  `Etcd=true` enabled (Helm value `featureGates.Etcd=true`).
+
+- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation).
+
+- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
+  The Autoscaler operator reads PVC usage through the custom metrics API, which is backed by
+  Prometheus.
+
+- You must have a `StorageClass` that supports volume expansion.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdAutoscaler](/docs/guides/etcd/concepts/etcdautoscaler.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Storage Autoscaling Overview](/docs/guides/etcd/autoscaler/storage/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout
+this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd)
+> folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Verify a volume-expandable StorageClass
+
+First verify that your cluster has a storage class that supports volume expansion.
+
+```bash
+$ kubectl get storageclass
+NAME                  PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+standard (default)    rancher.io/local-path   Delete          WaitForFirstConsumer   false                  32m
+topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsumer   true                   31m
+```
+
+The `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` set to `true`, so we can use
+it. You can install topolvm from [here](https://github.com/topolvm/topolvm).
+
+## Deploy Etcd
+
+In this section we deploy a three member etcd cluster with version `3.6.4` on that storage class.
+Below is the YAML of the `Etcd` CR that we are going to create,
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-autoscale
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "topolvm-provisioner"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/autoscaling/storage/etcd.yaml
+etcd.kubedb.com/etcd-autoscale created
+```
+
+Now, wait until `etcd-autoscale` has the status `Ready`.
+
+```bash
+$ kubectl get etcd -n demo
+NAME             VERSION   STATUS   AGE
+etcd-autoscale   3.6.4     Ready    3m
+```
+
+Let's check the volume size from the PetSet and from the persistent volumes,
+
+```bash
+$ kubectl get petset -n demo etcd-autoscale -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+"1Gi"
+
+$ kubectl get pv -n demo
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                          STORAGECLASS          AGE
+pvc-0a2f6b3a-6a3b-4a7e-8b58-1b0d6e0a1c11   1Gi        RWO            Delete           Bound    demo/data-etcd-autoscale-0     topolvm-provisioner   3m
+pvc-2c7d1b90-2f11-4d0c-b7a1-9d1f2b3c4d55   1Gi        RWO            Delete           Bound    demo/data-etcd-autoscale-1     topolvm-provisioner   3m
+pvc-5e91a4c2-77c9-41bb-9f3e-6a2c7d8e9f00   1Gi        RWO            Delete           Bound    demo/data-etcd-autoscale-2     topolvm-provisioner   3m
+```
+
+The PetSet requests 1Gi, and all three persistent volumes are 1Gi. We are now ready to apply the
+`EtcdAutoscaler` CRO.
+
+### Storage Autoscaling
+
+#### Create EtcdAutoscaler Object
+
+To set up storage autoscaling for this etcd cluster, we create an `EtcdAutoscaler` CRO with the
+desired configuration. Below is the YAML of the `EtcdAutoscaler` object that we are going to
+create,
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-storage-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-autoscale
+  storage:
+    etcd:
+      trigger: "On"
+      usageThreshold: 60
+      scalingThreshold: 50
+      expansionMode: "Online"
+      upperBound: 100Gi
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing storage autoscaling on the
+  `etcd-autoscale` database.
+- `spec.storage.etcd.trigger` specifies that storage autoscaling is enabled for this database.
+  The default is `Off`.
+- `spec.storage.etcd.usageThreshold` specifies the PVC usage threshold in percent. If no member's
+  volume is more than `60%` full, nothing happens.
+- `spec.storage.etcd.scalingThreshold` specifies by how much, in percent, the volume is grown once
+  the usage threshold is crossed — here `50%`, so a 1Gi volume becomes roughly 1.5Gi.
+- `spec.storage.etcd.expansionMode` selects the mode of the generated volume expansion
+  `EtcdOpsRequest`: `Online` or `Offline`. Use `Online` when your CSI driver supports expanding a
+  mounted volume, as topolvm does.
+- `spec.storage.etcd.upperBound` caps the volume growth. If the newly computed size would exceed
+  this, no ops request is created at all — so pick it deliberately.
+
+> **Note:** unlike some other KubeDB autoscalers, `EtcdAutoscaler` does not currently ship a
+> defaulting webhook, so the documented defaults for these fields are **not** filled in for you.
+> Set `trigger`, `usageThreshold`, `expansionMode` and either `scalingThreshold` or
+> `scalingRules` explicitly.
+
+##### Using scalingRules instead of a flat percentage
+
+A flat percentage is a poor fit once volumes get large — growing a 500Gi volume by 50% is a 250Gi
+jump. `scalingRules` lets the growth step depend on how much is currently used. Rules are matched
+in order of their `appliesUpto` size, and an entry with an empty `appliesUpto` acts as the
+catch-all. A threshold ending in `pc` or `%` is relative; anything else is parsed as an absolute
+quantity that is added to the current capacity.
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-storage-autoscaler-rules
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-autoscale
+  storage:
+    etcd:
+      trigger: "On"
+      usageThreshold: 60
+      expansionMode: "Online"
+      upperBound: 500Gi
+      scalingRules:
+        - appliesUpto: "50Gi"
+          threshold: "50pc"
+        - appliesUpto: "200Gi"
+          threshold: "25pc"
+        - appliesUpto: ""
+          threshold: "50Gi"
+```
+
+That reads as: while less than 50Gi is used, grow by 50%; between 50Gi and 200Gi, grow by 25%;
+beyond that, add a flat 50Gi at a time — never going past the 500Gi `upperBound`.
+
+Let's create the `EtcdAutoscaler` CR we showed first,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/autoscaling/storage/etcd-storage-autoscaler.yaml
+etcdautoscaler.autoscaling.kubedb.com/etcd-storage-autoscaler created
+```
+
+#### Verify autoscaling is set up successfully
+
+Let's check that the `etcdautoscaler` resource was created successfully,
+
+```bash
+$ kubectl get etcdautoscaler -n demo
+NAME                      AGE
+etcd-storage-autoscaler   40s
+
+$ kubectl describe etcdautoscaler etcd-storage-autoscaler -n demo
+Name:         etcd-storage-autoscaler
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  autoscaling.kubedb.com/v1alpha1
+Kind:         EtcdAutoscaler
+Metadata:
+  Creation Timestamp:  2026-02-11T10:02:11Z
+  Generation:          1
+  Resource Version:    52140
+  UID:                 8a2b6c1e-4f7a-4d20-9b18-70c4f2d5a3b9
+Spec:
+  Database Ref:
+    Name:  etcd-autoscale
+  Storage:
+    Etcd:
+      Expansion Mode:      Online
+      Scaling Threshold:   50
+      Trigger:             On
+      Upper Bound:         100Gi
+      Usage Threshold:     60
+Events:                    <none>
+```
+
+So the `EtcdAutoscaler` resource was created successfully.
+
+#### Watch the generated EtcdOpsRequest
+
+Now write enough data into the cluster that at least one member's volume crosses the 60% usage
+threshold. Once the Autoscaler operator observes that, it creates an `EtcdOpsRequest` of type
+`VolumeExpansion`. Note the `etcdops-` name prefix, which is how the Autoscaler operator names
+the requests it generates.
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                            TYPE              STATUS        AGE
+etcdops-etcd-autoscale-w7q2rk   VolumeExpansion   Progressing   20s
+```
+
+Let's wait for the ops request to become successful.
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                            TYPE              STATUS       AGE
+etcdops-etcd-autoscale-w7q2rk   VolumeExpansion   Successful   2m
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed to expand
+the volumes. The owner reference back to the `EtcdAutoscaler` is what tells you this request was
+generated rather than hand-written.
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcdops-etcd-autoscale-w7q2rk
+Name:         etcdops-etcd-autoscale-w7q2rk
+Namespace:    demo
+Labels:       app.kubernetes.io/component=database
+              app.kubernetes.io/instance=etcd-autoscale
+              app.kubernetes.io/managed-by=kubedb.com
+              app.kubernetes.io/name=etcds.kubedb.com
+Annotations:  <none>
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-02-11T10:14:52Z
+  Generation:          1
+  Owner References:
+    API Version:           autoscaling.kubedb.com/v1alpha1
+    Block Owner Deletion:  true
+    Controller:            true
+    Kind:                  EtcdAutoscaler
+    Name:                  etcd-storage-autoscaler
+    UID:                   8a2b6c1e-4f7a-4d20-9b18-70c4f2d5a3b9
+  Resource Version:        53310
+  UID:                     b1e7d2a4-9c8f-4b12-a0d7-53f9c1e2b6aa
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:  etcd-autoscale
+  Type:   VolumeExpansion
+  Volume Expansion:
+    Etcd:  1610612736
+    Mode:  Online
+Status:
+  Conditions:
+    Last Transition Time:  2026-02-11T10:14:52Z
+    Message:               Volume Expansion is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-02-11T10:14:55Z
+    Message:               3
+    Observed Generation:   1
+    Reason:                PetSetReplicasBeforeExpansion
+    Status:                True
+    Type:                  PetSetReplicasBeforeExpansion
+    Last Transition Time:  2026-02-11T10:16:38Z
+    Message:               Successfully expanded the etcd data volumes
+    Observed Generation:   1
+    Reason:                UpdateEtcdNodePVCs
+    Status:                True
+    Type:                  UpdateEtcdNodePVCs
+    Last Transition Time:  2026-02-11T10:16:39Z
+    Message:               Successfully updated the Etcd storage request
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-02-11T10:16:44Z
+    Message:               PetSet has been recreated with the expanded volume claim template
+    Observed Generation:   1
+    Reason:                ReadyPetSets
+    Status:                True
+    Type:                  ReadyPetSets
+    Last Transition Time:  2026-02-11T10:16:45Z
+    Message:               Successfully expanded the etcd data volumes
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:                    <none>
+```
+
+> The size in `spec.volumeExpansion.etcd` is written as a plain byte count because the autoscaler
+> computes it arithmetically from the observed capacity; `1610612736` is 1.5Gi.
+
+#### Verify the new volume size
+
+Now let's verify from the `PetSet` and the `PersistentVolume`s that the volumes were expanded.
+
+```bash
+$ kubectl get petset -n demo etcd-autoscale -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+"1610612736"
+
+$ kubectl get pv -n demo
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                          STORAGECLASS          AGE
+pvc-0a2f6b3a-6a3b-4a7e-8b58-1b0d6e0a1c11   2Gi        RWO            Delete           Bound    demo/data-etcd-autoscale-0     topolvm-provisioner   18m
+pvc-2c7d1b90-2f11-4d0c-b7a1-9d1f2b3c4d55   2Gi        RWO            Delete           Bound    demo/data-etcd-autoscale-1     topolvm-provisioner   18m
+pvc-5e91a4c2-77c9-41bb-9f3e-6a2c7d8e9f00   2Gi        RWO            Delete           Bound    demo/data-etcd-autoscale-2     topolvm-provisioner   18m
+```
+
+The output above confirms that the storage of the etcd cluster was autoscaled. (The reported PV
+capacity is rounded up to whatever unit the CSI driver allocates in, so it may be a little larger
+than the requested size.)
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdautoscaler -n demo etcd-storage-autoscaler
+kubectl delete etcd -n demo etcd-autoscale
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Compute Resource Autoscaling of an Etcd cluster](/docs/guides/etcd/autoscaler/compute/compute-autoscale.md).
+- [Volume Expansion of an Etcd cluster](/docs/guides/etcd/volume-expansion/volume-expansion.md) — the same operation, applied by hand.
+- Reclaim space inside the etcd backend with [Compact](/docs/guides/etcd/maintenance/compact.md)
+  and [Defragment](/docs/guides/etcd/maintenance/defragment.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/backup/_index.md
+++ b/docs/guides/etcd/backup/_index.md
@@ -1,0 +1,12 @@
+---
+title: Backup & Restore Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: guides-etcd-backup
+    name: Backup & Restore
+    parent: etcd-etcd-guides
+    weight: 40
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/backup/kubestash/_index.md
+++ b/docs/guides/etcd/backup/kubestash/_index.md
@@ -1,0 +1,12 @@
+---
+title: Backup & Restore Etcd | KubeStash
+menu:
+  docs_{{ .version }}:
+    identifier: guides-etcd-backup-stashv2
+    name: KubeStash (aka Stash 2.0)
+    parent: guides-etcd-backup
+    weight: 10
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/backup/kubestash/overview/index.md
+++ b/docs/guides/etcd/backup/kubestash/overview/index.md
@@ -146,8 +146,8 @@ provisioner does the rest before the first pod ever starts:
 1. You create a new `Etcd` object whose `spec.init.archiver.fullDBRepository` (and optionally
    `.manifestRepository`) points at the repositories produced by the backup.
 2. The provisioner sees `spec.init.archiver`, has not yet recorded the
-   `DatabaseSuccessfullyRestored` condition, and so **withholds the PetSet entirely**. The `Etcd`
-   object reports `status.phase: DataRestoring`.
+   `SuccessfullyDataRestored` condition, and so **withholds the PetSet entirely**. The `Etcd`
+   object stays in `status.phase: Provisioning` throughout.
 3. If `manifestRepository` is set, the provisioner first creates a `RestoreSession` named
    `<db-name>-manifest-restorer` running the shared `manifest-restore` task, so that the auth
    `Secret` and friends exist before any pod could reference them.
@@ -157,7 +157,7 @@ provisioner does the rest before the first pod ever starts:
    `<db-name>-0-snapshot-restorer`. That session targets the **PVC**, not a pod, and runs the
    `etcd-backup-restore` task, which rebuilds a complete etcd data directory inside the volume.
 5. Only after that `RestoreSession` reaches `Succeeded` does the provisioner set the
-   `DatabaseSuccessfullyRestored` condition and create the PetSet. Member 0 boots on the restored
+   `SuccessfullyDataRestored` condition and create the PetSet. Member 0 boots on the restored
    data directory; every other member joins through the normal membership path and streams its copy
    of the data from the leader, so only ordinal 0 is ever restored into.
 

--- a/docs/guides/etcd/backup/kubestash/overview/index.md
+++ b/docs/guides/etcd/backup/kubestash/overview/index.md
@@ -133,15 +133,15 @@ A few archiver fields worth calling out:
 
 Restore for etcd works differently from most KubeDB databases, and the difference is not cosmetic.
 
-**You cannot restore into a running `Etcd` cluster.** etcd's bootstrap semantics require a member's
-data directory to be either genuinely empty — so the member can start a brand new cluster with
-`--initial-cluster-state=new` — or a fully rebuilt, valid snapshot directory. Injecting data into a
-member that is already serving raft traffic is not a supported operation, and there is no "restore
-task" you can point at a live cluster.
+**A snapshot can never be poured into a running member.** etcd's bootstrap semantics require a
+member's data directory to be either genuinely empty — so the member can start a brand new cluster
+with `--initial-cluster-state=new` — or a fully rebuilt, valid snapshot directory. Injecting data
+into a member that is already serving raft traffic is not a supported operation, and there is no
+"restore task" you can point at a live cluster.
 
-KubeDB therefore gates restore entirely at **bootstrap time**. You do not create a `RestoreSession`;
-you create a *new* `Etcd` object with `spec.init.archiver` filled in, and the provisioner does the
-rest before the first pod ever starts:
+The path described below is therefore the **bootstrap-time** restore: you do not create a
+`RestoreSession`; you create a *new* `Etcd` object with `spec.init.archiver` filled in, and the
+provisioner does the rest before the first pod ever starts:
 
 1. You create a new `Etcd` object whose `spec.init.archiver.fullDBRepository` (and optionally
    `.manifestRepository`) points at the repositories produced by the backup.
@@ -163,6 +163,20 @@ rest before the first pod ever starts:
 
 Once the condition is set the gate is permanently open — the provisioner will not re-run a restore
 over a live cluster, which is exactly what you want.
+
+### Restoring into an Etcd that already exists
+
+When the `Etcd` object has to survive — because the `AppBinding`, the connection Secret and every
+application pointing at its Service must keep working — the bootstrap path is not available, and
+deleting and recreating the object loses everything else about it. That is what the `Restore`
+[EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md#specrestore) is for. It obeys the same
+rule as above rather than breaking it: the cluster is taken apart down to a single **empty** volume,
+the very same `etcd-backup-restore` `RestoreSession` writes the snapshot into that volume while
+nothing is running, and the seed member is then started on the restored data directory. Every other
+member is discarded and rejoins as a learner.
+
+The trade-off is severe and unavoidable: an in-place restore **replaces the entire keyspace of the
+live database**. See [In-place Restore](/docs/guides/etcd/restore/overview.md).
 
 Because `spec.storageType: Ephemeral` gives the provisioner no PVC to restore into ahead of the
 pods, restoring from a snapshot requires `spec.storageType: Durable` with `spec.storage` set. The

--- a/docs/guides/etcd/backup/kubestash/overview/index.md
+++ b/docs/guides/etcd/backup/kubestash/overview/index.md
@@ -1,0 +1,202 @@
+---
+title: Backup & Restore Etcd Overview | KubeStash
+description: Overview of how KubeDB backs up and restores an Etcd cluster using KubeStash
+menu:
+  docs_{{ .version }}:
+    identifier: guides-etcd-backup-overview-stashv2
+    name: Overview
+    parent: guides-etcd-backup-stashv2
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+
+# Etcd Backup & Restore Overview
+
+KubeDB uses [KubeStash](https://kubestash.com) to back up and restore an `Etcd` cluster. KubeStash is
+AppsCode's cloud native data backup and recovery solution for Kubernetes workloads and databases. It
+uses [restic](https://github.com/restic/restic) under the hood to store backup data — encrypted and
+deduplicated — in any cloud or on-prem storage backend (S3, GCS, Azure Blob, Minio, NetApp, Dell EMC
+and so on).
+
+## Snapshot-only: there is no point-in-time recovery
+
+This is the single most important thing to understand before you design a backup strategy for etcd
+in KubeDB:
+
+**Backing up an `Etcd` cluster is snapshot-only. There is no continuous archiving and there is no
+point-in-time recovery (PITR).**
+
+Databases such as PostgreSQL and MySQL ship a continuous stream of write-ahead-log segments to the
+backend alongside their periodic base backups, which lets you replay the log forward and land on an
+arbitrary point in time. etcd exposes no comparable primitive — there is no supported way to stream
+its raft WAL out of the cluster and replay it into a rebuilt data directory. KubeDB therefore
+deliberately scopes etcd backup to whole-cluster snapshots:
+
+- The `EtcdArchiver` CRD has a `spec.fullBackup` section and a `spec.manifestBackup` section, and
+  **no `spec.logBackup` section**. The field simply does not exist in the API.
+- The generated `BackupConfiguration` has at most two sessions, both of which produce full
+  snapshots. There is no third, incremental session.
+- Restoring rolls the cluster back to the state captured by one completed snapshot — the most
+  recent one, or an older one you select. Any write accepted after that snapshot was taken is lost.
+
+Set your backup schedule accordingly: with snapshot-only backup, your worst-case data loss window is
+the interval between two scheduled backups.
+
+## The moving parts
+
+| Object | API group | Who creates it | What it is for |
+|---|---|---|---|
+| `BackupStorage` | `storage.kubestash.com/v1alpha1` | you | Where the backup data lives (bucket, prefix, credentials `Secret`). |
+| `RetentionPolicy` | `storage.kubestash.com/v1alpha1` | you | How many old snapshots to keep. |
+| `EtcdArchiver` | `archiver.kubedb.com/v1alpha1` | you | The backup *policy*: which storage, which schedules, which encryption secret, which databases may consume it. |
+| `Etcd` | `kubedb.com/v1alpha2` | you | The database. Opts into an archiver through `spec.archiver.ref`. |
+| `BackupConfiguration` | `core.kubestash.com/v1alpha1` | the KubeDB provisioner | The concrete, per-database backup definition derived from the archiver. **You do not write this by hand.** |
+| `Repository`, `BackupSession`, `Snapshot` | `storage.kubestash.com` / `core.kubestash.com` | the KubeStash operator | The per-run bookkeeping. |
+| `RestoreSession` | `core.kubestash.com/v1alpha1` | the KubeDB provisioner | Created at bootstrap time when `spec.init.archiver` is set. **You do not write this by hand either.** |
+
+The important structural difference from a hand-rolled KubeStash setup is that for KubeDB databases
+you author an **`EtcdArchiver` policy**, not a `BackupConfiguration`. The KubeDB provisioner owns the
+`BackupConfiguration` and keeps it in sync with the archiver.
+
+## How backup is wired up
+
+1. You create a `Secret` holding the backend credentials and a `BackupStorage` that points at the
+   bucket.
+2. You create an `EtcdArchiver` referencing that `BackupStorage` through
+   `spec.backupStorage.ref`, plus a `RetentionPolicy` and an encryption `Secret`.
+3. The archiver declares who may consume it in `spec.databases`, which is the standard KubeDB
+   double opt-in selector — `spec.databases.namespaces.from` is one of `Same`, `All` or `Selector`,
+   optionally narrowed further by `spec.databases.selector`.
+4. An `Etcd` object opts in from the other side. Either you set `spec.archiver.ref` explicitly:
+
+    ```yaml
+    spec:
+      archiver:
+        ref:
+          name: etcd-archiver
+          namespace: demo
+    ```
+
+   or you leave `spec.archiver` unset, in which case the provisioner scans every `EtcdArchiver` in
+   the cluster, picks the highest-priority one whose `spec.databases` selector admits this database
+   (same namespace beats same project namespace beats anything else) and patches its reference into
+   `spec.archiver.ref` for you. That is the *double* opt-in: the archiver advertises who may consume
+   it, and the database is only ever auto-attached to an archiver that admits it. An explicit
+   `spec.archiver.ref` you write yourself is always honoured as-is.
+5. Once both sides match, the KubeDB provisioner creates a `BackupConfiguration` named
+   `<db-name>-archiver` in the database's namespace, owned by the `Etcd` object, targeting the
+   `Etcd` object itself.
+
+### The two sessions
+
+The generated `BackupConfiguration` carries up to two sessions, one per section of the archiver
+spec. If a section is omitted from the archiver, its session is not generated; if both are omitted,
+no `BackupConfiguration` is created at all.
+
+| Session | Generated from | Addon task(s) | Repository | What it captures |
+|---|---|---|---|---|
+| `full-backup` | `spec.fullBackup` | `etcd-backup`, then `manifest-backup` | `<db-name>-full` | A live snapshot of the etcd keyspace, plus the Kubernetes manifests. |
+| `manifest-backup` | `spec.manifestBackup` | `manifest-backup` | `<db-name>-manifest` | Only the Kubernetes manifests (`Etcd` object, auth `Secret`, and so on). |
+
+Both tasks come from the `etcd-addon` `Addon` object shipped by the KubeDB installer. The
+`etcd-backup` task runs the `etcd-restic-plugin` image, which connects to the cluster's client
+endpoint on port `2379` using the credentials from the `AppBinding`, streams a consistent snapshot
+of the keyspace over the client API, and pipes it straight into the restic repository. Because the
+snapshot is streamed rather than staged, the backup `Job` does not need a volume large enough to
+hold the whole keyspace.
+
+The `manifest-backup` task is the shared, cross-database `kubedbmanifest-backup` function that every
+KubeDB database reuses unchanged — nothing about it is etcd specific.
+
+Each session writes into `<spec.backupStorage.subDir>/<db-namespace>/<db-name>/<session-name>` in
+the bucket, and the snapshot data lands under the `dump` component of the resulting `Snapshot`
+object.
+
+A few archiver fields worth calling out:
+
+- `spec.pause: true` sets `spec.paused` on the generated `BackupConfiguration`. Scheduled sessions
+  stop firing, but the repositories and their snapshots are kept.
+- `spec.fullBackup.driver` exists for structural parity with the other KubeDB archivers and is
+  **ignored for etcd**. An etcd snapshot is always taken through the client API into a restic
+  repository; there is no `VolumeSnapshotter` variant to choose between.
+- `spec.deletionPolicy` controls what happens to the created repositories when the
+  `BackupConfiguration` goes away. It defaults to `Retain`.
+
+## How restore is wired up
+
+Restore for etcd works differently from most KubeDB databases, and the difference is not cosmetic.
+
+**You cannot restore into a running `Etcd` cluster.** etcd's bootstrap semantics require a member's
+data directory to be either genuinely empty — so the member can start a brand new cluster with
+`--initial-cluster-state=new` — or a fully rebuilt, valid snapshot directory. Injecting data into a
+member that is already serving raft traffic is not a supported operation, and there is no "restore
+task" you can point at a live cluster.
+
+KubeDB therefore gates restore entirely at **bootstrap time**. You do not create a `RestoreSession`;
+you create a *new* `Etcd` object with `spec.init.archiver` filled in, and the provisioner does the
+rest before the first pod ever starts:
+
+1. You create a new `Etcd` object whose `spec.init.archiver.fullDBRepository` (and optionally
+   `.manifestRepository`) points at the repositories produced by the backup.
+2. The provisioner sees `spec.init.archiver`, has not yet recorded the
+   `DatabaseSuccessfullyRestored` condition, and so **withholds the PetSet entirely**. The `Etcd`
+   object reports `status.phase: DataRestoring`.
+3. If `manifestRepository` is set, the provisioner first creates a `RestoreSession` named
+   `<db-name>-manifest-restorer` running the shared `manifest-restore` task, so that the auth
+   `Secret` and friends exist before any pod could reference them.
+4. The provisioner then selects the snapshot to restore (see below), pre-creates the seed member's
+   `PersistentVolumeClaim` — named `data-<db-name>-0`, exactly what the PetSet's volume claim
+   template would have produced for ordinal 0 — and creates a second `RestoreSession` named
+   `<db-name>-0-snapshot-restorer`. That session targets the **PVC**, not a pod, and runs the
+   `etcd-backup-restore` task, which rebuilds a complete etcd data directory inside the volume.
+5. Only after that `RestoreSession` reaches `Succeeded` does the provisioner set the
+   `DatabaseSuccessfullyRestored` condition and create the PetSet. Member 0 boots on the restored
+   data directory; every other member joins through the normal membership path and streams its copy
+   of the data from the leader, so only ordinal 0 is ever restored into.
+
+Once the condition is set the gate is permanently open — the provisioner will not re-run a restore
+over a live cluster, which is exactly what you want.
+
+Because `spec.storageType: Ephemeral` gives the provisioner no PVC to restore into ahead of the
+pods, restoring from a snapshot requires `spec.storageType: Durable` with `spec.storage` set. The
+provisioner rejects the combination explicitly.
+
+### Choosing which snapshot to restore
+
+`spec.init.archiver.recoveryTimestamp` is present on the shared `ArchiverRecovery` type, but for
+etcd it does **not** mean "replay to this instant". With no log stream to replay, it degrades to a
+selector over the completed snapshots:
+
+- Leave it unset (zero) and the provisioner restores the **newest** successful full `Snapshot` in
+  the repository.
+- Set it and the provisioner restores the newest successful full `Snapshot` that was completed **at
+  or before** that timestamp. If no snapshot qualifies, the restore fails with an explicit error
+  rather than silently picking a later one.
+
+"Completed" here is the restic summary end time of the `dump` component where available, because
+`Snapshot.status.snapshotTime` records when the session *started*, not when the data was consistent.
+
+### What the restore task rebuilds
+
+The `etcd-backup-restore` task does a server-side data directory rebuild. Along with the snapshot
+itself, it writes the bootstrap identity of the seed member into the new data directory — the member
+name, the `--initial-cluster` membership, the cluster token and the advertised peer URLs. All four
+have sensible defaults derived from the `Etcd` object (the ordinal-0 pod name, the seed member
+alone, the offshoot name, and the ordinal-0 pod's peer URL respectively), so you normally do not
+have to think about them. It also runs an etcd version-compatibility check and a free-space
+pre-flight check against the target volume before touching anything.
+
+## Next Steps
+
+- Walk through a complete backup and restore in
+  [Snapshot Backup & Restore of Etcd using KubeStash](/docs/guides/etcd/backup/kubestash/snapshot/index.md).
+- Detail concepts of the [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md) object.
+- Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+- Detail concepts of the [AppBinding](/docs/guides/etcd/concepts/appbinding.md) object.

--- a/docs/guides/etcd/backup/kubestash/snapshot/index.md
+++ b/docs/guides/etcd/backup/kubestash/snapshot/index.md
@@ -461,7 +461,18 @@ Set it back to `false` to resume.
 
 This is where etcd differs from most KubeDB databases, so read this before you try anything.
 
-{{< notice type="warning" message="**You cannot restore into a running `Etcd` cluster.** etcd requires a member's data directory to be either genuinely empty or a fully rebuilt snapshot directory *before* the member starts. There is no restore task you can point at a live cluster, and KubeDB will not create one. Restore happens only at bootstrap time, on a new `Etcd` object." >}}
+{{< notice type="warning" message="**A snapshot can never be poured into a running member.** etcd requires a member's data directory to be either genuinely empty or a fully rebuilt snapshot directory *before* the member starts. There is no restore task you can point at a live cluster, so restoring always means starting a member on an already-restored volume." >}}
+
+That leaves two ways to restore, and this section covers the first one:
+
+- **Bootstrap-time restore** (below): a **new** `Etcd` object with `spec.init.archiver` filled in.
+  The provisioner performs the restore before it creates the PetSet. Use this whenever you can —
+  there is no existing data to lose.
+- **In-place restore** into an `Etcd` that already exists: an `EtcdOpsRequest` of type `Restore`,
+  which takes the existing cluster apart down to a single empty volume and runs the very same
+  `RestoreSession` against it. It **replaces the entire keyspace of the live database**, so reach
+  for it only when the `Etcd` object itself has to survive. See
+  [In-place Restore](/docs/guides/etcd/restore/overview.md).
 
 So we deploy a **new** `Etcd` object with `spec.init.archiver` filled in, and the provisioner
 performs the restore before it creates the PetSet.
@@ -630,6 +641,8 @@ happens to the repositories then depends on the archiver's `spec.deletionPolicy`
 
 - Read the [Etcd Backup & Restore Overview](/docs/guides/etcd/backup/kubestash/overview/index.md)
   for the architecture behind what you just did.
+- Restore a snapshot into an `Etcd` cluster that already exists with an
+  [in-place Restore](/docs/guides/etcd/restore/restore.md) ops request.
 - Detail concepts of the [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md) object.
 - Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
 - Detail concepts of the [AppBinding](/docs/guides/etcd/concepts/appbinding.md) object.

--- a/docs/guides/etcd/backup/kubestash/snapshot/index.md
+++ b/docs/guides/etcd/backup/kubestash/snapshot/index.md
@@ -1,0 +1,636 @@
+---
+title: Snapshot Backup & Restore Etcd | KubeStash
+description: Take scheduled snapshot backups of an Etcd cluster with KubeStash and bootstrap a new cluster from one
+menu:
+  docs_{{ .version }}:
+    identifier: guides-etcd-backup-snapshot-stashv2
+    name: Snapshot Backup & Restore
+    parent: guides-etcd-backup-stashv2
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Snapshot Backup & Restore of Etcd using KubeStash
+
+This guide walks through the full lifecycle: deploying an `Etcd` cluster, attaching an
+`EtcdArchiver` backup policy to it, watching a snapshot land in an S3 bucket, and then bootstrapping
+a brand new `Etcd` cluster from that snapshot.
+
+{{< notice type="warning" message="Backup of an `Etcd` cluster is **snapshot-only**. There is no continuous archiving and therefore no point-in-time recovery — a restore rolls the data back to the state captured by one completed snapshot. Read the [overview](/docs/guides/etcd/backup/kubestash/overview/index.md) before you design a backup schedule." >}}
+
+## Before You Begin
+
+- You need a Kubernetes cluster with `kubectl` configured to talk to it. If you do not have one, you
+  can create one with [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md). etcd support is
+  an alpha feature gate, so it must be enabled explicitly — pass `--set featureGates.Etcd=true` to
+  the KubeDB Helm chart (equivalently `--feature-gates=Etcd=true` on the operator binaries).
+- Install `KubeStash` in your cluster following the steps
+  [here](https://kubestash.com/docs/latest/setup/install/kubestash/).
+- Install the KubeStash `kubectl` plugin following the steps
+  [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
+- Read the [Etcd Backup & Restore Overview](/docs/guides/etcd/backup/kubestash/overview/index.md)
+  first — especially the part about restore being gated at bootstrap time.
+
+You should be familiar with the following `KubeStash` concepts:
+
+- [BackupStorage](https://kubestash.com/docs/latest/concepts/crds/backupstorage/)
+- [BackupConfiguration](https://kubestash.com/docs/latest/concepts/crds/backupconfiguration/)
+- [BackupSession](https://kubestash.com/docs/latest/concepts/crds/backupsession/)
+- [RestoreSession](https://kubestash.com/docs/latest/concepts/crds/restoresession/)
+- [Addon](https://kubestash.com/docs/latest/concepts/crds/addon/)
+- [Function](https://kubestash.com/docs/latest/concepts/crds/function/)
+
+To keep everything isolated, this tutorial uses a separate namespace called `demo`.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** the YAML files used in this tutorial are stored in
+> [docs/examples/etcd/backup](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/backup)
+> of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Prepare the Backend
+
+We are going to store the backed up data in an `S3` bucket. Any other KubeStash backend works the
+same way — see the [backend configuration docs](https://kubestash.com/docs/latest/guides/backends/overview/).
+
+### Create the storage Secret
+
+```bash
+$ echo -n '<your-aws-access-key-id-here>' > AWS_ACCESS_KEY_ID
+$ echo -n '<your-aws-secret-access-key-here>' > AWS_SECRET_ACCESS_KEY
+$ kubectl create secret generic -n demo s3-secret \
+    --from-file=./AWS_ACCESS_KEY_ID \
+    --from-file=./AWS_SECRET_ACCESS_KEY
+secret/s3-secret created
+```
+
+### Create the BackupStorage
+
+```yaml
+apiVersion: storage.kubestash.com/v1alpha1
+kind: BackupStorage
+metadata:
+  name: s3-storage
+  namespace: demo
+spec:
+  storage:
+    provider: s3
+    s3:
+      endpoint: ap-south-1.linodeobjects.com
+      bucket: kubestash-etcd
+      region: ap-south-1
+      prefix: etcd-demo
+      secretName: s3-secret
+  usagePolicy:
+    allowedNamespaces:
+      from: All
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/backup/s3-storage.yaml
+backupstorage.storage.kubestash.com/s3-storage created
+```
+
+### Create a RetentionPolicy
+
+The `RetentionPolicy` decides how many old snapshots survive.
+
+```yaml
+apiVersion: storage.kubestash.com/v1alpha1
+kind: RetentionPolicy
+metadata:
+  name: demo-retention
+  namespace: demo
+spec:
+  default: true
+  failedSnapshots:
+    last: 2
+  maxRetentionPeriod: 2mo
+  successfulSnapshots:
+    last: 5
+  usagePolicy:
+    allowedNamespaces:
+      from: Same
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/backup/retentionpolicy.yaml
+retentionpolicy.storage.kubestash.com/demo-retention created
+```
+
+### Create the encryption Secret
+
+KubeStash encrypts everything it writes to the backend with a restic password.
+
+```bash
+$ echo -n 'changeit' > RESTIC_PASSWORD
+$ kubectl create secret generic -n demo encrypt-secret \
+    --from-file=./RESTIC_PASSWORD
+secret/encrypt-secret created
+```
+
+## Deploy a Sample Etcd
+
+Below is the `Etcd` object we are going to back up. Two things are worth pointing out: the
+`archiver: "true"` label, which is what the archiver's `spec.databases.selector` will match, and
+`spec.archiver.ref`, which is the database side of the opt-in.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: sample-etcd
+  namespace: demo
+  labels:
+    archiver: "true"
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  archiver:
+    ref:
+      name: etcd-archiver
+      namespace: demo
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/backup/sample-etcd.yaml
+etcd.kubedb.com/sample-etcd created
+```
+
+> If you omit `spec.archiver` entirely, the provisioner will find a matching `EtcdArchiver` on its
+> own and patch the reference in for you. Setting it explicitly just makes the intent obvious.
+
+Wait for the cluster to become `Ready`:
+
+```bash
+$ kubectl get etcd -n demo sample-etcd
+NAME          VERSION   STATUS   AGE
+sample-etcd   3.6.4     Ready    4m12s
+```
+
+KubeDB also created the auth `Secret`, the Services and the `AppBinding` that the backup job will use
+to reach the cluster:
+
+```bash
+$ kubectl get secret,svc,appbinding -n demo -l app.kubernetes.io/instance=sample-etcd
+NAME                      TYPE                       DATA   AGE
+secret/sample-etcd-auth   kubernetes.io/basic-auth   2      4m30s
+
+NAME                       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
+service/sample-etcd        ClusterIP   10.96.121.40    <none>        2379/TCP                     4m30s
+service/sample-etcd-pods   ClusterIP   None            <none>        2379/TCP,2380/TCP,2381/TCP   4m30s
+
+NAME                                             TYPE              VERSION   AGE
+appbinding.appcatalog.appscode.com/sample-etcd   kubedb.com/etcd   3.6.4     4m28s
+```
+
+The [AppBinding](/docs/guides/etcd/concepts/appbinding.md) is what the backup job reads to learn the client endpoint (`spec.clientConfig.service`
+on port `2379`), the credentials (`spec.secret`) and, when TLS is enabled, the client certificate
+(`spec.tlsSecret`).
+
+### Put some data in the cluster
+
+Read the root credentials out of the auth `Secret`:
+
+```bash
+$ kubectl get secret -n demo sample-etcd-auth -o jsonpath='{.data.username}' | base64 -d
+root
+$ kubectl get secret -n demo sample-etcd-auth -o jsonpath='{.data.password}' | base64 -d
+```
+
+Then exec into a member and write a key so we have something to verify after the restore:
+
+```bash
+$ kubectl exec -it -n demo sample-etcd-0 -c etcd -- sh
+
+$ export ETCDCTL_API=3
+$ export ETCDCTL_ENDPOINTS=http://127.0.0.1:2379
+$ export ETCDCTL_USER=root:<root-password>
+
+$ etcdctl put /demo/hello "hello from the original cluster"
+OK
+
+$ etcdctl get /demo/hello
+/demo/hello
+hello from the original cluster
+
+$ exit
+```
+
+## Configure Backup
+
+Instead of writing a `BackupConfiguration` by hand, you create an `EtcdArchiver` — the backup
+*policy* — and the KubeDB provisioner derives the `BackupConfiguration` from it.
+
+```yaml
+apiVersion: archiver.kubedb.com/v1alpha1
+kind: EtcdArchiver
+metadata:
+  name: etcd-archiver
+  namespace: demo
+spec:
+  databases:
+    namespaces:
+      from: Same
+    selector:
+      matchLabels:
+        archiver: "true"
+  backupStorage:
+    ref:
+      name: s3-storage
+      namespace: demo
+    subDir: etcd-archiver
+  retentionPolicy:
+    name: demo-retention
+    namespace: demo
+  encryptionSecret:
+    name: encrypt-secret
+    namespace: demo
+  fullBackup:
+    driver: Restic
+    scheduler:
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 3
+      schedule: "0 */2 * * *"
+      jobTemplate:
+        backoffLimit: 1
+  manifestBackup:
+    scheduler:
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 3
+      schedule: "0 */2 * * *"
+      jobTemplate:
+        backoffLimit: 1
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.databases` is the archiver side of the double opt-in. `namespaces.from: Same` restricts it to
+  the archiver's own namespace, and `selector` narrows it to `Etcd` objects labelled `archiver: "true"`.
+- `spec.backupStorage.ref` points at the `BackupStorage`. `subDir` is prefixed to the repository
+  directory, so the data ends up under `etcd-archiver/demo/sample-etcd/<session>` in the bucket.
+- `spec.fullBackup` generates the `full-backup` session, which takes the etcd snapshot. Its
+  `driver` field is required by the shared schema but is **ignored for etcd** — an etcd snapshot is
+  always streamed through the client API into a restic repository.
+- `spec.manifestBackup` generates the `manifest-backup` session, which captures the Kubernetes
+  objects (the `Etcd` manifest, the auth `Secret`, and so on).
+- `spec.deletionPolicy` decides what happens to the repositories when the backup is torn down. It
+  defaults to `Retain`.
+
+> **There is no `spec.logBackup`.** etcd has no WAL-shipping primitive, so the field does not exist.
+> Your recovery point is whatever the last completed snapshot captured.
+
+Create it:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/backup/etcd-archiver.yaml
+etcdarchiver.archiver.kubedb.com/etcd-archiver created
+```
+
+### Verify the generated BackupConfiguration
+
+The provisioner creates a `BackupConfiguration` named `<db-name>-archiver`, owned by the `Etcd`
+object:
+
+```bash
+$ kubectl get backupconfiguration -n demo
+NAME                   PHASE   PAUSED   AGE
+sample-etcd-archiver   Ready            1m20s
+```
+
+Its two sessions and two repositories match the two sections of the archiver:
+
+```bash
+$ kubectl get backupconfiguration -n demo sample-etcd-archiver \
+    -o jsonpath='{range .spec.sessions[*]}{.name}{"\t"}{.repositories[0].name}{"\t"}{range .addon.tasks[*]}{.name}{" "}{end}{"\n"}{end}'
+full-backup       sample-etcd-full       etcd-backup manifest-backup
+manifest-backup   sample-etcd-manifest   manifest-backup
+```
+
+The `Repository` objects are initialized as soon as the `BackupConfiguration` becomes `Ready`:
+
+```bash
+$ kubectl get repository -n demo
+NAME                   INTEGRITY   SNAPSHOT-COUNT   SIZE   PHASE   LAST-SUCCESSFUL-BACKUP   AGE
+sample-etcd-full                   0                0 B    Ready                            1m35s
+sample-etcd-manifest               0                0 B    Ready                            1m35s
+```
+
+And a `CronJob` per session fires on the schedule you set:
+
+```bash
+$ kubectl get cronjob -n demo
+NAME                                           SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+trigger-sample-etcd-archiver-full-backup       0 */2 * * *   False     0        <none>          1m45s
+trigger-sample-etcd-archiver-manifest-backup   0 */2 * * *   False     0        <none>          1m45s
+```
+
+### Watch the first BackupSession
+
+KubeStash triggers an instant backup as soon as the `BackupConfiguration` becomes `Ready`; after
+that the `CronJob`s take over.
+
+```bash
+$ kubectl get backupsession -n demo -w
+NAME                                          INVOKER-TYPE          INVOKER-NAME           PHASE       DURATION   AGE
+sample-etcd-archiver-full-backup-1755248400   BackupConfiguration   sample-etcd-archiver   Running                12s
+sample-etcd-archiver-full-backup-1755248400   BackupConfiguration   sample-etcd-archiver   Succeeded   31s        41s
+```
+
+If you want to trigger one yourself instead of waiting for the schedule, create a `BackupSession`
+naming the session you want:
+
+```yaml
+apiVersion: core.kubestash.com/v1alpha1
+kind: BackupSession
+metadata:
+  name: manual-full-backup
+  namespace: demo
+spec:
+  invoker:
+    apiGroup: core.kubestash.com
+    kind: BackupConfiguration
+    name: sample-etcd-archiver
+  session: full-backup
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/backup/trigger-backupsession.yaml
+backupsession.core.kubestash.com/manual-full-backup created
+```
+
+### Verify the Snapshot
+
+Once a session succeeds, its `Repository` is updated and a `Snapshot` object records the run:
+
+```bash
+$ kubectl get repository -n demo sample-etcd-full
+NAME               INTEGRITY   SNAPSHOT-COUNT   SIZE      PHASE   LAST-SUCCESSFUL-BACKUP   AGE
+sample-etcd-full   true        1                1.482 MiB Ready   45s                      6m10s
+
+$ kubectl get snapshot -n demo -l kubestash.com/repo-name=sample-etcd-full
+NAME                                                           REPOSITORY         SESSION       SNAPSHOT-TIME          DELETION-POLICY   PHASE       AGE
+sample-etcd-full-sample-etcd-archiver-full-backup-1755248400    sample-etcd-full   full-backup   2026-08-15T10:00:00Z   Delete            Succeeded   50s
+```
+
+Looking inside the `Snapshot`, the etcd data lands under the `dump` component — `etcdctl snapshot
+save` produces a single file, so the backup is a logical dump rather than a physical volume copy:
+
+```yaml
+apiVersion: storage.kubestash.com/v1alpha1
+kind: Snapshot
+metadata:
+  labels:
+    kubestash.com/app-ref-kind: Etcd
+    kubestash.com/app-ref-name: sample-etcd
+    kubestash.com/app-ref-namespace: demo
+    kubestash.com/repo-name: sample-etcd-full
+  name: sample-etcd-full-sample-etcd-archiver-full-backup-1755248400
+  namespace: demo
+spec:
+  appRef:
+    apiGroup: kubedb.com
+    kind: Etcd
+    name: sample-etcd
+    namespace: demo
+  backupSession: sample-etcd-archiver-full-backup-1755248400
+  repository: sample-etcd-full
+  session: full-backup
+  type: FullBackup
+  version: v1
+status:
+  components:
+    dump:
+      driver: Restic
+      integrity: true
+      path: repository/v1/full-backup/dump
+      phase: Succeeded
+    manifest:
+      driver: Restic
+      integrity: true
+      path: repository/v1/full-backup/manifest
+      phase: Succeeded
+  integrity: true
+  phase: Succeeded
+  snapshotTime: "2026-08-15T10:00:00Z"
+```
+
+> Only `Snapshot`s whose `status.phase` is `Succeeded` and whose `spec.type` is `FullBackup` are
+> eligible for restore. Anything else is skipped when the provisioner picks a snapshot.
+
+Navigating the bucket, the data is under
+`etcd-demo/etcd-archiver/demo/sample-etcd/full-backup/repository/v1/full-backup/dump`, and the
+`Snapshot` YAMLs are alongside it under `snapshots`. Everything is encrypted with the restic
+password from `encrypt-secret`, so it is unreadable until decrypted.
+
+### Pausing backup
+
+To stop the schedules without dropping the repositories, set `spec.pause` on the archiver:
+
+```bash
+$ kubectl patch etcdarchiver -n demo etcd-archiver --type merge -p '{"spec":{"pause":true}}'
+etcdarchiver.archiver.kubedb.com/etcd-archiver patched
+
+$ kubectl get backupconfiguration -n demo sample-etcd-archiver
+NAME                   PHASE   PAUSED   AGE
+sample-etcd-archiver   Ready   true     12m
+```
+
+Set it back to `false` to resume.
+
+## Restore
+
+This is where etcd differs from most KubeDB databases, so read this before you try anything.
+
+{{< notice type="warning" message="**You cannot restore into a running `Etcd` cluster.** etcd requires a member's data directory to be either genuinely empty or a fully rebuilt snapshot directory *before* the member starts. There is no restore task you can point at a live cluster, and KubeDB will not create one. Restore happens only at bootstrap time, on a new `Etcd` object." >}}
+
+So we deploy a **new** `Etcd` object with `spec.init.archiver` filled in, and the provisioner
+performs the restore before it creates the PetSet.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: restored-etcd
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  init:
+    archiver:
+      recoveryTimestamp: "0001-01-01T00:00:00Z"
+      encryptionSecret:
+        name: encrypt-secret
+        namespace: demo
+      fullDBRepository:
+        name: sample-etcd-full
+        namespace: demo
+      manifestRepository:
+        name: sample-etcd-manifest
+        namespace: demo
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.init.archiver.fullDBRepository` names the `Repository` holding the etcd snapshots. This is
+  the field that turns on data restore.
+- `spec.init.archiver.manifestRepository` names the `Repository` holding the Kubernetes objects.
+  Restoring it recreates the auth `Secret` before any pod could reference it. It is optional; without
+  `fullDBRepository` it would restore the manifests only and let the cluster come up empty.
+- `spec.init.archiver.encryptionSecret` must be the same restic password the backup was written with.
+- `spec.init.archiver.recoveryTimestamp` is required by the schema, but for etcd it is **not** a
+  point-in-time target — there is nothing to replay forward. It selects the newest successful full
+  snapshot completed **at or before** that instant. The zero time shown above means "no constraint",
+  i.e. restore the newest snapshot; put a real RFC 3339 timestamp there to pin an older one. If no
+  snapshot qualifies, the restore fails loudly instead of silently picking a later one.
+- `spec.storageType` must be `Durable` with `spec.storage` set. There is no PVC to restore into
+  ahead of the pods with `Ephemeral` storage, and the provisioner rejects that combination.
+
+{{< notice type="note" message="KubeStash's manifest-restore options do not yet carry an etcd section, so the restored manifests cannot currently be renamed or filtered the way some other KubeDB databases allow. If you only want the data and would rather let KubeDB generate a fresh auth `Secret` for the new cluster, omit `manifestRepository` and keep `fullDBRepository` alone." >}}
+
+Create it:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/backup/restored-etcd.yaml
+etcd.kubedb.com/restored-etcd created
+```
+
+### Watch the restore happen before the cluster boots
+
+The new `Etcd` reports `DataRestoring` while the seed volume is being rebuilt. Note that no pods
+exist yet — the PetSet is deliberately withheld:
+
+```bash
+$ kubectl get etcd -n demo restored-etcd
+NAME            VERSION   STATUS          AGE
+restored-etcd   3.6.4     DataRestoring   35s
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=restored-etcd
+No resources found in demo namespace.
+```
+
+The provisioner creates the manifest restore first, then the snapshot restore:
+
+```bash
+$ kubectl get restoresession -n demo
+NAME                              REPOSITORY             FAILURE-POLICY   PHASE       DURATION   AGE
+restored-etcd-manifest-restorer   sample-etcd-manifest                    Succeeded   9s         40s
+restored-etcd-0-snapshot-restorer sample-etcd-full                        Running                12s
+```
+
+The snapshot restore targets the seed member's `PersistentVolumeClaim` — created ahead of the PetSet
+so the data directory can be rebuilt while no etcd process is running:
+
+```bash
+$ kubectl get pvc -n demo
+NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   AGE
+data-restored-etcd-0   Bound    pvc-7b3d1f0c-9f1e-4a0a-9a3f-6d2b0c8a1e44   1Gi        RWO            45s
+
+$ kubectl get restoresession -n demo restored-etcd-0-snapshot-restorer \
+    -o jsonpath='{.spec.target.kind}{"/"}{.spec.target.name}{"\n"}'
+PersistentVolumeClaim/data-restored-etcd-0
+```
+
+Only ordinal 0 is ever restored into. Once it is up, members 1 and 2 join through the normal etcd
+membership path and stream their copy of the data from the leader.
+
+When the snapshot `RestoreSession` succeeds, the provisioner records the restore on the `Etcd`
+object and finally creates the PetSet:
+
+```bash
+$ kubectl get etcd -n demo restored-etcd -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{end}'
+DatabaseSuccessfullyRestored   True    DatabaseSuccessfullyRestored
+ProvisioningStarted            True    DatabaseProvisioningStartedSuccessfully
+ReplicaReady                   True    AllReplicasReady
+AcceptingConnection            True    DatabaseAcceptingConnectionRequest
+Ready                          True    ReadinessCheckSucceeded
+Provisioned                    True    DatabaseSuccessfullyProvisioned
+```
+
+```bash
+$ kubectl get etcd -n demo restored-etcd
+NAME            VERSION   STATUS   AGE
+restored-etcd   3.6.4     Ready    3m50s
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=restored-etcd
+NAME              READY   STATUS    RESTARTS   AGE
+restored-etcd-0   1/1     Running   0          2m40s
+restored-etcd-1   1/1     Running   0          2m18s
+restored-etcd-2   1/1     Running   0          1m56s
+```
+
+If the restore fails instead, the `DatabaseSuccessfullyRestored` condition is set to `False` with
+reason `FailedToRestoreSuccessfully`, and the PetSet is still not created — the cluster never boots on
+a half-restored data directory.
+
+### Verify the restored data
+
+```bash
+$ kubectl exec -it -n demo restored-etcd-0 -c etcd -- sh
+
+$ export ETCDCTL_API=3
+$ export ETCDCTL_ENDPOINTS=http://127.0.0.1:2379
+$ export ETCDCTL_USER=root:<root-password>
+
+$ etcdctl get /demo/hello
+/demo/hello
+hello from the original cluster
+
+$ exit
+```
+
+The key we wrote into `sample-etcd` before the backup is present in `restored-etcd`. Anything written
+to `sample-etcd` *after* that snapshot completed is not — that is the snapshot-only trade-off.
+
+## Cleanup
+
+```bash
+$ kubectl delete etcdarchiver -n demo etcd-archiver
+$ kubectl delete backupsession -n demo --all
+$ kubectl delete etcd -n demo restored-etcd
+$ kubectl delete etcd -n demo sample-etcd
+$ kubectl delete retentionpolicy -n demo demo-retention
+$ kubectl delete backupstorage -n demo s3-storage
+$ kubectl delete secret -n demo s3-secret
+$ kubectl delete secret -n demo encrypt-secret
+$ kubectl delete ns demo
+```
+
+Deleting the `EtcdArchiver` makes the provisioner delete the generated `BackupConfiguration`; what
+happens to the repositories then depends on the archiver's `spec.deletionPolicy`.
+
+## Next Steps
+
+- Read the [Etcd Backup & Restore Overview](/docs/guides/etcd/backup/kubestash/overview/index.md)
+  for the architecture behind what you just did.
+- Detail concepts of the [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md) object.
+- Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+- Detail concepts of the [AppBinding](/docs/guides/etcd/concepts/appbinding.md) object.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/backup/kubestash/snapshot/index.md
+++ b/docs/guides/etcd/backup/kubestash/snapshot/index.md
@@ -35,7 +35,7 @@ a brand new `Etcd` cluster from that snapshot.
 - Install the KubeStash `kubectl` plugin following the steps
   [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - Read the [Etcd Backup & Restore Overview](/docs/guides/etcd/backup/kubestash/overview/index.md)
-  first — especially the part about restore being gated at bootstrap time.
+  first — especially the part about a snapshot always being replayed into an empty data directory.
 
 You should be familiar with the following `KubeStash` concepts:
 
@@ -196,7 +196,7 @@ secret/sample-etcd-auth   kubernetes.io/basic-auth   2      4m30s
 
 NAME                       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
 service/sample-etcd        ClusterIP   10.96.121.40    <none>        2379/TCP                     4m30s
-service/sample-etcd-pods   ClusterIP   None            <none>        2379/TCP,2380/TCP,2381/TCP   4m30s
+service/sample-etcd-pods   ClusterIP   None            <none>        2379/TCP,2380/TCP   4m30s
 
 NAME                                             TYPE              VERSION   AGE
 appbinding.appcatalog.appscode.com/sample-etcd   kubedb.com/etcd   3.6.4     4m28s
@@ -535,13 +535,13 @@ etcd.kubedb.com/restored-etcd created
 
 ### Watch the restore happen before the cluster boots
 
-The new `Etcd` reports `DataRestoring` while the seed volume is being rebuilt. Note that no pods
+The new `Etcd` stays in `Provisioning` while the seed volume is being rebuilt. Note that no pods
 exist yet — the PetSet is deliberately withheld:
 
 ```bash
 $ kubectl get etcd -n demo restored-etcd
 NAME            VERSION   STATUS          AGE
-restored-etcd   3.6.4     DataRestoring   35s
+restored-etcd   3.6.4     Provisioning    35s
 
 $ kubectl get pods -n demo -l app.kubernetes.io/instance=restored-etcd
 No resources found in demo namespace.
@@ -577,11 +577,11 @@ object and finally creates the PetSet:
 
 ```bash
 $ kubectl get etcd -n demo restored-etcd -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{end}'
-DatabaseSuccessfullyRestored   True    DatabaseSuccessfullyRestored
+SuccessfullyDataRestored   True    SuccessfullyDataRestored
 ProvisioningStarted            True    DatabaseProvisioningStartedSuccessfully
 ReplicaReady                   True    AllReplicasReady
 AcceptingConnection            True    DatabaseAcceptingConnectionRequest
-Ready                          True    ReadinessCheckSucceeded
+Ready                          True    AllReplicasReady
 Provisioned                    True    DatabaseSuccessfullyProvisioned
 ```
 
@@ -597,7 +597,7 @@ restored-etcd-1   1/1     Running   0          2m18s
 restored-etcd-2   1/1     Running   0          1m56s
 ```
 
-If the restore fails instead, the `DatabaseSuccessfullyRestored` condition is set to `False` with
+If the restore fails instead, the `SuccessfullyDataRestored` condition is set to `False` with
 reason `FailedToRestoreSuccessfully`, and the PetSet is still not created — the cluster never boots on
 a half-restored data directory.
 

--- a/docs/guides/etcd/concepts/_index.md
+++ b/docs/guides/etcd/concepts/_index.md
@@ -1,0 +1,12 @@
+---
+title: Etcd Concepts
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-concepts-etcd
+    name: Concepts
+    parent: etcd-etcd-guides
+    weight: 20
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/concepts/appbinding.md
+++ b/docs/guides/etcd/concepts/appbinding.md
@@ -1,0 +1,102 @@
+---
+title: AppBinding CRD
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-appbinding-concepts
+    name: AppBinding
+    parent: etcd-concepts-etcd
+    weight: 40
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# AppBinding
+
+## What is AppBinding
+
+An `AppBinding` is a Kubernetes `CustomResourceDefinition`(CRD) which points to an application using either its URL (usually for a non-Kubernetes resident service instance) or a Kubernetes service object (if self-hosted in a Kubernetes cluster), some optional parameters and a credential secret. To learn more about AppBinding and the problems it solves, please read this blog post: [The case for AppBinding](https://appscode.com/blog/post/the-case-for-appbinding).
+
+When you deploy an [Etcd](/docs/guides/etcd/concepts/etcd.md) object with KubeDB, an `AppBinding` object is created automatically for it. Backup and restore tooling — [KubeStash](https://kubestash.com/) and the etcd backup addon — uses it to find out how to reach the cluster and which credentials to use.
+
+## The AppBinding created for an Etcd object
+
+An `AppBinding` object created by KubeDB for an etcd cluster is shown below:
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  creationTimestamp: "2026-01-14T10:02:45Z"
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: etcd-quickstart
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: etcds.kubedb.com
+  name: etcd-quickstart
+  namespace: demo
+  ownerReferences:
+    - apiVersion: kubedb.com/v1alpha2
+      blockOwnerDeletion: true
+      controller: true
+      kind: Etcd
+      name: etcd-quickstart
+      uid: 20e00408-abf1-470b-a049-bdf272b3e994
+  resourceVersion: "12345"
+  uid: 8fd15549-ab9c-4523-b85d-77275f620bb5
+spec:
+  appRef:
+    apiGroup: kubedb.com
+    kind: Etcd
+    name: etcd-quickstart
+    namespace: demo
+  clientConfig:
+    service:
+      name: etcd-quickstart
+      port: 2379
+      scheme: etcd
+      path: /
+    insecureSkipTLSVerify: false
+  secret:
+    name: etcd-quickstart-auth
+  type: kubedb.com/etcd
+  version: 3.6.4
+```
+
+What is etcd-specific about it:
+
+| Field                             | Value for etcd                                                                                                             |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `spec.type`                       | `kubedb.com/etcd`                                                                                                            |
+| `spec.clientConfig.service.scheme` | `etcd`                                                                                                                      |
+| `spec.clientConfig.service.name`  | The load balanced client Service, which has the same name as the `Etcd` object.                                              |
+| `spec.clientConfig.service.port`  | `2379`, etcd's client port. (The peer port `2380` and the metrics port `2381` are not part of the AppBinding — clients never talk to them.) |
+| `spec.secret`                     | The auth Secret holding the `username`/`password` of the etcd `root` user.                                                    |
+| `spec.version`                    | The etcd version, taken from the referenced [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md).                          |
+
+There is a single client Service rather than a primary/standby pair, because every etcd member serves the client API and forwards writes to the current Raft leader — see [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specservicetemplates).
+
+### When TLS is enabled
+
+If [`spec.tls`](/docs/guides/etcd/concepts/etcd.md#spectls) is configured on the `Etcd` object, KubeDB additionally fills in:
+
+- `spec.clientConfig.caBundle` — the CA certificate read from the `client` certificate Secret, so consumers can verify the etcd server certificate. `insecureSkipTLSVerify` stays `false`.
+- `spec.tlsSecret` — a reference to the `client` certificate Secret (`<db-name>-client-cert` by default), which holds the client certificate and key used to authenticate to etcd.
+
+### spec.secret
+
+`spec.secret` references the Secret holding the credentials required to access the cluster. It must be in the same namespace as the `AppBinding`, and contains the following keys:
+
+| Key        | Usage                                                                     |
+|------------|-----------------------------------------------------------------------------|
+| `username` | Username of the etcd superuser. KubeDB uses etcd's built-in `root` user.     |
+| `password` | Password for the user specified by `username`.                              |
+
+## Next Steps
+
+- Learn about the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd.
+- Learn how to use KubeDB to manage various databases [here](/docs/guides/README.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -236,7 +236,7 @@ spec:
 
 ### spec.monitor
 
-Etcd managed by KubeDB can be monitored with builtin-Prometheus and Prometheus operator out-of-the-box.
+Etcd managed by KubeDB can be monitored with built-in Prometheus and Prometheus operator out-of-the-box.
 
 etcd exposes Prometheus metrics natively, so **no exporter sidecar container is deployed**. KubeDB creates a stats Service that targets etcd's own metrics endpoint and, for `agent: prometheus.io/operator`, a matching `ServiceMonitor`.
 
@@ -378,7 +378,7 @@ Uses of some fields of `spec.podTemplate` are described below.
 
 #### spec.podTemplate.spec.containers[].resources
 
-`resources` on the `etcd` container can be used to request compute resources required by the database pods. To learn more, visit [here](http://kubernetes.io/docs/user-guide/compute-resources/).
+`resources` on the `etcd` container can be used to request compute resources required by the database pods. To learn more, visit [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 
 ```yaml
 spec:
@@ -506,7 +506,7 @@ spec:
 
 ### spec.deletionPolicy
 
-`deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of the `Etcd` crd or which resources KubeDB should keep or delete when you delete the `Etcd` crd. KubeDB provides the following four deletion policies:
+`deletionPolicy` controls whether KubeDB rejects deletion of the `Etcd` CRD and which resources it keeps or deletes when you do delete it. KubeDB provides the following four deletion policies:
 
 - DoNotTerminate
 - Halt
@@ -544,7 +544,7 @@ It defines the attributes for the health checker.
 - `spec.healthChecker.failureThreshold` specifies the minimum consecutive failures for the healthChecker to be considered failed. Defaults to `1`.
 - `spec.healthChecker.disableWriteCheck` specifies whether to disable the write check or not.
 
-For etcd, the health checker dials the client port of every member and uses etcd's own `Status()` and `MemberList()` RPCs. The cluster is considered quorum-healthy while at least `N/2+1` members respond. etcd is a key-value store, not a relational database, so there is no query-language based health probe.
+For etcd, the health checker dials the client port of every member and uses etcd's own `Status()` and `MemberList()` RPCs. The cluster is considered quorum-healthy while at least `floor(N/2) + 1` members respond. etcd is a key-value store, not a relational database, so there is no query-language-based health probe.
 
 Know details about KubeDB health checking from this [blog post](https://appscode.com/blog/post/kubedb-health-checker/).
 

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -389,6 +389,23 @@ spec:
               memory: 2Gi
 ```
 
+#### spec.podTemplate.spec.containers[].args
+
+`args` on the `etcd` container is an optional list of extra etcd command-line flags. It is the escape hatch for the etcd settings `spec.configuration.tuning` does not expose. Set it on the container entry named `etcd` — the pod-level `spec.podTemplate.spec.args` is not read for etcd:
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          args:
+            - --heartbeat-interval=250
+            - --election-timeout=2500
+```
+
+These flags are appended **after** the ones the operator renders. etcd parses its command line with Go's standard `flag` package, where a repeated flag is not an error and the last occurrence wins — so a flag you set here also overrides one the operator set. That makes it powerful and sharp: overriding the flags that carry a member's identity, its listeners or its TLS material detaches the member from the cluster KubeDB is reconciling, and `--force-new-cluster` in particular would rewrite the data directory into a fresh single-member cluster on every restart. See [Extra etcd flags](/docs/guides/etcd/custom-configuration/using-config.md#extra-etcd-flags).
+
 #### spec.podTemplate.spec.env
 
 `spec.podTemplate.spec.env` is an optional field that specifies the environment variables to pass to the etcd docker image.

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -1,0 +1,563 @@
+---
+title: Etcd CRD
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-etcd-concepts
+    name: Etcd
+    parent: etcd-concepts-etcd
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd
+
+## What is Etcd
+
+`Etcd` is a Kubernetes `Custom Resource Definitions` (CRD). It provides declarative configuration for [etcd](https://etcd.io/) in a Kubernetes native way. You only need to describe the desired database configuration in an Etcd object, and the KubeDB operator will create Kubernetes objects in the desired state for you.
+
+etcd is a strongly consistent, distributed key-value store that replicates data with the [Raft](https://raft.github.io/) consensus algorithm. Unlike most other databases KubeDB manages, etcd has **no standalone-vs-cluster topology switch**: a one member deployment is simply `spec.replicas: 1`, and a highly available deployment is `spec.replicas: 3` (or `5`). Every member serves the client API and forwards writes to the current Raft leader, so there is no primary/standby split and no read-replica concept. Members are added and removed through etcd's own membership API rather than by editing a config file, so KubeDB drives scaling through that API.
+
+## Etcd Spec
+
+As with all other Kubernetes objects, an Etcd needs `apiVersion`, `kind`, and `metadata` fields. It also needs a `.spec` section. Below is an example Etcd object.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  authSecret:
+    name: etcd-cluster-auth
+    externallyManaged: false
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          app: kubedb
+        interval: 10s
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+    certificates:
+      - alias: server
+        secretName: etcd-cluster-server-cert
+      - alias: client
+        secretName: etcd-cluster-client-cert
+      - alias: peer
+        secretName: etcd-cluster-peer-cert
+  podTemplate:
+    metadata:
+      annotations:
+        passMe: ToDatabasePod
+    controller:
+      annotations:
+        passMe: ToPetSet
+    spec:
+      serviceAccountName: my-service-account
+      schedulerName: my-scheduler
+      nodeSelector:
+        disktype: ssd
+      imagePullSecrets:
+        - name: myregistrykey
+      containers:
+        - name: etcd
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+  serviceTemplates:
+    - alias: primary
+      metadata:
+        annotations:
+          passMe: ToService
+      spec:
+        type: NodePort
+        ports:
+          - name: client
+            port: 2379
+  archiver:
+    pause: false
+    ref:
+      name: etcd-archiver
+      namespace: demo
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 1
+  deletionPolicy: Halt
+  halted: false
+```
+
+### spec.version
+
+`spec.version` is a required field specifying the name of the [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `EtcdVersion` crds,
+
+- `3.5.21`
+- `3.6.4`
+
+### spec.replicas
+
+`spec.replicas` is the number of etcd members in the cluster. If not set, it defaults to `3`.
+
+An **odd** number of members is strongly recommended: a cluster of `2n+1` members tolerates `n` failures, while adding an even member only grows the quorum size without improving fault tolerance. The validating webhook only rejects values below `1`; even numbers are allowed but discouraged.
+
+KubeDB uses a `PodDisruptionBudget` so that a majority of members stays available during [voluntary disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#voluntary-and-involuntary-disruptions), keeping quorum intact.
+
+Changing `spec.replicas` (directly, or through a `HorizontalScaling`
+[EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)) is reconciled against etcd's actual member list:
+
+- **Scale up** — the next ordinal is first added to the cluster as a **learner**. A learner replicates the log but does not vote and does not count toward quorum, so a cold member can never stall the cluster. Once its Raft revision has caught up with the leader's, the operator **promotes** it to a voting member.
+- **Scale down** — the **highest ordinal** member is removed from etcd's member list first, and only then is the PetSet shrunk, so etcd never sees the pod disappear before it has been un-registered.
+
+The operator performs at most one membership mutation per reconcile pass, which is what etcd's membership API expects.
+
+### spec.storageType
+
+`spec.storageType` is an optional field that specifies the type of storage to use for the etcd data directory. It can be either `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB provisions the members with `EmptyDir` volumes instead of PVCs — all data is lost when a pod is recreated, so this is only appropriate for testing.
+
+> `spec.storageType: Ephemeral` cannot be combined with `spec.deletionPolicy: Halt`, since there is nothing to halt onto. The webhook rejects that combination.
+
+### spec.storage
+
+If you set `spec.storageType` to `Durable`, then `spec.storage` is a required field that specifies the StorageClass of PVCs dynamically allocated to store the etcd data directory (`/var/lib/etcd`). This storage spec will be passed to the PetSet created by the KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
+
+- `spec.storage.storageClassName` is the name of the StorageClass used to provision PVCs. PVCs don't necessarily have to request a class. A PVC with its storageClassName set equal to "" is always interpreted to be requesting a PV with no class, so it can only be bound to PVs with no class (no annotation or one set equal to ""). A PVC with no storageClassName is not quite the same and is treated differently by the cluster depending on whether the DefaultStorageClass admission plugin is turned on.
+- `spec.storage.accessModes` uses the same conventions as Kubernetes PVCs when requesting storage with specific access modes.
+- `spec.storage.resources` can be used to request specific quantities of storage. This follows the same resource model used by PVCs.
+
+To learn how to configure `spec.storage`, please visit the links below:
+
+- https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+
+> etcd is latency sensitive. Its backend commits every write to disk before acknowledging it, so a StorageClass backed by SSD/NVMe is strongly recommended for production clusters.
+
+### spec.authSecret
+
+`spec.authSecret` is an optional field that points to a Secret used to hold credentials for the etcd **`root`** user — the superuser of etcd's built-in RBAC. If not set, the KubeDB operator creates a new Secret `{etcd-object-name}-auth` for storing the password of the `root` user.
+
+We can use this field in 3 modes.
+
+1. Using an external secret. In this case, you need to create an auth secret first with the required fields, then specify the secret name when creating the Etcd object using `spec.authSecret.name` & set `spec.authSecret.externallyManaged` to true.
+
+```yaml
+authSecret:
+  name: <your-created-auth-secret-name>
+  externallyManaged: true
+```
+
+2. Specifying the secret name only. In this case, you need to specify the secret name when creating the Etcd object using `spec.authSecret.name`. `externallyManaged` is by default false.
+
+```yaml
+authSecret:
+  name: <intended-auth-secret-name>
+```
+
+3. Let KubeDB do everything for you. In this case, no work for you.
+
+The auth secret contains a `username` key and a `password` key which contain the username and the password respectively for the etcd `root` user.
+
+Example:
+
+```bash
+$ kubectl create secret generic etcd-auth -n demo \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=root \
+  --from-literal=password=6q8u_2jMOW-OOZXk
+secret "etcd-auth" created
+```
+
+```yaml
+apiVersion: v1
+data:
+  password: NnE4dV8yak1PVy1PT1pYaw==
+  username: cm9vdA==
+kind: Secret
+metadata:
+  name: etcd-auth
+  namespace: demo
+type: kubernetes.io/basic-auth
+```
+
+Secrets provided by users are not managed by KubeDB, and therefore won't be modified or garbage collected by the KubeDB operator.
+
+`spec.authSecret` also carries `rotateAfter`, which the Recommendation Engine uses to propose a `RotateAuth` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) once the credential reaches the given age.
+
+### spec.init
+
+`spec.init` is an optional section that can be used to initialize a newly created Etcd cluster. For etcd, the interesting sub-section is `spec.init.archiver`, which restores the cluster from a KubeStash snapshot taken by an [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md).
+
+```yaml
+spec:
+  init:
+    archiver:
+      encryptionSecret:
+        name: encrypt-secret
+        namespace: demo
+      fullDBRepository:
+        name: etcd-full-repo
+        namespace: demo
+      recoveryTimestamp: "2024-05-02T10:02:45Z"
+```
+
+Restore is only possible **at bootstrap time**. etcd requires a seed member's data directory to be either genuinely empty or a fully restored, valid snapshot — a snapshot can never be restored into a running cluster. So the operator pre-creates the ordinal-0 PVC, runs the `RestoreSession` against it, and only then creates the PetSet and starts the first member. While that happens, `status.phase` is `DataRestoring`.
+
+### spec.monitor
+
+Etcd managed by KubeDB can be monitored with builtin-Prometheus and Prometheus operator out-of-the-box.
+
+etcd exposes Prometheus metrics natively, so **no exporter sidecar container is deployed**. KubeDB creates a stats Service that targets etcd's own metrics endpoint and, for `agent: prometheus.io/operator`, a matching `ServiceMonitor`.
+
+```yaml
+spec:
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+```
+
+### spec.configuration
+
+`spec.configuration` is an optional field that specifies custom configuration for the etcd cluster. For etcd, only the typed `tuning` block is supported:
+
+```yaml
+spec:
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+```
+
+These map directly onto etcd's own command line flags:
+
+| Field                     | etcd flag                    | Meaning                                                                                                            |
+|---------------------------|------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `quotaBackendBytes`       | `--quota-backend-bytes`      | Maximum size of the backend database. etcd raises a `NOSPACE` alarm and goes read-only once the backend grows past it. |
+| `autoCompactionMode`      | `--auto-compaction-mode`     | How `autoCompactionRetention` is interpreted. Either `periodic` or `revision`.                                       |
+| `autoCompactionRetention` | `--auto-compaction-retention`| A duration (e.g. `"1h"`) when the mode is `periodic`, a revision count (e.g. `"1000"`) when the mode is `revision`.   |
+| `snapshotCount`           | `--snapshot-count`           | Number of committed transactions that trigger a snapshot to disk.                                                    |
+
+> **`configuration.applyConfig` and `configuration.configSecret` are not supported for etcd.** etcd's `--config-file` is mutually exclusive with the individual command line flags that KubeDB must set to bootstrap and reconcile cluster membership, so a free-form config file would silently break cluster management. The `Reconfigure` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) webhook rejects both fields. The top-level `spec.configSecret` field exists only for structural parity with the other KubeDB databases and should not be used.
+
+Because etcd has no live-reload path for these flags, applying a new `tuning` block always requires a restart of the members. The `Reconfigure` OpsRequest does that for you with a leader-aware rolling restart.
+
+### spec.tls
+
+`spec.tls` specifies the TLS/SSL configuration. The KubeDB operator supports TLS management by using [cert-manager](https://cert-manager.io/). When `spec.tls` is set, `spec.tls.issuerRef` is required.
+
+```yaml
+spec:
+  tls:
+    issuerRef:
+      apiGroup: "cert-manager.io"
+      kind: Issuer
+      name: etcd-issuer
+    certificates:
+      - alias: server
+        privateKey:
+          encoding: PKCS8
+        secretName: etcd-server-cert
+        subject:
+          organizations:
+            - kubedb
+      - alias: client
+        secretName: etcd-client-cert
+      - alias: peer
+        secretName: etcd-peer-cert
+      - alias: metrics-exporter
+        secretName: etcd-metrics-exporter-cert
+```
+
+The `spec.tls` contains the following fields:
+
+- `tls.issuerRef` - references the `Issuer` or `ClusterIssuer` custom resource object of [cert-manager](https://cert-manager.io/docs/concepts/issuer/). It is used to generate the necessary certificate secrets for etcd.
+  - `apiGroup` - is the group name of the resource that is being referenced. Currently, the only supported value is `cert-manager.io`.
+  - `kind` - is the type of resource that is being referenced. The supported values are `Issuer` and `ClusterIssuer`.
+  - `name` - is the name of the resource ( `Issuer` or `ClusterIssuer` ) that is being referenced.
+
+- `tls.certificates` - is an `optional` field that specifies a list of certificate configurations. It has the following fields:
+  - `alias` - represents the identifier of the certificate. etcd supports the following aliases:
+    - `server` - served by each member on the client (gRPC/HTTP) API port.
+    - `client` - used by KubeDB itself (health checker, ops-manager, metrics scraping) to talk to etcd.
+    - `peer` - used for member-to-member Raft traffic. Peer traffic is **always mutually authenticated** once TLS is enabled; there is no server-only mode for peers.
+    - `metrics-exporter` - used to serve the metrics endpoint over TLS.
+
+  - `secretName` - ( `string` | `"<database-name>-<alias>-cert"` ) - specifies the k8s secret name that holds the certificates.
+
+  - `subject` - specifies an `X.509` distinguished name (DN). It has the following configurable fields:
+    - `organizations` ( `[]string` | `nil` ) - is a list of organization names.
+    - `organizationalUnits` ( `[]string` | `nil` ) - is a list of organization unit names.
+    - `countries` ( `[]string` | `nil` ) -  is a list of country names (ie. Country Codes).
+    - `localities` ( `[]string` | `nil` ) - is a list of locality names.
+    - `provinces` ( `[]string` | `nil` ) - is a list of province names.
+    - `streetAddresses` ( `[]string` | `nil` ) - is a list of street addresses.
+    - `postalCodes` ( `[]string` | `nil` ) - is a list of postal codes.
+    - `serialNumber` ( `string` | `""` ) is a serial number.
+
+    For more details, visit [here](https://golang.org/pkg/crypto/x509/pkix/#Name).
+
+  - `duration` ( `string` | `""` ) - is the period during which the certificate is valid.
+  - `renewBefore` ( `string` | `""` ) - is a specifiable time before expiration duration.
+  - `dnsNames` ( `[]string` | `nil` ) - is a list of subject alt names.
+  - `ipAddresses` ( `[]string` | `nil` ) - is a list of IP addresses.
+  - `uris` ( `[]string` | `nil` ) - is a list of URI Subject Alternative Names.
+  - `emailAddresses` ( `[]string` | `nil` ) - is a list of email Subject Alternative Names.
+
+Enabling TLS switches the scheme of every advertised client and peer URL from `http` to `https`, so it is applied with a rolling restart. Use the `ReconfigureTLS` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) to add, rotate or remove TLS on a running cluster.
+
+### spec.podTemplate
+
+KubeDB allows providing a template for the database pod through `spec.podTemplate`. The KubeDB operator will pass the information provided in `spec.podTemplate` to the PetSet created for the etcd cluster.
+
+KubeDB accepts the following fields to set in `spec.podTemplate`:
+
+- metadata:
+  - annotations (pod's annotation)
+  - labels (pod's labels)
+- controller:
+  - annotations (petset's annotation)
+  - labels (petset's labels)
+- spec:
+  - containers
+  - initContainers
+  - args
+  - env
+  - resources
+  - imagePullSecrets
+  - nodeSelector
+  - serviceAccountName
+  - schedulerName
+  - tolerations
+  - priorityClassName
+  - podPlacementPolicy
+  - priority
+  - securityContext
+
+You can check out the full list [here](https://github.com/kmodules/offshoot-api/blob/master/api/v2/types.go).
+
+The etcd pod runs a main container named **`etcd`** and an init container named **`etcd-init`**; use those names when overriding container level settings such as `resources`.
+
+Uses of some fields of `spec.podTemplate` are described below.
+
+#### spec.podTemplate.spec.containers[].resources
+
+`resources` on the `etcd` container can be used to request compute resources required by the database pods. To learn more, visit [here](http://kubernetes.io/docs/user-guide/compute-resources/).
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+```
+
+#### spec.podTemplate.spec.env
+
+`spec.podTemplate.spec.env` is an optional field that specifies the environment variables to pass to the etcd docker image.
+
+> The cluster bootstrap variables (`ETCD_NAME`, `ETCD_INITIAL_CLUSTER`, `ETCD_INITIAL_CLUSTER_STATE`, `ETCD_INITIAL_ADVERTISE_PEER_URLS`, and the listen/advertise URL variables) are computed by the operator and re-projected on every membership change. Do not override them.
+
+#### spec.podTemplate.spec.imagePullSecret
+
+`KubeDB` provides the flexibility of deploying etcd from a private Docker registry.
+
+#### spec.podTemplate.spec.podPlacementPolicy
+
+`spec.podTemplate.spec.podPlacementPolicy` is an optional field. This can be used to provide the reference of the `podPlacementPolicy`. `name` of the podPlacementPolicy is referred under this attribute. This will be used by our PetSet controller to place the db pods throughout the region, zone & nodes according to the policy. It utilizes the Kubernetes affinity & podTopologySpreadConstraints features to do so.
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      podPlacementPolicy:
+        name: default
+```
+
+Spreading etcd members across failure domains is particularly valuable, since quorum survives only a minority of members failing at once.
+
+#### spec.podTemplate.spec.nodeSelector
+
+`spec.podTemplate.spec.nodeSelector` is an optional field that specifies a map of key-value pairs. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels (it can have additional labels as well). To learn more, see [here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector).
+
+#### spec.podTemplate.spec.serviceAccountName
+
+`serviceAccountName` is an optional field that can be used to specify a custom service account to fine tune role based access control.
+
+If this field is left empty, the KubeDB operator will create a service account whose name matches the Etcd crd name. Role and RoleBinding that provide the necessary access permissions will also be generated automatically for this service account.
+
+If a service account name is given, but there's no existing service account by that name, the KubeDB operator will create one, and Role and RoleBinding that provide the necessary access permissions will also be generated for this service account.
+
+If a service account name is given, and there's an existing service account by that name, the KubeDB operator will use that existing service account. Since this service account is not managed by KubeDB, users are responsible for providing the necessary access permissions manually.
+
+### spec.serviceTemplates
+
+You can also provide a template for the services created by the KubeDB operator for etcd through `spec.serviceTemplates`. This will allow you to set the type and other properties of the services.
+
+KubeDB allows the following fields to be set in `spec.serviceTemplates`:
+
+- `alias` represents the identifier of the service. For etcd it has the following possible values:
+  - `primary` — the load balanced client Service (`<db-name>`) on port `2379`. Because every etcd member serves the client API and forwards writes to the Raft leader, one Service over all members is correct — there is no separate `standby` service for etcd.
+  - `stats` — the metrics Service used by Prometheus.
+
+- metadata:
+  - annotations
+  - labels
+- spec:
+  - type
+  - ports
+  - clusterIP
+  - externalIPs
+  - loadBalancerIP
+  - loadBalancerSourceRanges
+  - externalTrafficPolicy
+  - healthCheckNodePort
+  - sessionAffinityConfig
+
+See [here](https://github.com/kmodules/offshoot-api/blob/kubernetes-1.16.3/api/v1/types.go#L163) to understand these fields in detail.
+
+Besides these, the operator always creates a headless *governing* Service named `<db-name>-pods`, which publishes not-ready addresses and exposes both the client port `2379` and the peer port `2380`. The stable per-member DNS names derived from it (`<db-name>-0.<db-name>-pods.<namespace>.svc.<cluster-domain>`) are what etcd uses as its peer and client URLs. A learner has to be reachable by its peers *before* it becomes ready, which is why not-ready addresses are published.
+
+### spec.archiver
+
+`spec.archiver` opts the cluster into a scheduled snapshot backup driven by an [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md) policy object.
+
+```yaml
+spec:
+  archiver:
+    pause: false
+    ref:
+      name: etcd-archiver
+      namespace: demo
+```
+
+- `spec.archiver.ref` is the name/namespace reference to the `EtcdArchiver` object.
+- `spec.archiver.pause` temporarily stops the archiver-driven backup for this database.
+
+### spec.deletionPolicy
+
+`deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of the `Etcd` crd or which resources KubeDB should keep or delete when you delete the `Etcd` crd. KubeDB provides the following four deletion policies:
+
+- DoNotTerminate
+- Halt
+- Delete (`Default`)
+- WipeOut
+
+When `deletionPolicy` is `DoNotTerminate`, KubeDB takes advantage of the `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement the `DoNotTerminate` feature. If the admission webhook is enabled, `DoNotTerminate` prevents users from deleting the database as long as `spec.deletionPolicy` is set to `DoNotTerminate`.
+
+The following table shows what KubeDB does when you delete an Etcd crd for different deletion policies,
+
+| Behavior                            | DoNotTerminate |   Halt   |  Delete  | WipeOut  |
+|-------------------------------------|:--------------:|:--------:|:--------:|:--------:|
+| 1. Block Delete operation           |    &#10003;    | &#10007; | &#10007; | &#10007; |
+| 2. Delete PetSet                    |    &#10007;    | &#10003; | &#10003; | &#10003; |
+| 3. Delete Services                  |    &#10007;    | &#10003; | &#10003; | &#10003; |
+| 4. Delete PVCs                      |    &#10007;    | &#10007; | &#10003; | &#10003; |
+| 5. Delete Secrets                   |    &#10007;    | &#10007; | &#10007; | &#10003; |
+| 6. Delete Snapshots                 |    &#10007;    | &#10007; | &#10007; | &#10003; |
+| 7. Delete Snapshot data from bucket |    &#10007;    | &#10007; | &#10007; | &#10003; |
+
+If you don't specify `spec.deletionPolicy`, KubeDB uses the `Delete` deletion policy by default.
+
+> For more details you can visit [here](https://appscode.com/blog/post/deletion-policy/)
+
+### spec.halted
+
+Indicates that the database is halted and all offshoot Kubernetes resources except PVCs are deleted.
+
+### spec.healthChecker
+
+It defines the attributes for the health checker.
+
+- `spec.healthChecker.periodSeconds` specifies how often to perform the health check. Defaults to `10`.
+- `spec.healthChecker.timeoutSeconds` specifies the number of seconds after which the probe times out. Defaults to `10`.
+- `spec.healthChecker.failureThreshold` specifies the minimum consecutive failures for the healthChecker to be considered failed. Defaults to `1`.
+- `spec.healthChecker.disableWriteCheck` specifies whether to disable the write check or not.
+
+For etcd, the health checker dials the client port of every member and uses etcd's own `Status()` and `MemberList()` RPCs. The cluster is considered quorum-healthy while at least `N/2+1` members respond. etcd is a key-value store, not a relational database, so there is no query-language based health probe.
+
+Know details about KubeDB health checking from this [blog post](https://appscode.com/blog/post/kubedb-health-checker/).
+
+## Etcd Status
+
+`.status` describes the observed state of the `Etcd` object. It has the following fields.
+
+### status.phase
+
+`status.phase` is the overall phase of the database, derived from the conditions below:
+
+| Phase           | Meaning                                                                                     |
+|-----------------|-----------------------------------------------------------------------------------------------|
+| `Provisioning`  | Offshoot resources are being created.                                                          |
+| `DataRestoring` | The seed member's volume is being restored from a snapshot before the cluster is bootstrapped. |
+| `Ready`         | All members are ready, quorum is healthy and the client endpoint accepts connections.          |
+| `Critical`      | The client endpoint is reachable, but not every member is ready.                               |
+| `NotReady`      | The client endpoint is not reachable.                                                          |
+| `Halted`        | `spec.halted` is `true`.                                                                       |
+| `Unknown`       | The phase could not be computed.                                                               |
+
+### status.observedGeneration
+
+`status.observedGeneration` shows the most recent generation of the `Etcd` object observed by the KubeDB operator.
+
+### status.conditions
+
+`status.conditions` is an array describing the state of individual steps of provisioning and of the running cluster. Each entry carries a `type`, a `status` (`True` / `False` / `Unknown`), a `reason`, a human readable `message`, a `lastTransitionTime` and an `observedGeneration`.
+
+| Type                  | Meaning                                                                    |
+|-----------------------|-----------------------------------------------------------------------------|
+| `ProvisioningStarted` | The operator has accepted the object and started creating its offshoots.    |
+| `ReplicaReady`        | All etcd member pods are ready.                                             |
+| `AcceptingConnection` | The client endpoint is accepting connection requests.                       |
+| `Ready`               | The readiness check (quorum health) succeeded.                              |
+| `Provisioned`         | The cluster has been successfully provisioned.                              |
+| `DataRestored`        | The bootstrap restore from a snapshot completed.                            |
+
+### status.authSecret
+
+`status.authSecret` records the age of the credential currently referenced by `spec.authSecret`. Together with `spec.authSecret.rotateAfter`, this is what lets the Recommendation Engine propose a `RotateAuth` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) when the credential gets old.
+
+## Next Steps
+
+- Learn how to use KubeDB to run an etcd cluster [here](/docs/guides/etcd/README.md).
+- Deploy your first etcd cluster with KubeDB by following the guide [here](/docs/guides/etcd/quickstart/quickstart.md).
+- Detail concepts of [EtcdVersion object](/docs/guides/etcd/concepts/etcdversion.md).
+- Detail concepts of [EtcdOpsRequest object](/docs/guides/etcd/concepts/etcdopsrequest.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -227,7 +227,9 @@ spec:
       recoveryTimestamp: "2024-05-02T10:02:45Z"
 ```
 
-Restore is only possible **at bootstrap time**. etcd requires a seed member's data directory to be either genuinely empty or a fully restored, valid snapshot — a snapshot can never be restored into a running cluster. So the operator pre-creates the ordinal-0 PVC, runs the `RestoreSession` against it, and only then creates the PetSet and starts the first member. While that happens, `status.phase` is `DataRestoring`.
+`spec.init.archiver` restores **at bootstrap time**, into a brand new cluster. etcd requires a seed member's data directory to be either genuinely empty or a fully restored, valid snapshot, so a snapshot can never be replayed into a *running* cluster. The operator therefore pre-creates the ordinal-0 PVC, runs the `RestoreSession` against it, and only then creates the PetSet and starts the first member. While that happens, `status.phase` stays `Provisioning`, and the restore's outcome is reported on the `SuccessfullyDataRestored` condition.
+
+> To restore into an `Etcd` object that already exists, use an `EtcdOpsRequest` of type `Restore`. It obeys the same rule rather than breaking it: the cluster is taken apart down to a single empty volume first, the snapshot is replayed into that, and the remaining members rejoin as new members. See [In-place Restore](/docs/guides/etcd/restore/overview.md).
 
 ### spec.monitor
 
@@ -312,7 +314,7 @@ The `spec.tls` contains the following fields:
     - `server` - served by each member on the client (gRPC/HTTP) API port.
     - `client` - used by KubeDB itself (health checker, ops-manager, metrics scraping) to talk to etcd.
     - `peer` - used for member-to-member Raft traffic. Peer traffic is **always mutually authenticated** once TLS is enabled; there is no server-only mode for peers.
-    - `metrics-exporter` - used to serve the metrics endpoint over TLS.
+    - `metrics-exporter` - accepted by the schema, but **inert**. etcd's `--listen-metrics-urls` has no TLS flags of its own, so KubeDB keeps the metrics listener on plain HTTP and never issues or mounts a certificate for this alias. Enabling `spec.tls` does not encrypt the metrics endpoint.
 
   - `secretName` - ( `string` | `"<database-name>-<alias>-cert"` ) - specifies the k8s secret name that holds the certificates.
 
@@ -352,9 +354,7 @@ KubeDB accepts the following fields to set in `spec.podTemplate`:
 - spec:
   - containers
   - initContainers
-  - args
-  - env
-  - resources
+  - volumes
   - imagePullSecrets
   - nodeSelector
   - serviceAccountName
@@ -365,9 +365,11 @@ KubeDB accepts the following fields to set in `spec.podTemplate`:
   - priority
   - securityContext
 
+> `args`, `env` and `resources` are **container**-level fields, not pod-level ones. Set them on the entry in `spec.podTemplate.spec.containers` whose `name` is `etcd`, as shown below.
+
 You can check out the full list [here](https://github.com/kmodules/offshoot-api/blob/master/api/v2/types.go).
 
-The etcd pod runs a main container named **`etcd`** and an init container named **`etcd-init`**; use those names when overriding container level settings such as `resources`.
+The etcd pod runs a single operator-managed container, named **`etcd`**; use that name when overriding container level settings such as `resources` or `args`. KubeDB adds no init container of its own — anything you put in `spec.podTemplate.spec.initContainers` is yours and is passed through as-is.
 
 Uses of some fields of `spec.podTemplate` are described below.
 
@@ -391,7 +393,7 @@ spec:
 
 #### spec.podTemplate.spec.containers[].args
 
-`args` on the `etcd` container is an optional list of extra etcd command-line flags. It is the escape hatch for the etcd settings `spec.configuration.tuning` does not expose. Set it on the container entry named `etcd` — the pod-level `spec.podTemplate.spec.args` is not read for etcd:
+`args` on the `etcd` container is an optional list of extra etcd command-line flags. It is the escape hatch for the etcd settings `spec.configuration.tuning` does not expose. It has to go on the container entry named `etcd` — there is no pod-level `args` field:
 
 ```yaml
 spec:
@@ -406,15 +408,26 @@ spec:
 
 These flags are appended **after** the ones the operator renders. etcd parses its command line with Go's standard `flag` package, where a repeated flag is not an error and the last occurrence wins — so a flag you set here also overrides one the operator set. That makes it powerful and sharp: overriding the flags that carry a member's identity, its listeners or its TLS material detaches the member from the cluster KubeDB is reconciling, and `--force-new-cluster` in particular would rewrite the data directory into a fresh single-member cluster on every restart. See [Extra etcd flags](/docs/guides/etcd/custom-configuration/using-config.md#extra-etcd-flags).
 
-#### spec.podTemplate.spec.env
+#### spec.podTemplate.spec.containers[].env
 
-`spec.podTemplate.spec.env` is an optional field that specifies the environment variables to pass to the etcd docker image.
+`env` on the `etcd` container is an optional list of environment variables to pass to the etcd image. Like `args` and `resources`, it is a container-level field — there is no pod-level `spec.podTemplate.spec.env`:
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          env:
+            - name: ETCD_LOG_LEVEL
+              value: debug
+```
 
 > The cluster bootstrap variables (`ETCD_NAME`, `ETCD_INITIAL_CLUSTER`, `ETCD_INITIAL_CLUSTER_STATE`, `ETCD_INITIAL_ADVERTISE_PEER_URLS`, and the listen/advertise URL variables) are computed by the operator and re-projected on every membership change. Do not override them.
 
-#### spec.podTemplate.spec.imagePullSecret
+#### spec.podTemplate.spec.imagePullSecrets
 
-`KubeDB` provides the flexibility of deploying etcd from a private Docker registry.
+`KubeDB` provides the flexibility of deploying etcd from a private Docker registry. `spec.podTemplate.spec.imagePullSecrets` is a list of references to Secrets in the same namespace that hold the registry credentials.
 
 #### spec.podTemplate.spec.podPlacementPolicy
 
@@ -543,7 +556,6 @@ Know details about KubeDB health checking from this [blog post](https://appscode
 | Phase           | Meaning                                                                                     |
 |-----------------|-----------------------------------------------------------------------------------------------|
 | `Provisioning`  | Offshoot resources are being created.                                                          |
-| `DataRestoring` | The seed member's volume is being restored from a snapshot before the cluster is bootstrapped. |
 | `Ready`         | All members are ready, quorum is healthy and the client endpoint accepts connections.          |
 | `Critical`      | The client endpoint is reachable, but not every member is ready.                               |
 | `NotReady`      | The client endpoint is not reachable.                                                          |
@@ -565,7 +577,7 @@ Know details about KubeDB health checking from this [blog post](https://appscode
 | `AcceptingConnection` | The client endpoint is accepting connection requests.                       |
 | `Ready`               | The readiness check (quorum health) succeeded.                              |
 | `Provisioned`         | The cluster has been successfully provisioned.                              |
-| `DataRestored`        | The bootstrap restore from a snapshot completed.                            |
+| `SuccessfullyDataRestored` | The restore from a snapshot completed (bootstrap or in-place).          |
 
 ### status.authSecret
 

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -312,7 +312,7 @@ The `spec.tls` contains the following fields:
 - `tls.certificates` - is an `optional` field that specifies a list of certificate configurations. It has the following fields:
   - `alias` - represents the identifier of the certificate. etcd supports the following aliases:
     - `server` - served by each member on the client (gRPC/HTTP) API port.
-    - `client` - used by KubeDB itself (health checker, ops-manager, metrics scraping) to talk to etcd.
+    - `client` - used by KubeDB itself (health checker, ops-manager) to talk to etcd.
     - `peer` - used for member-to-member Raft traffic. Peer traffic is **always mutually authenticated** once TLS is enabled; there is no server-only mode for peers.
     - `metrics-exporter` - accepted by the schema, but **inert**. etcd's `--listen-metrics-urls` has no TLS flags of its own, so KubeDB keeps the metrics listener on plain HTTP and never issues or mounts a certificate for this alias. Enabling `spec.tls` does not encrypt the metrics endpoint.
 
@@ -369,7 +369,7 @@ KubeDB accepts the following fields to set in `spec.podTemplate`:
 
 You can check out the full list [here](https://github.com/kmodules/offshoot-api/blob/master/api/v2/types.go).
 
-The etcd pod runs a single operator-managed container, named **`etcd`**; use that name when overriding container level settings such as `resources` or `args`. KubeDB adds no init container of its own — anything you put in `spec.podTemplate.spec.initContainers` is yours and is passed through as-is.
+The etcd pod runs a single operator-managed container, named **`etcd`**; use that name when overriding container-level settings such as `resources` or `args`. KubeDB adds no init container of its own — anything you put in `spec.podTemplate.spec.initContainers` is yours and is passed through as-is.
 
 Uses of some fields of `spec.podTemplate` are described below.
 

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -134,7 +134,7 @@ KubeDB uses a `PodDisruptionBudget` so that a majority of members stays availabl
 Changing `spec.replicas` (directly, or through a `HorizontalScaling`
 [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)) is reconciled against etcd's actual member list:
 
-- **Scale up** — the next ordinal is first added to the cluster as a **learner**. A learner replicates the log but does not vote and does not count toward quorum, so a cold member can never stall the cluster. Once its Raft revision has caught up with the leader's, the operator **promotes** it to a voting member.
+- **Scale up** — the next ordinal is first added to the cluster as a **learner**. A learner replicates the log but does not vote and does not count toward quorum, so a cold member can never stall the cluster. Once its applied revision reaches 90% of the leader's — not full equality — the operator **promotes** it to a voting member.
 - **Scale down** — the **highest ordinal** member is removed from etcd's member list first, and only then is the PetSet shrunk, so etcd never sees the pod disappear before it has been un-registered.
 
 The operator performs at most one membership mutation per reconcile pass, which is what etcd's membership API expects.
@@ -190,14 +190,14 @@ Example:
 $ kubectl create secret generic etcd-auth -n demo \
   --type=kubernetes.io/basic-auth \
   --from-literal=username=root \
-  --from-literal=password=6q8u_2jMOW-OOZXk
+  --from-literal=password=not@secret
 secret "etcd-auth" created
 ```
 
 ```yaml
 apiVersion: v1
 data:
-  password: NnE4dV8yak1PVy1PT1pYaw==
+  password: bm90QHNlY3JldA==
   username: cm9vdA==
 kind: Secret
 metadata:
@@ -205,6 +205,9 @@ metadata:
   namespace: demo
 type: kubernetes.io/basic-auth
 ```
+
+> Use a real, unique password of your own when you actually create this secret — the value above is
+> a placeholder for the example, not something to reuse.
 
 Secrets provided by users are not managed by KubeDB, and therefore won't be modified or garbage collected by the KubeDB operator.
 

--- a/docs/guides/etcd/concepts/etcdarchiver.md
+++ b/docs/guides/etcd/concepts/etcdarchiver.md
@@ -1,0 +1,177 @@
+---
+title: EtcdArchiver CRD
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-archiver-concepts
+    name: EtcdArchiver
+    parent: etcd-concepts-etcd
+    weight: 35
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# EtcdArchiver
+
+## What is EtcdArchiver
+
+`EtcdArchiver` is a Kubernetes `Custom Resource Definitions` (CRD). It is a **policy object**: it describes, once, how the etcd clusters that opt into it should be backed up — where the snapshots go, on what schedule, with what retention and encryption — so that individual [Etcd](/docs/guides/etcd/concepts/etcd.md) objects only have to point at it.
+
+When an `Etcd` object references an `EtcdArchiver` through `spec.archiver.ref` (and the archiver's own `spec.databases` selector allows that namespace), the KubeDB provisioner builds a [KubeStash](https://kubestash.com/) `BackupConfiguration` for it.
+
+## Snapshot-only: no PITR
+
+This is the most important thing to know about `EtcdArchiver`, and it is a deliberate scope decision rather than a missing feature.
+
+Databases like Postgres have a continuous, shippable write-ahead log, which is what lets KubeDB offer point-in-time recovery: take a base backup, then replay the log up to any chosen instant. **etcd has no equivalent primitive that can be streamed out of the cluster.** Its Raft log is an internal replication mechanism, not an archivable, restorable log stream.
+
+Consequently:
+
+- `EtcdArchiver.spec` has **no `logBackup` section** — unlike `PostgresArchiver` or `MSSQLServerArchiver`.
+- There is **no point-in-time recovery** between two snapshots. Recovery lands you exactly on the snapshot you restore, and everything written after it is lost.
+- Your recovery point objective is therefore your snapshot interval. Choose `fullBackup.scheduler.schedule` accordingly.
+
+Also note that a snapshot can only be restored **at bootstrap time**, into a brand new cluster. etcd requires a seed member's data directory to be either genuinely empty or a fully restored, valid snapshot; a snapshot can never be restored into a running cluster. See [spec.init](/docs/guides/etcd/concepts/etcd.md#specinit).
+
+## EtcdArchiver CRD Specifications
+
+Like any official Kubernetes resource, an `EtcdArchiver` has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+```yaml
+apiVersion: archiver.kubedb.com/v1alpha1
+kind: EtcdArchiver
+metadata:
+  name: etcd-archiver
+  namespace: demo
+spec:
+  pause: false
+  databases:
+    namespaces:
+      from: Selector
+      selector:
+        matchLabels:
+          kubernetes.io/metadata.name: demo
+    selector:
+      matchLabels:
+        archiver: etcd
+  fullBackup:
+    driver: Restic
+    scheduler:
+      successfulJobsHistoryLimit: 1
+      failedJobsHistoryLimit: 1
+      schedule: "0 */2 * * *"
+    sessionHistoryLimit: 3
+  manifestBackup:
+    scheduler:
+      successfulJobsHistoryLimit: 1
+      failedJobsHistoryLimit: 1
+      schedule: "0 */2 * * *"
+    sessionHistoryLimit: 3
+  backupStorage:
+    ref:
+      name: s3-storage
+      namespace: demo
+  retentionPolicy:
+    name: keep-1mo
+    namespace: demo
+  encryptionSecret:
+    name: encrypt-secret
+    namespace: demo
+  deletionPolicy: WipeOut
+```
+
+Here, we are going to describe the various sections of an `EtcdArchiver` crd.
+
+### spec.databases
+
+`spec.databases` is a required field that defines which `Etcd` objects are allowed to consume this archiver. It is a double opt-in: the `Etcd` object has to reference the archiver in `spec.archiver.ref`, **and** the archiver has to allow the database's namespace here.
+
+- `namespaces.from` can be `Same` (only this namespace), `All`, or `Selector`.
+- `namespaces.selector` is the label selector applied to namespaces when `from` is `Selector`.
+- `selector` further restricts which `Etcd` objects inside those namespaces may use this archiver.
+
+### spec.pause
+
+`spec.pause` is an optional boolean. When set to `true`, the backup driven by this archiver is stopped for every database that consumes it. To pause the backup of just one database, set `spec.archiver.pause` on that `Etcd` object instead.
+
+### spec.fullBackup
+
+`spec.fullBackup` defines the session configuration of the full snapshot backup. Its options end up on the generated KubeStash `BackupConfiguration`'s `full` session.
+
+- `driver` is the KubeStash driver. For etcd this is the `Restic` driver: the backup task streams a live etcd snapshot out of the cluster and uploads it to the backend, rather than taking a volume snapshot.
+- `scheduler.schedule` is the cron expression for the snapshot. Because there is no PITR, this interval **is** your recovery point objective.
+- `scheduler.concurrencyPolicy`, `scheduler.jobTemplate`, `containerRuntimeSettings`, `jobTemplate`, `retryConfig`, `timeout` and `sessionHistoryLimit` follow the usual KubeStash semantics.
+
+The full backup runs the `etcd-backup` addon task. It takes a snapshot through etcd's client API — the same operation as `etcdctl snapshot save` — so it is served by a live member and does not require access to any member's data directory.
+
+### spec.manifestBackup
+
+`spec.manifestBackup` defines the session configuration of the manifest backup — the Kubernetes-object-level backup of the `Etcd` CR and its companion objects (Secrets, etc.). It runs the same cross-database `manifest-backup` task every KubeDB database uses, unchanged.
+
+### spec.backupStorage
+
+`spec.backupStorage` is the backend where the snapshots are written.
+
+- `ref` is the name/namespace reference of the KubeStash `BackupStorage` object.
+- `subDir` optionally scopes this archiver's repositories to a sub-directory of that storage.
+
+### spec.retentionPolicy
+
+`spec.retentionPolicy` is a name/namespace reference to a KubeStash `RetentionPolicy` object, which decides how many snapshots are kept in the repository.
+
+### spec.encryptionSecret
+
+`spec.encryptionSecret` is a name/namespace reference to the Secret holding the Restic encryption key used for the repository. Keep this Secret safe and backed up separately — without it the snapshots cannot be restored.
+
+### spec.deletionPolicy
+
+`spec.deletionPolicy` is the `deletionPolicy` applied to the repositories created by this archiver, and follows KubeStash's `BackupConfigDeletionPolicy` semantics (for example `Delete` or `WipeOut`).
+
+## EtcdArchiver `Status`
+
+### status.databaseRefs
+
+`status.databaseRefs` lists the `Etcd` objects currently managed by this archiver, so you can see at a glance which databases a policy is actually covering.
+
+## Restoring
+
+Restore is driven from the `Etcd` object being created, not from the archiver:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-restored
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  init:
+    archiver:
+      encryptionSecret:
+        name: encrypt-secret
+        namespace: demo
+      fullDBRepository:
+        name: etcd-full-repo
+        namespace: demo
+      recoveryTimestamp: "2026-01-14T09:41:52Z"
+  deletionPolicy: WipeOut
+```
+
+When `spec.init.archiver.fullDBRepository` is set, the provisioner pre-creates the ordinal-0 PVC, runs a KubeStash `RestoreSession` against it *before* the PetSet or the first pod is ever created, and only then bootstraps the cluster from the restored data directory. The remaining members join the restored seed as ordinary new members. A `manifest-restore` session runs alongside for Kubernetes-object-level restore.
+
+## Next Steps
+
+- Learn about the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd.
+- Follow the [etcd backup & restore guide](/docs/guides/etcd/backup/kubestash/overview/index.md) for an end-to-end walkthrough.
+- Learn more about [KubeStash](https://kubestash.com/).

--- a/docs/guides/etcd/concepts/etcdarchiver.md
+++ b/docs/guides/etcd/concepts/etcdarchiver.md
@@ -34,7 +34,7 @@ Consequently:
 - There is **no point-in-time recovery** between two snapshots. Recovery lands you exactly on the snapshot you restore, and everything written after it is lost.
 - Your recovery point objective is therefore your snapshot interval. Choose `fullBackup.scheduler.schedule` accordingly.
 
-Also note that a snapshot can only be restored **at bootstrap time**, into a brand new cluster. etcd requires a seed member's data directory to be either genuinely empty or a fully restored, valid snapshot; a snapshot can never be restored into a running cluster. See [spec.init](/docs/guides/etcd/concepts/etcd.md#specinit).
+Also note that a snapshot is always replayed into an **empty** data directory: etcd requires a seed member's data directory to be either genuinely empty or a fully restored, valid snapshot, so it can never be replayed into a running member. There are two ways to get there — restore at bootstrap through [spec.init](/docs/guides/etcd/concepts/etcd.md#specinit), or an `EtcdOpsRequest` of type `Restore`, which tears an existing cluster down to one empty volume first. See [In-place Restore](/docs/guides/etcd/restore/overview.md).
 
 ## EtcdArchiver CRD Specifications
 
@@ -168,7 +168,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 
-When `spec.init.archiver.fullDBRepository` is set, the provisioner pre-creates the ordinal-0 PVC, runs a KubeStash `RestoreSession` against it *before* the PetSet or the first pod is ever created, and only then bootstraps the cluster from the restored data directory. The remaining members join the restored seed as ordinary new members. A `manifest-restore` session runs alongside for Kubernetes-object-level restore.
+When `spec.init.archiver.fullDBRepository` is set, the provisioner pre-creates the ordinal-0 PVC, runs a KubeStash `RestoreSession` against it *before* the PetSet or the first pod is ever created, and only then bootstraps the cluster from the restored data directory. The remaining members join the restored seed as ordinary new members. A separate `manifest-restore` session for Kubernetes-object-level restore runs only if you also set `spec.init.archiver.manifestRepository`; setting `fullDBRepository` alone does not trigger one.
 
 To restore a snapshot into an `Etcd` object that **already exists**, use an `EtcdOpsRequest` of type `Restore` instead — it replaces the whole keyspace of the live database. See [In-place Restore](/docs/guides/etcd/restore/overview.md).
 

--- a/docs/guides/etcd/concepts/etcdarchiver.md
+++ b/docs/guides/etcd/concepts/etcdarchiver.md
@@ -170,6 +170,8 @@ spec:
 
 When `spec.init.archiver.fullDBRepository` is set, the provisioner pre-creates the ordinal-0 PVC, runs a KubeStash `RestoreSession` against it *before* the PetSet or the first pod is ever created, and only then bootstraps the cluster from the restored data directory. The remaining members join the restored seed as ordinary new members. A `manifest-restore` session runs alongside for Kubernetes-object-level restore.
 
+To restore a snapshot into an `Etcd` object that **already exists**, use an `EtcdOpsRequest` of type `Restore` instead — it replaces the whole keyspace of the live database. See [In-place Restore](/docs/guides/etcd/restore/overview.md).
+
 ## Next Steps
 
 - Learn about the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd.

--- a/docs/guides/etcd/concepts/etcdautoscaler.md
+++ b/docs/guides/etcd/concepts/etcdautoscaler.md
@@ -1,0 +1,125 @@
+---
+title: EtcdAutoscaler CRD
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-autoscaler-concepts
+    name: EtcdAutoscaler
+    parent: etcd-concepts-etcd
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# EtcdAutoscaler
+
+## What is EtcdAutoscaler
+
+`EtcdAutoscaler` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration for autoscaling the compute resources and the storage of a KubeDB managed [etcd](https://etcd.io/) cluster in a Kubernetes native way.
+
+An `EtcdAutoscaler` never mutates the `Etcd` object directly. It watches the resource usage of the members, computes a recommendation, and when that recommendation differs enough from the current setting it creates an [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) — a `VerticalScaling` one for compute, a `VolumeExpansion` one for storage — which then goes through the normal, quorum-aware ops-manager flow.
+
+> `EtcdAutoscaler` scales members **vertically** (bigger members) and grows their **volumes**. It does not change the number of etcd members: quorum size is a deliberate design decision for a consensus cluster, not something to be adjusted automatically off a usage metric.
+
+## EtcdAutoscaler CRD Specifications
+
+Like any official Kubernetes resource, an `EtcdAutoscaler` has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+**Sample `EtcdAutoscaler` for an etcd cluster:**
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: EtcdAutoscaler
+metadata:
+  name: etcd-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-quickstart
+  opsRequestOptions:
+    timeout: 5m
+    apply: IfReady
+  compute:
+    etcd:
+      trigger: "On"
+      podLifeTimeThreshold: 5m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 400m
+        memory: 1Gi
+      maxAllowed:
+        cpu: 2
+        memory: 4Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"
+  storage:
+    etcd:
+      trigger: "On"
+      usageThreshold: 60
+      scalingThreshold: 50
+      expansionMode: "Online"
+      upperBound: 100Gi
+```
+
+Here, we are going to describe the various sections of an `EtcdAutoscaler` crd.
+
+An `EtcdAutoscaler` object has the following fields in the `spec` section.
+
+### spec.databaseRef
+
+`spec.databaseRef` is a required field that points to the [Etcd](/docs/guides/etcd/concepts/etcd.md) object for which the autoscaling will be performed. This field consists of the following sub-field:
+
+- **spec.databaseRef.name :** specifies the name of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+
+### spec.opsRequestOptions
+
+These are the options passed into the internally created [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md). It has the following fields:
+
+- `timeout` specifies the timeout for each step of the generated ops request.
+- `apply` controls whether the generated ops request runs only when the database is Ready (`IfReady`, the default) or regardless of the database state (`Always`).
+- `maxRetries` is the number of times a failed generated ops request is retried. Defaults to `1`.
+
+### spec.compute
+
+`spec.compute` specifies the autoscaling configuration for the compute resources, i.e. cpu and memory, of the etcd members. This field consists of the following sub-fields:
+
+- `spec.compute.etcd` indicates the desired compute autoscaling configuration for the `etcd` container.
+- `spec.compute.nodeTopology` optionally references a `NodeTopology` object so the recommender can take the shape of the node pool into account when deciding whether to scale up.
+
+`spec.compute.etcd` has the following sub-fields:
+
+- `trigger` indicates if compute autoscaling is enabled for this component of the database. If `"On"` then compute autoscaling is enabled. If `"Off"` then compute autoscaling is disabled.
+- `minAllowed` specifies the minimal amount of resources that will be recommended, default is no minimum.
+- `maxAllowed` specifies the maximum amount of resources that will be recommended, default is no maximum.
+- `controlledResources` specifies which type of compute resources (cpu and memory) are allowed for autoscaling. Allowed values are `"cpu"` and `"memory"`.
+- `containerControlledValues` specifies which resource values should be controlled. Allowed values are `"RequestsAndLimits"` and `"RequestsOnly"`.
+- `resourceDiffPercentage` specifies the minimum resource difference between the recommended value and the current value in percentage. If the difference percentage is greater than this value then autoscaling will be triggered.
+- `podLifeTimeThreshold` specifies the minimum pod lifetime of at least one of the pods before triggering autoscaling.
+
+> The generated `VerticalScaling` ops request carries only the container resources (`spec.verticalScaling.etcd.resources`) — the etcd vertical scaling API has no node-selection or topology sub-fields — so the autoscaler does not emit node-affinity or placement hints today.
+
+### spec.storage
+
+`spec.storage` specifies the autoscaling configuration for the storage resources of the etcd members. This field consists of the following sub-field:
+
+- `spec.storage.etcd` indicates the desired storage autoscaling configuration for the etcd data volume.
+
+It has the following sub-fields:
+
+- `trigger` indicates if storage autoscaling is enabled for this component of the database. If `"On"` then storage autoscaling is enabled. If `"Off"` then storage autoscaling is disabled.
+- `usageThreshold` indicates the usage percentage threshold; if the current storage usage exceeds it, storage autoscaling will be triggered. The default is 80%.
+- `scalingThreshold` indicates the percentage of the current storage that will be added. The default is 50%.
+- `scalingRules` allows a more dynamic scaling threshold — for example, grow by a percentage up to a certain size and by an absolute amount after that.
+- `upperBound` sets a maximum size beyond which the volume will not be grown any further.
+- `expansionMode` indicates the volume expansion mode, `Online` or `Offline`.
+
+> Keep an eye on `spec.configuration.tuning.quotaBackendBytes` when you let the volume grow: etcd will not use more backend space than the quota allows, no matter how large the underlying volume becomes. See [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specconfiguration).
+
+## Next Steps
+
+- Learn about the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd.
+- Learn about the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) crd.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/concepts/etcdopsrequest.md
+++ b/docs/guides/etcd/concepts/etcdopsrequest.md
@@ -1,0 +1,537 @@
+---
+title: EtcdOpsRequest CRD
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-opsrequest-concepts
+    name: EtcdOpsRequest
+    parent: etcd-concepts-etcd
+    weight: 25
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# EtcdOpsRequest
+
+## What is EtcdOpsRequest
+
+`EtcdOpsRequest` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration for [etcd](https://etcd.io/) administrative operations like version updating, horizontal scaling, vertical scaling, TLS reconfiguration, and etcd's own maintenance RPCs (leader transfer, defragmentation, compaction) in a Kubernetes native way.
+
+## EtcdOpsRequest CRD Specifications
+
+Like any official Kubernetes resource, an `EtcdOpsRequest` has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+Here, some sample `EtcdOpsRequest` CRs for different administrative operations are given below:
+
+**Sample `EtcdOpsRequest` for updating the database version:**
+
+Let's assume that you have a KubeDB managed etcd cluster named `etcd-quickstart` running on your Kubernetes cluster with version `3.5.21`. Now, you can update its version to `3.6.4` using the following manifest.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-update-version
+  namespace: demo
+spec:
+  databaseRef:
+    name: etcd-quickstart
+  type: UpdateVersion
+  updateVersion:
+    targetVersion: 3.6.4
+```
+
+**Sample `EtcdOpsRequest` for horizontal scaling of the cluster:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-horizontal-scale-up
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: etcd-quickstart
+  horizontalScaling:
+    replicas: 5
+```
+
+**Sample `EtcdOpsRequest` for vertical scaling of the cluster:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-vscale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: etcd-quickstart
+  verticalScaling:
+    mode: Restart
+    etcd:
+      resources:
+        requests:
+          cpu: 600m
+          memory: 1.2Gi
+        limits:
+          cpu: 1
+          memory: 2Gi
+```
+
+**Sample `EtcdOpsRequest` for reconfiguring the cluster:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-reconfigure
+  namespace: demo
+spec:
+  apply: IfReady
+  databaseRef:
+    name: etcd-quickstart
+  type: Reconfigure
+  configuration:
+    tuning:
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      quotaBackendBytes: 8589934592
+```
+
+**Sample `EtcdOpsRequest` for volume expansion:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-online-volume-expansion
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: etcd-quickstart
+  volumeExpansion:
+    mode: "Online"
+    etcd: 3Gi
+```
+
+**Sample `EtcdOpsRequest` objects for reconfiguring TLS:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-rotate-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-quickstart
+  tls:
+    rotateCertificates: true
+```
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-quickstart
+  tls:
+    issuerRef:
+      name: etcd-ca-issuer
+      kind: Issuer
+      apiGroup: "cert-manager.io"
+    certificates:
+      - alias: server
+        secretName: etcd-quickstart-server-cert
+      - alias: client
+        secretName: etcd-quickstart-client-cert
+      - alias: peer
+        secretName: etcd-quickstart-peer-cert
+```
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-remove-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-quickstart
+  tls:
+    remove: true
+```
+
+**Sample `EtcdOpsRequest` objects for the etcd-native maintenance operations:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-move-leader
+  namespace: demo
+spec:
+  type: MoveLeader
+  databaseRef:
+    name: etcd-quickstart
+  moveLeader:
+    newLeader: etcd-quickstart-2
+```
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-compact
+  namespace: demo
+spec:
+  type: Compact
+  databaseRef:
+    name: etcd-quickstart
+  compact: {}
+```
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-defragment
+  namespace: demo
+spec:
+  type: Defragment
+  databaseRef:
+    name: etcd-quickstart
+  defragment: {}
+```
+
+Here, we are going to describe the various sections of an `EtcdOpsRequest` crd.
+
+An `EtcdOpsRequest` object has the following fields in the `spec` section.
+
+### spec.databaseRef
+
+`spec.databaseRef` is a required field that points to the [Etcd](/docs/guides/etcd/concepts/etcd.md) object for which the administrative operations will be performed. This field consists of the following sub-field:
+
+- **spec.databaseRef.name :** specifies the name of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object. The referenced object must live in the same namespace as the `EtcdOpsRequest`.
+
+### spec.type
+
+`spec.type` specifies the kind of operation that will be applied to the database. The following twelve types of operations are allowed in an `EtcdOpsRequest`.
+
+| Type                | What it does                                                                                                                                 |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `UpdateVersion`     | Updates the cluster to a different [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md), member by member.                                    |
+| `HorizontalScaling` | Changes the number of etcd members, adding new members as learners and removing members through etcd's membership API.                            |
+| `VerticalScaling`   | Changes the CPU/memory resources of the etcd container.                                                                                          |
+| `VolumeExpansion`   | Grows the PVCs holding the etcd data directory.                                                                                                  |
+| `Restart`           | Performs a leader-aware rolling restart of the members.                                                                                          |
+| `Reconfigure`       | Applies a new `spec.configuration.tuning` block.                                                                                                 |
+| `ReconfigureTLS`    | Adds, rotates or removes TLS for the client, peer and metrics endpoints.                                                                         |
+| `RotateAuth`        | Rotates the credential of the etcd `root` user.                                                                                                  |
+| `StorageMigration`  | Migrates the data PVCs onto a different StorageClass.                                                                                            |
+| `MoveLeader`        | Hands the Raft leadership over to another member on purpose.                                                                                     |
+| `Defragment`        | Runs etcd's `Defragment` RPC on every member, one at a time, to reclaim backend file space.                                                       |
+| `Compact`           | Runs etcd's `Compact` RPC to drop superseded MVCC key revisions from the keyspace history.                                                        |
+
+The last three have no analog in the other KubeDB databases. etcd is its own consensus layer — there is no external replication to repair, no "force failover" and no "reconnect standby" — but it does expose maintenance RPCs that a cluster operator is expected to call, and those are what these ops request types wrap. See [spec.moveLeader](#specmoveleader), [spec.defragment](#specdefragment) and [spec.compact](#speccompact) below.
+
+> You can perform only one type of operation in a single `EtcdOpsRequest` CR. For example, if you want to update the version of your database and scale up its members, you have to create two separate `EtcdOpsRequest` objects. First create the one for updating. Once it is completed, then create the other one for scaling.
+
+### spec.updateVersion
+
+If you want to update your etcd version, you have to specify the `spec.updateVersion` section. This field consists of the following sub-field:
+
+- `spec.updateVersion.targetVersion` refers to an [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) CR that contains the etcd version information you want to update to.
+
+The target version is validated against the current version's `spec.updateConstraints`, which encode etcd's own upgrade rules: no downgrades, no major version jumps and at most one minor version step at a time. So going from `3.5.x` to `3.7.x` requires two ops requests, with a stop at `3.6.x`.
+
+### spec.horizontalScaling
+
+If you want to scale up or scale down the number of members in your etcd cluster, you have to specify the `spec.horizontalScaling` section. This field consists of the following sub-field:
+
+- `spec.horizontalScaling.replicas` indicates the desired number of etcd members after scaling.
+
+This ops request is deliberately a thin wrapper: it patches `spec.replicas` on the `Etcd` object and then waits for the provisioner to converge. The provisioner is the component that continuously reconciles the PetSet replica count against etcd's actual member list — adding the next ordinal as a **learner**, waiting for it to catch up with the leader's Raft revision, then **promoting** it, and on the way down removing the **highest ordinal** member through `MemberRemove` before shrinking the PetSet.
+
+> Prefer odd member counts. A `2n+1` member cluster tolerates `n` failures; growing to an even count only raises the quorum size without improving fault tolerance.
+
+### spec.verticalScaling
+
+`spec.verticalScaling` specifies the information about the `Etcd` resources like `cpu` and `memory` that will be scaled. This field consists of the following sub-fields:
+
+- `spec.verticalScaling.etcd` indicates the desired resources for the `etcd` container. It only has a `resources` sub-field — etcd has a single container role, so there is no node-selection or topology sub-field here.
+- `spec.verticalScaling.exporter` exists for structural parity with the other KubeDB databases. **For etcd there is no exporter sidecar container to resize** — etcd serves its Prometheus metrics natively — so setting this field has no container to act on.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated. `Restart` (the default) applies the new resources by restarting the pods, while `InPlace` resizes the running pods in place via the Kubernetes `pods/resize` subresource (no restart), automatically falling back to `Restart` for any pod whose node cannot fit the new resources.
+
+The `resources` field has the below structure:
+
+```yaml
+requests:
+  memory: "600Mi"
+  cpu: "0.5"
+limits:
+  memory: "800Mi"
+  cpu: "0.8"
+```
+
+Here, when you specify the resource request, the scheduler uses this information to decide which node to place the container of the pod on, and when you specify a resource limit for the container, the `kubelet` enforces those limits so that the running container is not allowed to use more of that resource than the limit you set. You can find more details [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+
+### spec.volumeExpansion
+
+> To use the volume expansion feature the storage class must support volume expansion.
+
+If you want to expand the volume of your etcd cluster, you have to specify the `spec.volumeExpansion` section. This field consists of the following sub-fields:
+
+- `spec.volumeExpansion.etcd` indicates the desired size for the persistent volume holding the etcd data directory. It refers to the Kubernetes `Quantity` type.
+- `spec.volumeExpansion.mode` indicates the mode of the volume expansion. It can be `Online` or `Offline`, based on what the storage class supports.
+
+Example usage of this field is given below:
+
+```yaml
+spec:
+  volumeExpansion:
+    mode: "Online"
+    etcd: "2Gi"
+```
+
+This will expand the volume size of all the etcd members to 2 GB.
+
+### spec.configuration
+
+If you want to reconfigure a running etcd cluster with a new tuning configuration, you have to specify the `spec.configuration` section:
+
+```yaml
+spec:
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+```
+
+- `spec.configuration.tuning` holds the KubeDB-managed etcd tuning knobs described in [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specconfiguration). They end up on the etcd command line.
+
+> The generic `configuration.configSecret` and `configuration.applyConfig` fields are **rejected by the webhook for etcd**. etcd's `--config-file` is mutually exclusive with the individual flags KubeDB has to set to bootstrap and reconcile membership, so a free-form config file cannot be supported. Only the typed `tuning` block is available.
+
+etcd has no live-reload path for these flags — nothing analogous to Postgres' `pg_reload_conf()` — so a `Reconfigure` ops request always ends with a leader-aware rolling restart of the members.
+
+### spec.tls
+
+If you want to reconfigure the TLS configuration of your etcd cluster — add TLS, remove TLS, update the issuer or the certificates, or rotate the certificates — you have to specify the `spec.tls` section. It consists of the following sub-fields:
+
+- `spec.tls.issuerRef` specifies the issuer name, kind and api group.
+- `spec.tls.certificates` specifies the certificates. You can learn more about this field from [here](/docs/guides/etcd/concepts/etcd.md#spectls). The valid aliases are `server`, `client`, `peer` and `metrics-exporter`.
+- `spec.tls.rotateCertificates` tells the operator to rotate the certificates of this database.
+- `spec.tls.remove` tells the operator to remove TLS from this database.
+
+Exactly one of the three operations — issue/update (`issuerRef`/`certificates`), `rotateCertificates`, or `remove` — should be requested per ops request. Each of them changes the scheme of the advertised peer and client URLs or the certificate material on disk, so the operator follows up with the same leader-aware rolling restart used by `Restart`.
+
+### spec.authentication
+
+If you want to rotate the credential of the etcd `root` user, use `spec.type: RotateAuth`. This field consists of the following sub-field:
+
+- `spec.authentication.secretRef` optionally points to a Secret holding the new credential. If it is omitted, ops-manager generates a random password.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-rotate-auth
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: etcd-quickstart
+  authentication:
+    secretRef:
+      kind: Secret
+      name: etcd-new-auth
+```
+
+Unlike most KubeDB databases, `RotateAuth` on etcd **does not restart the pods**. etcd applies an RBAC password change live through its `UserChangePassword` RPC, so the operator stages the new credential on the auth Secret (using `.prev` / `.next` keys) and promotes it in place.
+
+### spec.restart
+
+`spec.type: Restart` performs a rolling restart of the members. `spec.restart` itself carries no fields:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: etcd-quickstart
+  restart: {}
+```
+
+The restart is **leader-aware**: if the pod about to be restarted is the current Raft leader, the operator first moves leadership off it, then evicts and recreates pods one at a time, waiting for each pod to become Ready and for the cluster to be quorum-healthy again before moving on to the next one.
+
+### spec.migration
+
+If you want to move the data PVCs onto a different StorageClass, use `spec.type: StorageMigration` together with the `spec.migration` section:
+
+- `spec.migration.storageClassName` is the desired StorageClass to migrate the PVCs to.
+- `spec.migration.oldPVReclaimPolicy` controls the reclaim policy applied to the previous PersistentVolume after the PVC has been re-pointed. Set it to `Retain` to keep the old PV around.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: etcd-quickstart
+  migration:
+    storageClassName: fast-ssd
+  timeout: 30m
+```
+
+> `spec.timeout` is required for a `StorageMigration` ops request, since copying the data directory of each member can take an arbitrary amount of time.
+
+### spec.moveLeader
+
+`spec.type: MoveLeader` wraps etcd's `MoveLeader` RPC, which hands Raft leadership from the current leader to another voting member.
+
+- `spec.moveLeader.newLeader` is the optional name of the member (pod) that should become the new leader. If it is empty, the operator picks a healthy member that is caught up with the leader.
+
+```yaml
+spec:
+  type: MoveLeader
+  databaseRef:
+    name: etcd-quickstart
+  moveLeader:
+    newLeader: etcd-quickstart-2
+```
+
+Why it exists: etcd elects its own leader, and an unplanned leader loss costs an election round during which writes stall. Moving leadership deliberately — before draining the node that hosts the leader, before taking that member down for maintenance, or before a rolling operation — turns an unplanned election into a fast, controlled handover. The same primitive is what makes the `Restart`, `Reconfigure` and `UpdateVersion` rollouts leader-aware.
+
+### spec.defragment
+
+`spec.type: Defragment` wraps etcd's `Defragment` RPC. `spec.defragment` carries no fields:
+
+```yaml
+spec:
+  type: Defragment
+  databaseRef:
+    name: etcd-quickstart
+  defragment: {}
+```
+
+Why it exists: etcd's backend never shrinks its database file on its own. Deleting keys, or compacting away old revisions, frees space *inside* the file but leaves the file itself as large as it ever was — and that size is what counts against `quotaBackendBytes`. Defragmentation rewrites the backend to release that space back to the filesystem.
+
+Defragmenting briefly blocks the member it runs on, so the operator walks the members **one at a time and leaves the leader for last**, checking between each step that the cluster still has quorum.
+
+### spec.compact
+
+`spec.type: Compact` wraps etcd's `Compact` RPC, which discards superseded revisions from the MVCC keyspace history.
+
+- `spec.compact.revision` is the optional revision to compact the history up to. If it is omitted, the operator compacts up to the current revision at execution time.
+
+```yaml
+spec:
+  type: Compact
+  databaseRef:
+    name: etcd-quickstart
+  compact:
+    revision: 1000000
+```
+
+Why it exists: etcd keeps every past version of every key so that watchers and historical reads work. Left alone, that history grows without bound and eventually trips the backend quota. Compaction drops the old versions; **defragmentation is what actually returns the freed space to the filesystem**, so the two are usually run as a pair — `Compact` first, then `Defragment`.
+
+If you would rather have this happen automatically, set `spec.configuration.tuning.autoCompactionMode` and `autoCompactionRetention` on the [Etcd](/docs/guides/etcd/concepts/etcd.md#specconfiguration) object instead, and use this ops request only for one-off cleanups.
+
+### spec.timeout
+
+As we internally retry the ops request steps multiple times, this `timeout` field helps the users specify the timeout for those steps of the ops request. If a step doesn't finish within the specified timeout, the ops request will result in failure.
+
+### spec.apply
+
+This field controls the execution of the ops request depending on the database state. It has two supported values: `Always` & `IfReady`. Use `IfReady` if you want to process the ops request only when the database is Ready, and use `Always` if you want to process the ops request irrespective of the database state. It defaults to `IfReady`.
+
+### spec.maxRetries
+
+`spec.maxRetries` is the number of times a failed ops request will be retried before it is finally marked as `Failed`. It defaults to `1`.
+
+## EtcdOpsRequest `Status`
+
+`.status` describes the current state and progress of an `EtcdOpsRequest` operation. It has the following fields:
+
+### status.phase
+
+`status.phase` indicates the overall phase of the operation for this `EtcdOpsRequest`. It can have the following values:
+
+| Phase       | Meaning                                                                        |
+|-------------|----------------------------------------------------------------------------------|
+| Successful  | KubeDB has successfully performed the operation requested in the EtcdOpsRequest  |
+| Progressing | KubeDB has started the execution of the applied EtcdOpsRequest                   |
+| Failed      | KubeDB has failed the operation requested in the EtcdOpsRequest                  |
+| Denied      | KubeDB has denied the operation requested in the EtcdOpsRequest                  |
+| Skipped     | KubeDB has skipped the operation requested in the EtcdOpsRequest                 |
+
+Important: The ops-manager operator can skip an ops request only if its execution has not been started yet & there is a newer ops request applied in the cluster. `spec.type` has to be the same as the skipped one, in this case.
+
+### status.observedGeneration
+
+`status.observedGeneration` shows the most recent generation observed by the `EtcdOpsRequest` controller.
+
+### status.conditions
+
+`status.conditions` is an array that specifies the conditions of different steps of `EtcdOpsRequest` processing. Each condition entry has the following fields:
+
+- `type` specifies the type of the condition. `EtcdOpsRequest` uses the shared KubeDB condition types plus a handful of etcd-specific ones:
+
+| Type                       | Meaning                                                                        |
+|----------------------------|----------------------------------------------------------------------------------|
+| `Running`                  | Set once, when the operation starts being executed (`status.phase` moves to `Progressing`, but the condition `type` written for this step is `Running`, not `Progressing`). |
+| `Successful`               | The operation on the database was successful.                                    |
+| `Failed`                   | The operation on the database failed.                                            |
+| `DatabasePauseSucceeded`   | The database is paused by the operator.                                          |
+| `ResumeDatabase`           | The database is resumed by the operator.                                         |
+| `UpdateEtcdPetSet`         | The PetSet of the etcd cluster has been updated.                                 |
+| `UpdateEtcdNodePVCs`       | The PVCs of the etcd members have been updated.                                  |
+| `MigrateEtcdStorage`       | The etcd data has been migrated onto the new StorageClass.                       |
+| `RestartEtcdPods`          | The etcd member pods have been restarted.                                        |
+| `ReadyEtcdPod`             | An etcd member pod has become ready.                                             |
+| `EtcdClusterHealthy`       | The etcd cluster is quorum-healthy.                                              |
+| `EtcdMemberListReady`      | etcd's member list matches the desired membership.                               |
+| `EtcdLearnerPromoted`      | A learner has caught up and has been promoted to a voting member. (`EtcdMemberAdded`/`EtcdMemberRemoved` are declared in the API but not currently set by the operator — the learner-add and member-remove steps are only observable indirectly, via `EtcdMemberListReady` and the provisioner's own logs, not a dedicated condition.) |
+| `EtcdLeaderMoved`          | Raft leadership has been transferred to another member. Only set by the standalone `MoveLeader` ops type; a `Restart` that has to move leadership off the pod being evicted instead records a `MoveLeader--<pod-name>` condition. |
+| `EtcdDefragmented`         | The backend of the members has been defragmented.                                |
+| `EtcdCompacted`            | The keyspace history has been compacted.                                         |
+| `EtcdAlarmCleared`         | An etcd alarm (for example `NOSPACE`) has been cleared.                          |
+| `IssueCertificatesSucceeded` | The TLS certificate issuing is successful.                                     |
+| `UpdateDatabase`           | The `Etcd` CR has been updated.                                                  |
+
+- The `status` field is a string, with possible values `True`, `False`, and `Unknown`.
+  - `status` will be `True` if the current transition succeeded.
+  - `status` will be `False` if the current transition failed.
+  - `status` will be `Unknown` if the current transition was denied.
+- The `message` field is a human-readable message indicating details about the condition.
+- The `reason` field is a unique, one-word, CamelCase reason for the condition's last transition.
+- The `lastTransitionTime` field provides a timestamp for when the operation last transitioned from one state to another.
+- The `observedGeneration` shows the most recent condition transition generation observed by the controller.
+
+## Next Steps
+
+- Learn about the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd.
+- Learn about the [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) crd.
+- Deploy your first etcd cluster with KubeDB by following the guide [here](/docs/guides/etcd/quickstart/quickstart.md).

--- a/docs/guides/etcd/concepts/etcdopsrequest.md
+++ b/docs/guides/etcd/concepts/etcdopsrequest.md
@@ -18,7 +18,7 @@ section_menu_id: guides
 
 ## What is EtcdOpsRequest
 
-`EtcdOpsRequest` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration for [etcd](https://etcd.io/) administrative operations like version updating, horizontal scaling, vertical scaling, TLS reconfiguration, and etcd's own maintenance RPCs (leader transfer, defragmentation, compaction) in a Kubernetes native way.
+`EtcdOpsRequest` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration for [etcd](https://etcd.io/) administrative operations like version updating, horizontal scaling, vertical scaling, TLS reconfiguration, etcd's own maintenance RPCs (leader transfer, defragmentation, compaction), and the two disaster-recovery procedures (rebuilding a cluster after a permanent quorum loss, and restoring a snapshot into an existing cluster) in a Kubernetes native way.
 
 ## EtcdOpsRequest CRD Specifications
 
@@ -229,7 +229,7 @@ An `EtcdOpsRequest` object has the following fields in the `spec` section.
 
 ### spec.type
 
-`spec.type` specifies the kind of operation that will be applied to the database. The following twelve types of operations are allowed in an `EtcdOpsRequest`.
+`spec.type` specifies the kind of operation that will be applied to the database. The following fourteen types of operations are allowed in an `EtcdOpsRequest`.
 
 | Type                | What it does                                                                                                                                 |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -245,8 +245,12 @@ An `EtcdOpsRequest` object has the following fields in the `spec` section.
 | `MoveLeader`        | Hands the Raft leadership over to another member on purpose.                                                                                     |
 | `Defragment`        | Runs etcd's `Defragment` RPC on every member, one at a time, to reclaim backend file space.                                                       |
 | `Compact`           | Runs etcd's `Compact` RPC to drop superseded MVCC key revisions from the keyspace history.                                                        |
+| `RecoverFromQuorumLoss` | **Destructive.** Rebuilds a cluster that has permanently lost its Raft quorum from a single surviving member, discarding every other member's data. |
+| `Restore`           | **Destructive.** Replaces the entire keyspace of an existing cluster with a KubeStash snapshot.                                                   |
 
-The last three have no analog in the other KubeDB databases. etcd is its own consensus layer — there is no external replication to repair, no "force failover" and no "reconnect standby" — but it does expose maintenance RPCs that a cluster operator is expected to call, and those are what these ops request types wrap. See [spec.moveLeader](#specmoveleader), [spec.defragment](#specdefragment) and [spec.compact](#speccompact) below.
+The last two are break-glass, disaster-recovery procedures, not routine maintenance. Both throw data away as their *normal* outcome, both require `spec.timeout`, and both leave the cluster as a healthy single member that the ordinary membership reconciliation then regrows back to `spec.replicas`. See [spec.recoverFromQuorumLoss](#specrecoverfromquorumloss) and [spec.restore](#specrestore) below.
+
+`MoveLeader`, `Defragment` and `Compact` have no analog in the other KubeDB databases. etcd is its own consensus layer — there is no external replication to repair, no "force failover" and no "reconnect standby" — but it does expose maintenance RPCs that a cluster operator is expected to call, and those are what these ops request types wrap. See [spec.moveLeader](#specmoveleader), [spec.defragment](#specdefragment) and [spec.compact](#speccompact) below.
 
 > You can perform only one type of operation in a single `EtcdOpsRequest` CR. For example, if you want to update the version of your database and scale up its members, you have to create two separate `EtcdOpsRequest` objects. First create the one for updating. Once it is completed, then create the other one for scaling.
 
@@ -459,6 +463,84 @@ Why it exists: etcd keeps every past version of every key so that watchers and h
 
 If you would rather have this happen automatically, set `spec.configuration.tuning.autoCompactionMode` and `autoCompactionRetention` on the [Etcd](/docs/guides/etcd/concepts/etcd.md#specconfiguration) object instead, and use this ops request only for one-off cleanups.
 
+### spec.recoverFromQuorumLoss
+
+`spec.type: RecoverFromQuorumLoss` rebuilds an etcd cluster that has **permanently** lost its Raft quorum — a majority of its voting members is gone for good — from a single surviving member, using etcd's own `--force-new-cluster` procedure.
+
+> **This is a destructive, break-glass procedure.** Every member except the confirmed survivor has its data directory discarded permanently, and any write the lost majority had committed but the survivor had not yet applied is lost with no way to get it back. It is **never** triggered automatically: the Provisioner operator only ever raises a `QuorumLost` condition on the `Etcd` object as a signal, and the recovery itself has to be asked for by a human-authored ops request. Read the [Recover from Quorum Loss Overview](/docs/guides/etcd/recover-from-quorum-loss/overview.md) before using it.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-recover-quorum
+  namespace: demo
+spec:
+  type: RecoverFromQuorumLoss
+  databaseRef:
+    name: etcd-quickstart
+  recoverFromQuorumLoss:
+    member: etcd-quickstart-1
+    confirmMember: etcd-quickstart-1
+  timeout: 30m
+  apply: Always
+```
+
+- `spec.recoverFromQuorumLoss.member` is the **optional** pod name — or a bare ordinal, e.g. `"1"` — of the surviving member to rebuild the cluster from. If it is empty, the operator picks the reachable member with the **highest Raft applied index**, which is the survivor that has lost the fewest writes.
+- `spec.recoverFromQuorumLoss.confirmMember` is a **mandatory hard confirmation gate**. The operator resolves the survivor exactly once, records it in an `EtcdQuorumLossSurvivorResolved--<pod>` condition, reports it in the `EtcdQuorumLossAwaitingConfirmation` condition, and then refuses to do anything destructive until this field names *exactly* that pod. It waits there indefinitely — the wait never times out and never fails the request, because what it is waiting for is a person. This exists so a mistyped `member` cannot silently destroy the wrong member's data, which is why the gate applies even when you set `member` yourself.
+
+The intended workflow is therefore two steps: create the request with `confirmMember` unset, read the resolved survivor back out of the status, then patch `confirmMember` to match it.
+
+The request is **refused outright** — terminally, without burning `spec.maxRetries` — unless the target `Etcd` currently reports the `QuorumLost` condition with status `True`. The condition is read live from the API server on every admission, and a cluster that has regained its quorum on its own while the request waited for confirmation is refused as well.
+
+> `spec.timeout` is required for a `RecoverFromQuorumLoss` ops request. Several steps — waiting for the rebuilt member to come up, waiting for a volume to rebind — have no other deadline at all. `spec.storageType` must also be `Durable`: an ephemeral member's data died with its pod, so there is nothing to rescue.
+
+Because the cluster it is run against is by definition not `Ready`, this ops request generally needs `spec.apply: Always`. It ends at a healthy **single-member** cluster; the members that were discarded are added back afterwards by the ordinary membership reconciliation, as learners, through the same path an ordinary scale up uses.
+
+See the [Recover from Quorum Loss guide](/docs/guides/etcd/recover-from-quorum-loss/recover-from-quorum-loss.md) for the full walkthrough.
+
+### spec.restore
+
+`spec.type: Restore` restores a [KubeStash](https://kubestash.com/) snapshot into an `Etcd` database that **already exists** and may already have running members.
+
+> **This replaces the entire keyspace of the database.** Everything currently stored in it is discarded and replaced by the contents of the snapshot. Full data loss is not a failure mode here — it is the normal, successful outcome of the operation, and there is no undo.
+
+This is the in-place counterpart of the **bootstrap-time** restore configured through `spec.init.archiver` on the [Etcd](/docs/guides/etcd/concepts/etcd.md#specinit) object itself, which only works while a brand-new `Etcd` object is being created. If you are standing up a new cluster from a backup, use that one instead — see [Snapshot Backup & Restore](/docs/guides/etcd/backup/kubestash/snapshot/index.md#restore).
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-restore
+  namespace: demo
+spec:
+  type: Restore
+  databaseRef:
+    name: etcd-quickstart
+  restore:
+    fullDBRepository:
+      name: etcd-full-repo
+      namespace: demo
+    encryptionSecret:
+      name: encrypt-secret
+      namespace: demo
+    recoveryTimestamp: "2026-08-15T08:30:00Z"
+  timeout: 30m
+  apply: Always
+```
+
+- `spec.restore.fullDBRepository` names the KubeStash `Repository` to restore the etcd snapshot from. It is **required and has no default** — unlike the bootstrap-time restore this destroys data that is already there, so guessing which repository was meant is not an option.
+- `spec.restore.recoveryTimestamp` is optional. If it is omitted, the **latest** available snapshot is used; otherwise the operator picks the newest successful full snapshot taken *at or before* that instant. As with the bootstrap restore, this is snapshot selection rather than point-in-time recovery — etcd has no log stream to replay forward.
+- `spec.restore.encryptionSecret` refers to the Secret holding the encryption key the snapshot was backed up with, if any.
+
+Mechanically, **only the seed member (ordinal 0) is ever restored into**. The cluster is taken apart down to a single empty volume, the snapshot is written into it by the same `RestoreSession` the bootstrap path uses, and the seed is started on the restored data directory. The other members are discarded and rejoin as fresh **learners**, streaming the restored keyspace from the seed through the same learner-add/promote path an ordinary [horizontal scale up](#spechorizontalscaling) uses. Their old data directories describe a keyspace the restored one no longer relates to, so they could not have rejoined anyway.
+
+> `spec.timeout` is required for a `Restore` ops request — the `RestoreSession` has no other deadline. `spec.storageType` must be `Durable` with `spec.storage` set: there is no PVC to restore into before the seed member starts otherwise.
+
+Because the cluster it is run against is often degraded, this ops request generally needs `spec.apply: Always`.
+
+See the [In-place Restore guide](/docs/guides/etcd/restore/restore.md) for the full walkthrough.
+
 ### spec.timeout
 
 As we internally retry the ops request steps multiple times, this `timeout` field helps the users specify the timeout for those steps of the ops request. If a step doesn't finish within the specified timeout, the ops request will result in failure.
@@ -520,6 +602,39 @@ Important: The ops-manager operator can skip an ops request only if its executio
 | `EtcdAlarmCleared`         | An etcd alarm (for example `NOSPACE`) has been cleared.                          |
 | `IssueCertificatesSucceeded` | The TLS certificate issuing is successful.                                     |
 | `UpdateDatabase`           | The `Etcd` CR has been updated.                                                  |
+
+A `RecoverFromQuorumLoss` request additionally reports its own step conditions, in this order:
+
+| Type                                      | Meaning                                                                    |
+|-------------------------------------------|------------------------------------------------------------------------------|
+| `EtcdQuorumLossAdmitted`                  | The `Etcd` was observed reporting `QuorumLost=True`, so the request is allowed to run. |
+| `EtcdQuorumLossSurvivorResolved--<pod>`   | The member the cluster will be rebuilt from has been chosen. Resolved **once** and never re-picked. |
+| `EtcdQuorumLossAwaitingConfirmation`      | `False` while `spec.recoverFromQuorumLoss.confirmMember` does not name the resolved survivor — its message tells you what to set it to. `True` once it does. |
+| `EtcdQuorumLossPreflight`                 | The last checks before anything is destroyed: the quorum is still lost, and ordinal 0's pod exists. |
+| `EtcdQuorumLossPVCRelocated`              | The survivor's volume now answers to ordinal 0's claim name.                 |
+| `EtcdQuorumLossStaleMembersRemoved`       | Every member outside the survivor has been discarded.                        |
+| `EtcdQuorumLossClusterStateSeeded`        | The cluster state ConfigMap has been rewritten for a single-member cluster.  |
+| `EtcdQuorumLossForceNewClusterBoot`       | Ordinal 0 has been recreated with `--force-new-cluster`.                     |
+| `EtcdQuorumLossSingleMemberHealthy`       | The rebuilt member is Ready and reports exactly one member.                  |
+| `EtcdQuorumLossFlagRemoved`               | Ordinal 0 has been recreated without `--force-new-cluster`, so a later restart cannot re-trigger it. |
+| `EtcdQuorumLossVolumesReclaimed`          | The parked reclaim policies have been restored — this is what finally destroys the discarded members' data. |
+| `EtcdQuorumLossPetSetRestored`            | The PetSet has been recreated around the rebuilt member.                     |
+| `RecoverEtcdFromQuorumLoss`               | The whole recovery is done.                                                  |
+
+A `Restore` request reports these:
+
+| Type                              | Meaning                                                                            |
+|-----------------------------------|--------------------------------------------------------------------------------------|
+| `EtcdRestorePetSetDeleted`        | The PetSet has been orphaned so its pods and claims can be replaced.                 |
+| `EtcdRestoreMembersDiscarded`     | Every member outside the seed has been discarded. Completed per member first, as `EtcdRestoreMembersDiscarded--<pod>`. |
+| `EtcdRestoreSeedPVCWiped`         | The seed member's data volume has been replaced with an empty PVC.                   |
+| `EtcdRestoreSessionCreated`       | The KubeStash `RestoreSession` has been created — this is what pins the chosen snapshot. |
+| `EtcdRestoreSnapshotApplied`      | The session finished writing the snapshot into the seed volume.                      |
+| `EtcdRestoreClusterStateSeeded`   | The cluster state ConfigMap has been rewritten for a single-member cluster.          |
+| `EtcdRestorePetSetRestored`       | The PetSet has been recreated, bringing the seed back on the restored volume.        |
+| `EtcdRestoreSingleMemberHealthy`  | The seed member is Ready and serving the restored keyspace.                          |
+| `EtcdRestoreVolumesReclaimed`     | The parked reclaim policies have been restored — this is what finally destroys the replaced data. |
+| `RestoreEtcdSnapshot`             | The whole restore is done.                                                           |
 
 - The `status` field is a string, with possible values `True`, `False`, and `Unknown`.
   - `status` will be `True` if the current transition succeeded.

--- a/docs/guides/etcd/concepts/etcdopsrequest.md
+++ b/docs/guides/etcd/concepts/etcdopsrequest.md
@@ -260,7 +260,9 @@ If you want to update your etcd version, you have to specify the `spec.updateVer
 
 - `spec.updateVersion.targetVersion` refers to an [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) CR that contains the etcd version information you want to update to.
 
-The target version is validated against the current version's `spec.updateConstraints`, which encode etcd's own upgrade rules: no downgrades, no major version jumps and at most one minor version step at a time. So going from `3.5.x` to `3.7.x` requires two ops requests, with a stop at `3.6.x`.
+The target version is validated against etcd's own upgrade rules: no downgrades, no major version jumps and at most one minor version step at a time. So going from `3.5.x` to `3.7.x` requires two ops requests, with a stop at `3.6.x`. A target whose `EtcdVersion` is marked `spec.deprecated` is refused as well.
+
+> These rules are applied by the ops-manager when the request starts executing — they are hard-coded there, not read from the `EtcdVersion`'s `spec.updateConstraints.allowlist`. The admission webhook only checks that `spec.updateVersion.targetVersion` is non-empty, so an invalid upgrade path produces a request that is accepted and then fails. See [The Upgrade Path Is Validated](/docs/guides/etcd/update-version/overview.md#the-upgrade-path-is-validated--read-this-first).
 
 ### spec.horizontalScaling
 
@@ -329,9 +331,9 @@ spec:
 
 - `spec.configuration.tuning` holds the KubeDB-managed etcd tuning knobs described in [Etcd CRD](/docs/guides/etcd/concepts/etcd.md#specconfiguration). They end up on the etcd command line.
 
-> The generic `configuration.configSecret` and `configuration.applyConfig` fields are **rejected by the webhook for etcd**. etcd's `--config-file` is mutually exclusive with the individual flags KubeDB has to set to bootstrap and reconcile membership, so a free-form config file cannot be supported. Only the typed `tuning` block is available.
+> The generic `configuration.applyConfig` field is **rejected by the webhook for etcd**, and `configuration.configSecret` is accepted but inert — nothing ever mounts it. etcd's `--config-file` is mutually exclusive with the individual flags KubeDB has to set to bootstrap and reconcile membership, so a free-form config file cannot be supported. In practice, only the typed `tuning` block is available.
 
-etcd has no live-reload path for these flags — nothing analogous to Postgres' `pg_reload_conf()` — so a `Reconfigure` ops request always ends with a leader-aware rolling restart of the members.
+etcd has no live-reload path for these flags — nothing analogous to Postgres' `pg_reload_conf()` — so a `Reconfigure` ops request normally ends with a leader-aware rolling restart of the members. You can suppress that with `spec.configuration.restart: "false"`, but the new values will then not take effect until the members are restarted for some other reason.
 
 ### spec.tls
 
@@ -479,11 +481,17 @@ spec:
   type: RecoverFromQuorumLoss
   databaseRef:
     name: etcd-quickstart
-  recoverFromQuorumLoss:
-    member: etcd-quickstart-1
-    confirmMember: etcd-quickstart-1
+  recoverFromQuorumLoss: {}
   timeout: 30m
   apply: Always
+```
+
+You then read the resolved survivor out of the status and patch `confirmMember` to match it:
+
+```yaml
+spec:
+  recoverFromQuorumLoss:
+    confirmMember: etcd-quickstart-1
 ```
 
 - `spec.recoverFromQuorumLoss.member` is the **optional** pod name — or a bare ordinal, e.g. `"1"` — of the surviving member to rebuild the cluster from. If it is empty, the operator picks the reachable member with the **highest Raft applied index**, which is the survivor that has lost the fewest writes.
@@ -592,10 +600,11 @@ Important: The ops-manager operator can skip an ops request only if its executio
 | `UpdateEtcdNodePVCs`       | The PVCs of the etcd members have been updated.                                  |
 | `MigrateEtcdStorage`       | The etcd data has been migrated onto the new StorageClass.                       |
 | `RestartEtcdPods`          | The etcd member pods have been restarted.                                        |
-| `ReadyEtcdPod`             | An etcd member pod has become ready.                                             |
-| `EtcdClusterHealthy`       | The etcd cluster is quorum-healthy.                                              |
+| `EtcdClusterHealthy`       | The etcd cluster is quorum-healthy. Written per pod as `EtcdClusterHealthy--<pod-name>` by the operations that walk the members one at a time (`Restart`, `Reconfigure`, `VerticalScaling`, `UpdateVersion`, `StorageMigration`, `Defragment`), and bare by `HorizontalScaling`. |
 | `EtcdMemberListReady`      | etcd's member list matches the desired membership.                               |
-| `EtcdLearnerPromoted`      | A learner has caught up and has been promoted to a voting member. (`EtcdMemberAdded`/`EtcdMemberRemoved` are declared in the API but not currently set by the operator — the learner-add and member-remove steps are only observable indirectly, via `EtcdMemberListReady` and the provisioner's own logs, not a dedicated condition.) |
+| `EtcdMemberAdded`          | Recorded at the start of a scale-up, before `spec.replicas` is patched.          |
+| `EtcdMemberRemoved`        | Recorded at the start of a scale-down, before `spec.replicas` is patched.        |
+| `EtcdLearnerPromoted`      | A learner has caught up and has been promoted to a voting member. Also set on a scale-down, where the check simply confirms no member is still a learner. |
 | `EtcdLeaderMoved`          | Raft leadership has been transferred to another member. Only set by the standalone `MoveLeader` ops type; a `Restart` that has to move leadership off the pod being evicted instead records a `MoveLeader--<pod-name>` condition. |
 | `EtcdDefragmented`         | The backend of the members has been defragmented.                                |
 | `EtcdCompacted`            | The keyspace history has been compacted.                                         |

--- a/docs/guides/etcd/concepts/etcdversion.md
+++ b/docs/guides/etcd/concepts/etcdversion.md
@@ -85,7 +85,9 @@ The default value of this field is `false`. If `spec.deprecated` is set to `true
 
 ### spec.initContainer.image
 
-`spec.initContainer.image` is an optional field that specifies the image for the init container (`etcd-init`).
+`spec.initContainer.image` is an optional field that specifies the image used for an init container named `etcd-init`.
+
+> The etcd provisioner does **not** create an init container, so on a stock cluster this field is inert. It is only consulted by an `UpdateVersion` `EtcdOpsRequest`, which re-images an init container named `etcd-init` **if one already exists** in the `PetSet` — i.e. only if you added it yourself through `spec.podTemplate.spec.initContainers`.
 
 ### spec.exporter.image
 
@@ -123,7 +125,7 @@ helm upgrade -i kubedb oci://ghcr.io/appscode-charts/kubedb \
   --namespace kubedb --create-namespace \
   --set additionalPodSecurityPolicies[0]=custom-db-policy \
   --set-file global.license=/path/to/the/license.txt \
-  --set global.featureGates.Etcd=true \
+  --set featureGates.Etcd=true \
   --wait --burst-limit=10000 --debug
 ```
 

--- a/docs/guides/etcd/concepts/etcdversion.md
+++ b/docs/guides/etcd/concepts/etcdversion.md
@@ -1,0 +1,133 @@
+---
+title: EtcdVersion CRD
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-catalog-concepts
+    name: EtcdVersion
+    parent: etcd-concepts-etcd
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# EtcdVersion
+
+## What is EtcdVersion
+
+`EtcdVersion` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration to specify the docker images to be used for [etcd](https://etcd.io/) deployed with KubeDB in a Kubernetes native way.
+
+When you install KubeDB, an `EtcdVersion` custom resource will be created automatically for every supported etcd version. You have to specify the name of the `EtcdVersion` crd in the `spec.version` field of the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd. Then, KubeDB will use the docker images specified in the `EtcdVersion` crd to create your expected database.
+
+Using a separate crd for specifying the respective docker images and pod security policy names allows us to modify the images and policies independently of the KubeDB operator. This also allows users to use a custom image for the database.
+
+> Unlike most other databases, etcd has no vendor distributions — there is a single upstream implementation — so `EtcdVersion` deliberately has **no** `spec.distribution` field.
+
+`EtcdVersion` is a cluster-scoped resource, so it is not created in any namespace.
+
+## EtcdVersion Specification
+
+As with all other Kubernetes objects, an EtcdVersion needs `apiVersion`, `kind`, and `metadata` fields. It also needs a `.spec` section.
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: EtcdVersion
+metadata:
+  annotations:
+    meta.helm.sh/release-name: kubedb
+    meta.helm.sh/release-namespace: kubedb
+  creationTimestamp: "2026-01-14T09:41:52Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: kubedb
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kubedb-catalog
+  name: 3.6.4
+  resourceVersion: "12345"
+  uid: 3c5a4714-4ce2-4b41-8ad9-4899c3127dcc
+spec:
+  db:
+    image: ghcr.io/appscode-images/etcd:v3.6.4
+  exporter:
+    image: ghcr.io/appscode-images/etcd:v3.6.4
+  securityContext:
+    runAsUser: 1000
+  updateConstraints:
+    allowlist:
+      - '>= 3.6.4, <= 3.7.0'
+  version: 3.6.4
+```
+
+### metadata.name
+
+`metadata.name` is a required field that specifies the name of the `EtcdVersion` crd. You have to specify this name in the `spec.version` field of the [Etcd](/docs/guides/etcd/concepts/etcd.md) crd.
+
+### spec.version
+
+`spec.version` is a required field that specifies the original version of the etcd server that has been used to build the docker image specified in the `spec.db.image` field.
+
+### spec.deprecated
+
+`spec.deprecated` is an optional field that specifies whether the docker images specified here are supported by the current KubeDB operator.
+
+The default value of this field is `false`. If `spec.deprecated` is set to `true`, the KubeDB operator will skip processing this CRD object and will add an event to the CRD object specifying that the DB version is deprecated.
+
+### spec.endOfLife
+
+`spec.endOfLife` is an optional field that marks whether this etcd version has reached its end of life according to [endoflife.date](https://endoflife.date/). It is informational — it does not by itself block provisioning — but the Recommendation Engine takes it into account when proposing an `UpdateVersion` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md).
+
+### spec.db.image
+
+`spec.db.image` is a required field that specifies the docker image which will be used by the KubeDB operator to create the PetSet running the expected etcd members.
+
+### spec.initContainer.image
+
+`spec.initContainer.image` is an optional field that specifies the image for the init container (`etcd-init`).
+
+### spec.exporter.image
+
+`spec.exporter.image` is a required field in the schema and specifies the image used for metrics related tooling.
+
+> For etcd, **no exporter sidecar is actually deployed**. etcd serves its own Prometheus metrics endpoint natively, so KubeDB points the stats Service and the ServiceMonitor directly at etcd. The field is kept for structural parity with the other KubeDB catalog types.
+
+### spec.securityContext
+
+`spec.securityContext` holds the additional security settings applied to the etcd container.
+
+- `spec.securityContext.runAsUser` is the default UID for the DB container. The upstream etcd image runs as uid `1000`.
+- `spec.securityContext.runAsAnyNonRoot` will be `true` if the user is allowed to change the default DB container user to something other than the image's default user.
+
+### spec.updateConstraints
+
+`updateConstraints` specifies the constraints that need to be considered during a version update. Here, `allowlist` contains the versions that are allowed as the target of an update from the current version. An empty `allowlist` indicates that all versions are accepted except those in the `denylist`. Conversely, `denylist` contains all the rejected versions for the update request; an empty list indicates that no version is rejected.
+
+For etcd, the shipped constraints follow the upstream upgrade rules: updates must stay within the same major version, must never go backwards, and must move at most one minor version at a time. For example, `3.5.21` allows `>= 3.5.21, <= 3.6.4`.
+
+### spec.stash
+
+This holds the backup & restore task definitions, where a `TaskRef` has a `Name` & `Params` section. `Params` specifies a list of parameters to pass to the task.
+
+### spec.archiver
+
+`spec.archiver` holds the KubeStash addon related specification used by the [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md) driven snapshot backup.
+
+### spec.podSecurityPolicies.databasePolicyName
+
+`spec.podSecurityPolicies.databasePolicyName` specifies the name of the pod security policy required to get the database server pod(s) running. To use a user-defined policy, the name of the policy has to be set in `spec.podSecurityPolicies` and in the list of allowed policy names in the KubeDB operator like below:
+
+```bash
+helm upgrade -i kubedb oci://ghcr.io/appscode-charts/kubedb \
+  --namespace kubedb --create-namespace \
+  --set additionalPodSecurityPolicies[0]=custom-db-policy \
+  --set-file global.license=/path/to/the/license.txt \
+  --set global.featureGates.Etcd=true \
+  --wait --burst-limit=10000 --debug
+```
+
+## Next Steps
+
+- Learn about the Etcd crd [here](/docs/guides/etcd/concepts/etcd.md).
+- Deploy your first etcd cluster with KubeDB by following the guide [here](/docs/guides/etcd/quickstart/quickstart.md).

--- a/docs/guides/etcd/custom-configuration/_index.md
+++ b/docs/guides/etcd/custom-configuration/_index.md
@@ -1,0 +1,12 @@
+---
+title: Run Etcd with Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-custom-configuration
+    name: Custom Configuration
+    parent: etcd-etcd-guides
+    weight: 30
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/custom-configuration/using-config.md
+++ b/docs/guides/etcd/custom-configuration/using-config.md
@@ -1,0 +1,244 @@
+---
+title: Run Etcd with Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-using-config-configuration
+    name: Customize Configuration
+    parent: etcd-custom-configuration
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Run Etcd with Custom Configuration
+
+KubeDB lets you tune an etcd cluster at creation time through the typed `spec.configuration.tuning` block. This guide covers what each knob does, how to set it, and how to verify it took effect.
+
+This guide is about **day-1** configuration — the settings you bake into the `Etcd` object before the cluster exists. To change these on a cluster that is already running, use a `Reconfigure` [EtcdOpsRequest](/docs/guides/etcd/reconfigure/reconfigure.md) instead; the fields are the same.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the operator was installed with `--set featureGates.Etcd=true`.
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+  ```bash
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Custom config files are not supported for etcd
+
+Most KubeDB databases let you mount a configuration file — `spec.configuration.configSecret` pointing at a `Secret` holding `postgresql.conf`, `my.cnf`, `zoo.cfg` and so on — or merge in free-form key/value pairs with `spec.configuration.applyConfig`. **etcd supports neither.**
+
+The reason is a property of etcd itself, not a KubeDB limitation: **etcd's `--config-file` flag is mutually exclusive with the individual command-line flags.** From etcd's own documentation, if you pass `--config-file`, etcd ignores every other flag on the command line and takes its entire configuration from that file.
+
+That is fatal for an orchestrator. KubeDB *must* own a set of flags for the cluster to work at all:
+
+- `--name`, `--initial-advertise-peer-urls`, `--advertise-client-urls` — per-member identity, resolved from the pod's own name through the downward API.
+- `--listen-peer-urls`, `--listen-client-urls`, `--listen-metrics-urls` — the listeners, whose scheme flips between `http` and `https` when you enable TLS.
+- `--cert-file`, `--key-file`, `--trusted-ca-file`, `--client-cert-auth`, and the `--peer-*` equivalents — the TLS material, whose paths come from the mounted certificate secrets.
+- `--data-dir` — the mounted PersistentVolume.
+
+If a user-supplied config file took over, all of those would silently stop being applied: the member would not know its own identity, would not join the right cluster, and would not use the certificates that were issued for it. Rather than merge a config file and a flag set — which etcd will not do — KubeDB exposes the safe subset as typed fields and renders them as additional flags.
+
+So, concretely:
+
+- `spec.configuration.tuning` — **supported**. This is the path described in the rest of this guide.
+- `spec.configuration.applyConfig` — **not supported**. A `Reconfigure` `EtcdOpsRequest` carrying it is rejected by the admission webhook.
+- `spec.configuration.configSecret` — **not supported**. Likewise rejected by the `Reconfigure` webhook.
+- `spec.configSecret` (the deprecated top-level field) — present only for structural parity with the other KubeDB databases. It is not mounted into the etcd container and has no effect. Do not use it.
+
+The webhook's rejection message spells it out:
+
+```
+spec.configuration.applyConfig and spec.configuration.configSecret are not supported for Etcd, use spec.configuration.tuning instead
+```
+
+If you need an etcd flag that `tuning` does not cover, use `spec.podTemplate` to set the corresponding `ETCD_*` environment variable, which etcd reads as an alternative to the flag — but be aware that any variable colliding with one KubeDB manages will be overwritten by the operator.
+
+## The tuning knobs
+
+`spec.configuration.tuning` has four fields, each mapping onto exactly one etcd flag:
+
+| Field                     | etcd flag                     | Type     | Default (etcd)          |
+|---------------------------|-------------------------------|----------|-------------------------|
+| `quotaBackendBytes`       | `--quota-backend-bytes`       | integer  | 2 GiB                   |
+| `autoCompactionMode`      | `--auto-compaction-mode`      | enum     | `periodic`              |
+| `autoCompactionRetention` | `--auto-compaction-retention` | string   | `0` (disabled)          |
+| `snapshotCount`           | `--snapshot-count`            | integer  | version dependent       |
+
+Any field you leave unset simply produces no flag, so etcd's own default applies. KubeDB does not fill in defaults of its own here.
+
+### `quotaBackendBytes`
+
+Caps the size of etcd's backend database file (the bbolt file on disk that holds the keyspace and its MVCC history).
+
+This is a **hard limit with a sharp edge**: when the backend grows past the quota, etcd raises a `NOSPACE` alarm and the entire cluster goes **read-only**. Writes are rejected until an operator compacts history, defragments the backend to actually release the space, and then disarms the alarm. It is not a soft warning — it is the mechanism etcd uses to stop a runaway keyspace from filling the disk and corrupting the cluster.
+
+Practical guidance:
+
+- etcd's own default is 2 GiB and upstream recommends staying below 8 GiB. Going much beyond that trades away recovery time: a larger backend means slower startup, slower snapshot transfer to a new member, and longer defragmentation pauses.
+- Set the quota comfortably below the size of the volume in `spec.storage`. The volume also holds the write-ahead log and snapshots, so the backend is not the only thing consuming it.
+- Monitor `etcd_mvcc_db_total_size_in_bytes` against `etcd_server_quota_backend_bytes` and alert well before the ratio reaches 1. See [monitoring](/docs/guides/etcd/monitoring/overview.md).
+
+The value is in **bytes**, so `8589934592` is 8 GiB. Note this is a plain integer, not a Kubernetes `resource.Quantity` — `8Gi` is not accepted here.
+
+### `autoCompactionMode` and `autoCompactionRetention`
+
+etcd is an MVCC store: every write creates a new revision and the old ones are kept, so the keyspace grows even under a workload that only ever updates the same keys. **Compaction** discards revisions older than a chosen point. These two fields configure etcd to do it automatically, in the background, instead of requiring a periodic manual `Compact`.
+
+The two fields work as a pair — the mode determines how the retention string is interpreted:
+
+- `autoCompactionMode: periodic` — `autoCompactionRetention` is a **duration**, and etcd keeps at least that much history. `"1h"` means "discard revisions older than one hour". This is the mode you usually want: it bounds history in the terms you actually care about (how far back can a watch or a lagging client rewind?), regardless of write rate.
+
+- `autoCompactionMode: revision` — `autoCompactionRetention` is a **revision count**. `"1000"` means "keep the last 1000 revisions". This bounds history in terms of writes rather than time, which is useful when your write rate is predictable and you want a hard ceiling on growth.
+
+Leaving `autoCompactionRetention` unset (or `"0"`) disables auto-compaction entirely, which means the keyspace grows without bound until you hit `quotaBackendBytes`. For any long-lived cluster, set it.
+
+> **Compaction alone does not shrink the file on disk.** It frees space *inside* the backend database for reuse, but the file stays the same size. To actually return the space to the filesystem you must defragment — use the `Defragment` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md), which walks the members one at a time (leader last) so the cluster never loses quorum while a member is blocked defragmenting.
+
+### `snapshotCount`
+
+The number of committed transactions after which etcd writes a snapshot of its state to disk and truncates the write-ahead log.
+
+The trade-off is between memory/WAL size and recovery cost:
+
+- A **lower** value snapshots more often. The WAL stays small and a restarting member replays less, but each snapshot costs I/O.
+- A **higher** value snapshots less often. Fewer I/O spikes, but etcd holds more entries in memory, the WAL directory grows larger, and a member that restarts (or a slow follower catching up) has more to replay.
+
+The main reason to raise it is a slow follower: if a follower falls behind by more than `snapshotCount` entries, the leader can no longer send it the missing log entries and has to ship an entire snapshot instead, which is far more expensive. Raising the count widens the window in which cheap log-based catch-up still works.
+
+## Deploy Etcd with a tuning configuration
+
+Below is an `Etcd` object with all four knobs set:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-custom-config
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `quotaBackendBytes: 8589934592` caps the backend at 8 GiB — comfortably below the 10 GiB volume, which also has to hold the WAL and snapshots.
+- `autoCompactionMode: periodic` with `autoCompactionRetention: "1h"` keeps one hour of MVCC history and discards the rest automatically.
+- `snapshotCount: 10000` snapshots every 10,000 committed transactions.
+
+Create it:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/custom-configuration/etcd-custom-config.yaml
+etcd.kubedb.com/etcd-custom-config created
+```
+
+Wait until the cluster is `Ready`:
+
+```bash
+$ kubectl get etcd -n demo etcd-custom-config
+NAME                 VERSION   STATUS   AGE
+etcd-custom-config   3.6.4     Ready    3m
+```
+
+## Verify the configuration was applied
+
+Because the knobs are rendered as command-line flags rather than into a config file, the pod spec itself is the source of truth:
+
+```bash
+$ kubectl get pod -n demo etcd-custom-config-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n'
+["--name=$(POD_NAME)"
+"--data-dir=/var/lib/etcd/data"
+"--initial-advertise-peer-urls=$(ETCD_MEMBER_PEER_URL)"
+"--listen-peer-urls=http://0.0.0.0:2380"
+"--listen-client-urls=http://0.0.0.0:2379"
+"--advertise-client-urls=$(ETCD_MEMBER_CLIENT_URL)"
+"--listen-metrics-urls=http://0.0.0.0:2381"
+"--quota-backend-bytes=8589934592"
+"--auto-compaction-mode=periodic"
+"--auto-compaction-retention=1h"
+"--snapshot-count=10000"]
+```
+
+The tuning flags are appended after the flags KubeDB owns, in the order `quota-backend-bytes`, `auto-compaction-mode`, `auto-compaction-retention`, `snapshot-count`. Any knob you left unset simply does not appear.
+
+You can also confirm the quota from etcd's own metrics endpoint, which is a good end-to-end check that etcd actually accepted the value rather than just that it was passed:
+
+```bash
+$ kubectl exec -it -n demo etcd-custom-config-0 -c etcd -- \
+    curl -s http://127.0.0.1:2381/metrics | grep -E '^etcd_server_quota_backend_bytes|^etcd_mvcc_db_total_size_in_bytes'
+etcd_server_quota_backend_bytes 8.589934592e+09
+etcd_mvcc_db_total_size_in_bytes 2.0480e+04
+```
+
+And the settings are, of course, recorded on the `Etcd` object itself:
+
+```bash
+$ kubectl get etcd -n demo etcd-custom-config -o jsonpath='{.spec.configuration.tuning}'
+{"autoCompactionMode":"periodic","autoCompactionRetention":"1h","quotaBackendBytes":8589934592,"snapshotCount":10000}
+```
+
+## Changing the configuration later
+
+Editing `spec.configuration.tuning` on a live `Etcd` object is **not** the way to change these settings. etcd has no live-reload path for command-line flags — there is no equivalent of PostgreSQL's `pg_reload_conf()` — so a change only takes effect when a member restarts, and restarting an etcd cluster safely requires moving Raft leadership around.
+
+Use a `Reconfigure` `EtcdOpsRequest` instead. It patches the `Etcd` object, re-renders the `PetSet`, and then performs a leader-aware rolling restart — followers first, one at a time with quorum checks in between, and the leader last after handing off its leadership. It also only touches the knobs your request actually names, so a partial reconfigure does not silently reset the others:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: etcd-custom-config
+  configuration:
+    tuning:
+      autoCompactionRetention: "2h"
+```
+
+See the [Reconfigure guide](/docs/guides/etcd/reconfigure/reconfigure.md) for the full walkthrough.
+
+## Cleaning up
+
+```bash
+$ kubectl delete etcd -n demo etcd-custom-config
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Change the tuning knobs on a running cluster with a [Reconfigure EtcdOpsRequest](/docs/guides/etcd/reconfigure/reconfigure.md).
+- Watch the backend size against the quota with [monitoring](/docs/guides/etcd/monitoring/overview.md).
+- Run your etcd cluster with [TLS/SSL encryption](/docs/guides/etcd/tls/configure-ssl.md).
+- Detail concepts of [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/custom-configuration/using-config.md
+++ b/docs/guides/etcd/custom-configuration/using-config.md
@@ -53,15 +53,9 @@ If a user-supplied config file took over, all of those would silently stop being
 So, concretely:
 
 - `spec.configuration.tuning` — **supported**. This is the path described in the rest of this guide.
-- `spec.configuration.applyConfig` — **not supported**. A `Reconfigure` `EtcdOpsRequest` carrying it is rejected by the admission webhook.
-- `spec.configuration.configSecret` — **not supported**. Likewise rejected by the `Reconfigure` webhook.
-- `spec.configSecret` (the deprecated top-level field) — present only for structural parity with the other KubeDB databases. It is not mounted into the etcd container and has no effect. Do not use it.
-
-The webhook's rejection message spells it out:
-
-```
-spec.configuration.applyConfig and spec.configuration.configSecret are not supported for Etcd, use spec.configuration.tuning instead
-```
+- `spec.configuration.applyConfig` — **not supported**. A `Reconfigure` `EtcdOpsRequest` carrying it is rejected by the admission webhook, and the ops-manager refuses it a second time if it ever gets that far. `applyConfig` merges free-form key/value pairs into a rendered config file, and etcd has no such file here — `--config-file` is mutually exclusive with the individual command-line flags KubeDB must set to bootstrap and reconcile membership, so accepting it would silently drop your settings.
+- `spec.configuration.configSecret` — **has no effect**. The field is carried on the `Etcd` object for structural parity with the other KubeDB databases, but the provisioner never mounts it into the etcd container, for the same `--config-file` reason. Do not use it.
+- `spec.configSecret` (the deprecated top-level field) — same story, and likewise inert. Do not use it.
 
 If you need an etcd flag that `tuning` does not cover, there is an escape hatch: pass it verbatim through `spec.podTemplate.spec.containers[name=etcd].args`. See [Extra etcd flags](#extra-etcd-flags) below.
 

--- a/docs/guides/etcd/custom-configuration/using-config.md
+++ b/docs/guides/etcd/custom-configuration/using-config.md
@@ -151,7 +151,7 @@ and `args` on any other entry in the list belongs to a sidecar of your own.
 
 Your flags are appended **after** the ones KubeDB owns, and that ordering is the whole point:
 
-```
+```text
 etcd --name=$(POD_NAME) --data-dir=... --listen-client-urls=... \
      --quota-backend-bytes=8589934592 \
      --heartbeat-interval=250 --election-timeout=2500 --max-request-bytes=3145728
@@ -203,11 +203,15 @@ the members one at a time, leader last, with quorum checks in between.
 Verify the same way as the tuning knobs — the pod spec is the source of truth:
 
 ```bash
-$ kubectl get pod -n demo etcd-extra-args-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n' | tail -3
+$ kubectl get pod -n demo etcd-extra-args-0 -o jsonpath='{.spec.containers[?(@.name=="etcd")].args}' | tr ',' '\n' | tail -3
 "--heartbeat-interval=250"
 "--election-timeout=2500"
 "--max-request-bytes=3145728"]
 ```
+
+Selecting the container by name rather than by index matters here specifically: `spec.podTemplate`
+can carry additional containers of your own, and if one of those sorts before `etcd` in the pod
+spec, `containers[0]` would silently show the wrong container's args.
 
 ## Deploy Etcd with a tuning configuration
 
@@ -323,9 +327,9 @@ See the [Reconfigure guide](/docs/guides/etcd/reconfigure/reconfigure.md) for th
 ## Cleaning up
 
 ```bash
-$ kubectl delete etcd -n demo etcd-custom-config
-$ kubectl delete etcd -n demo etcd-extra-args
-$ kubectl delete ns demo
+kubectl delete etcd -n demo etcd-custom-config
+kubectl delete etcd -n demo etcd-extra-args
+kubectl delete ns demo
 ```
 
 ## Next Steps

--- a/docs/guides/etcd/custom-configuration/using-config.md
+++ b/docs/guides/etcd/custom-configuration/using-config.md
@@ -63,7 +63,7 @@ The webhook's rejection message spells it out:
 spec.configuration.applyConfig and spec.configuration.configSecret are not supported for Etcd, use spec.configuration.tuning instead
 ```
 
-If you need an etcd flag that `tuning` does not cover, use `spec.podTemplate` to set the corresponding `ETCD_*` environment variable, which etcd reads as an alternative to the flag — but be aware that any variable colliding with one KubeDB manages will be overwritten by the operator.
+If you need an etcd flag that `tuning` does not cover, there is an escape hatch: pass it verbatim through `spec.podTemplate.spec.containers[name=etcd].args`. See [Extra etcd flags](#extra-etcd-flags) below.
 
 ## The tuning knobs
 
@@ -116,6 +116,104 @@ The trade-off is between memory/WAL size and recovery cost:
 - A **higher** value snapshots less often. Fewer I/O spikes, but etcd holds more entries in memory, the WAL directory grows larger, and a member that restarts (or a slow follower catching up) has more to replay.
 
 The main reason to raise it is a slow follower: if a follower falls behind by more than `snapshotCount` entries, the leader can no longer send it the missing log entries and has to ship an entire snapshot instead, which is far more expensive. Raising the count widens the window in which cheap log-based catch-up still works.
+
+## Extra etcd flags
+
+`spec.configuration.tuning` is a deliberately small, closed set of knobs. For anything else, you can
+hand etcd raw command-line flags through `spec.podTemplate.spec.containers[name=etcd].args`:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-extra-args
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          args:
+            - --heartbeat-interval=250
+            - --election-timeout=2500
+            - --max-request-bytes=3145728
+  deletionPolicy: WipeOut
+```
+
+The container **must** be named `etcd` — that is the container KubeDB renders the etcd process into,
+and `args` on any other entry in the list belongs to a sidecar of your own.
+
+### Append-after, last-one-wins
+
+Your flags are appended **after** the ones KubeDB owns, and that ordering is the whole point:
+
+```
+etcd --name=$(POD_NAME) --data-dir=... --listen-client-urls=... \
+     --quota-backend-bytes=8589934592 \
+     --heartbeat-interval=250 --election-timeout=2500 --max-request-bytes=3145728
+     ^ operator-owned flags first                     ^ yours last
+```
+
+etcd parses its command line with Go's standard `flag` package, where every value **overwrites**
+rather than accumulates. So a flag given twice is **not an error** — the last occurrence simply wins,
+and the last occurrence is always yours. That makes this an escape hatch rather than merely a
+passthrough: you can override a flag KubeDB set, including one that `spec.configuration.tuning`
+renders.
+
+Which also means you can break the cluster with it. Overriding the flags that carry a member's
+identity or its listeners — `--name`, `--data-dir`, `--initial-advertise-peer-urls`,
+`--advertise-client-urls`, `--listen-peer-urls`, `--listen-client-urls`, `--listen-metrics-urls`, or
+any of the `--cert-file`/`--peer-*` TLS paths when TLS is enabled — will detach the member from the
+cluster KubeDB is reconciling. Do not.
+
+> **Never set `--force-new-cluster` here.** It makes etcd rewrite the member's data directory into a
+> brand new single-member cluster on *every* start, silently discarding the rest of the cluster each
+> time the pod restarts. Rebuilding a cluster from one survivor is a supported operation, but it is a
+> one-shot, gated procedure — use a
+> [RecoverFromQuorumLoss EtcdOpsRequest](/docs/guides/etcd/recover-from-quorum-loss/overview.md),
+> which adds the flag for exactly one boot and then takes it back off.
+
+### Some flags worth knowing
+
+| Flag | Unit | etcd default | What it is for |
+|---|---|---|---|
+| `--heartbeat-interval` | milliseconds | `100` | How often the leader pings followers. Raise it when members are separated by a slow or high-latency network, so a healthy follower is not mistaken for a dead one. Upstream guidance is to set it close to the round-trip time between members. |
+| `--election-timeout` | milliseconds | `1000` | How long a follower waits without a heartbeat before starting an election. **Keep it at least 5× — ideally 10× — the heartbeat interval**, or a slow link will trigger spurious elections and stall writes. etcd rejects values above 50000. |
+| `--max-request-bytes` | bytes | `1572864` (1.5 MiB) | The largest client request etcd will accept. Raise it only if your workload genuinely needs bigger values; large requests raise latency for everyone and count against `quotaBackendBytes` fast. |
+
+The pair in the example above (`250` / `2500`) keeps the recommended 10× ratio while giving members
+on a cross-zone network more slack than the default.
+
+### Applying and verifying
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/custom-configuration/etcd-extra-args.yaml
+etcd.kubedb.com/etcd-extra-args created
+```
+
+The `PetSet` uses an `OnDelete` update strategy, so editing `args` on a live `Etcd` object re-renders
+the `PetSet` but **does not restart the running members** — they keep the flags they booted with.
+Apply the change with a [Restart EtcdOpsRequest](/docs/guides/etcd/restart/restart.md), which rolls
+the members one at a time, leader last, with quorum checks in between.
+
+Verify the same way as the tuning knobs — the pod spec is the source of truth:
+
+```bash
+$ kubectl get pod -n demo etcd-extra-args-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n' | tail -3
+"--heartbeat-interval=250"
+"--election-timeout=2500"
+"--max-request-bytes=3145728"]
+```
 
 ## Deploy Etcd with a tuning configuration
 
@@ -232,6 +330,7 @@ See the [Reconfigure guide](/docs/guides/etcd/reconfigure/reconfigure.md) for th
 
 ```bash
 $ kubectl delete etcd -n demo etcd-custom-config
+$ kubectl delete etcd -n demo etcd-extra-args
 $ kubectl delete ns demo
 ```
 

--- a/docs/guides/etcd/custom-rbac/_index.md
+++ b/docs/guides/etcd/custom-rbac/_index.md
@@ -1,0 +1,12 @@
+---
+title: Run Etcd with Custom RBAC resources
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-custom-rbac
+    name: Custom RBAC
+    parent: etcd-etcd-guides
+    weight: 61
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/etcd/custom-rbac/using-custom-rbac.md
@@ -1,0 +1,314 @@
+---
+title: Run Etcd with Custom RBAC resources
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-custom-rbac-quickstart
+    name: Custom RBAC
+    parent: etcd-custom-rbac
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Using Custom RBAC resources
+
+KubeDB supports finer user control over the role based access permissions provided to an `Etcd`
+cluster. This tutorial shows you how to run an etcd cluster with custom RBAC resources.
+
+## Before You Begin
+
+At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+configured to communicate with your cluster. If you do not already have a cluster, you can create one
+by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+Now, install the KubeDB CLI on your workstation and the KubeDB operator in your cluster following the
+steps [here](/docs/setup/README.md). etcd support is an alpha feature gate, so it must be enabled
+explicitly — pass `--set featureGates.Etcd=true` to the KubeDB Helm chart.
+
+To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: the YAML files used in this tutorial are stored in
+> [docs/examples/etcd/custom-rbac](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/custom-rbac)
+> of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Overview
+
+KubeDB allows users to provide custom RBAC resources — namely a `ServiceAccount`, a `Role` and a
+`RoleBinding` — for an `Etcd` cluster. This is done through the
+`spec.podTemplate.spec.serviceAccountName` field of the `Etcd` CRD.
+
+- If the field is left empty, the KubeDB operator creates a `ServiceAccount` whose name matches the
+  `Etcd` object's name. A `Role` and a `RoleBinding` granting the necessary access permissions are
+  generated automatically for that service account.
+- If a service account name is given but no service account by that name exists, the KubeDB operator
+  creates one, along with the `Role` and `RoleBinding` that grant the necessary permissions.
+- If a service account name is given and a service account by that name already exists, the KubeDB
+  operator uses the existing one. Since that service account is not managed by KubeDB, **you** are
+  responsible for granting it the necessary permissions.
+
+This guide shows how to create a custom `ServiceAccount`, `Role` and `RoleBinding` for an `Etcd`
+cluster named `etcd-quickstart` with the bare minimum access permissions.
+
+## Custom RBAC for Etcd
+
+At first, let's create a `ServiceAccount` in the `demo` namespace.
+
+```bash
+$ kubectl create serviceaccount -n demo my-custom-serviceaccount
+serviceaccount/my-custom-serviceaccount created
+```
+
+It should create a service account.
+
+```yaml
+$ kubectl get serviceaccount -n demo my-custom-serviceaccount -o yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: "2026-08-15T04:23:39Z"
+  name: my-custom-serviceaccount
+  namespace: demo
+  resourceVersion: "21657"
+  uid: b2ec2b05-8292-11e9-8d10-080027a8b217
+```
+
+Now, we need to create a `Role` with the access permissions the `Etcd` cluster named
+`etcd-quickstart` needs.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/custom-rbac/etcd-custom-role.yaml
+role.rbac.authorization.k8s.io/my-custom-role created
+```
+
+Below is the YAML for the `Role` we just created.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: my-custom-role
+  namespace: demo
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - etcd-db
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+```
+
+This permission is required for etcd pods running on PSP enabled clusters.
+
+Now create a `RoleBinding` to bind this `Role` with the service account we created.
+
+```bash
+$ kubectl create rolebinding my-custom-rolebinding --role=my-custom-role --serviceaccount=demo:my-custom-serviceaccount --namespace=demo
+rolebinding.rbac.authorization.k8s.io/my-custom-rolebinding created
+```
+
+It should bind `my-custom-role` and `my-custom-serviceaccount` successfully.
+
+```yaml
+$ kubectl get rolebinding -n demo my-custom-rolebinding -o yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: "2026-08-15T04:25:12Z"
+  name: my-custom-rolebinding
+  namespace: demo
+  resourceVersion: "1405"
+  uid: 123afc02-8297-11e9-8d10-080027a8b217
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: my-custom-role
+subjects:
+- kind: ServiceAccount
+  name: my-custom-serviceaccount
+  namespace: demo
+```
+
+Now, create an `Etcd` object with `spec.podTemplate.spec.serviceAccountName` set to
+`my-custom-serviceaccount`.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/custom-rbac/etcd-custom-db.yaml
+etcd.kubedb.com/etcd-quickstart created
+```
+
+Below is the YAML for the `Etcd` object we just created.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      serviceAccountName: my-custom-serviceaccount
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  deletionPolicy: DoNotTerminate
+```
+
+> The container name in `spec.podTemplate.spec.containers` must be `etcd` — that is the name of the
+> main etcd container in a KubeDB-managed pod.
+
+Now, wait a few minutes. The KubeDB operator will create the necessary PetSet, Services, Secrets and
+so on. Members are brought up one ordinal at a time, so if everything goes well we should end up with
+three running pods.
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-quickstart
+NAME                READY   STATUS    RESTARTS   AGE
+etcd-quickstart-0   1/1     Running   0          5m54s
+etcd-quickstart-1   1/1     Running   0          4m42s
+etcd-quickstart-2   1/1     Running   0          3m31s
+```
+
+Verify that the pods are actually using the custom service account:
+
+```bash
+$ kubectl get pod -n demo etcd-quickstart-0 -o jsonpath='{.spec.serviceAccountName}{"\n"}'
+my-custom-serviceaccount
+```
+
+And that the cluster reached `Ready`:
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart
+NAME              VERSION   STATUS   AGE
+etcd-quickstart   3.6.4     Ready    6m10s
+```
+
+## Reusing a Service Account
+
+An existing service account can be reused by another `Etcd` cluster. No new access permission is
+required to run the new cluster.
+
+Now, create an `Etcd` object named `minute-etcd` using the same service account name
+`my-custom-serviceaccount` in the `spec.podTemplate.spec.serviceAccountName` field.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/custom-rbac/etcd-custom-db-two.yaml
+etcd.kubedb.com/minute-etcd created
+```
+
+Below is the YAML for the `Etcd` object we just created.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: minute-etcd
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 1
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      serviceAccountName: my-custom-serviceaccount
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  deletionPolicy: DoNotTerminate
+```
+
+Now, wait a few minutes. The KubeDB operator will create the necessary PVC, PetSet, Services, Secrets
+and so on. If everything goes well, we should see a pod named `minute-etcd-0`.
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=minute-etcd
+NAME            READY   STATUS    RESTARTS   AGE
+minute-etcd-0   1/1     Running   0          5m52s
+```
+
+> A single-member cluster is a perfectly valid `Etcd` object — etcd has no separate "standalone" mode
+> in KubeDB, `spec.replicas: 1` is all there is to it. It has no fault tolerance, though: use an odd
+> number of members (3 or 5) for anything you care about.
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl patch -n demo etcd/etcd-quickstart -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+etcd.kubedb.com/etcd-quickstart patched
+
+$ kubectl delete -n demo etcd/etcd-quickstart
+etcd.kubedb.com "etcd-quickstart" deleted
+
+$ kubectl patch -n demo etcd/minute-etcd -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+etcd.kubedb.com/minute-etcd patched
+
+$ kubectl delete -n demo etcd/minute-etcd
+etcd.kubedb.com "minute-etcd" deleted
+
+$ kubectl delete -n demo role my-custom-role
+role.rbac.authorization.k8s.io "my-custom-role" deleted
+
+$ kubectl delete -n demo rolebinding my-custom-rolebinding
+rolebinding.rbac.authorization.k8s.io "my-custom-rolebinding" deleted
+
+$ kubectl delete sa -n demo my-custom-serviceaccount
+serviceaccount "my-custom-serviceaccount" deleted
+
+$ kubectl delete ns demo
+namespace "demo" deleted
+```
+
+If you would like to uninstall the KubeDB operator, please follow the steps
+[here](/docs/setup/README.md).
+
+## Next Steps
+
+- Use a [private Docker registry](/docs/guides/etcd/private-registry/using-private-registry.md) to
+  deploy etcd with KubeDB.
+- Back up and restore your etcd cluster with
+  [KubeStash](/docs/guides/etcd/backup/kubestash/overview/index.md).
+- Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+- Monitor your etcd cluster with KubeDB using the
+  [out-of-the-box Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/gitops/_index.md
+++ b/docs/guides/etcd/gitops/_index.md
@@ -1,0 +1,12 @@
+---
+title: GitOps Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-gitops
+    name: GitOps
+    parent: etcd-etcd-guides
+    weight: 120
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/gitops/gitops.md
+++ b/docs/guides/etcd/gitops/gitops.md
@@ -1,0 +1,427 @@
+---
+title: GitOps Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-using-gitops
+    name: GitOps Etcd
+    parent: etcd-gitops
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# GitOps Etcd using the KubeDB GitOps Operator
+
+This guide shows how to use the KubeDB GitOps operator to create an `Etcd` cluster and manage updates
+to it through a GitOps workflow.
+
+## Before You Begin
+
+- You need a Kubernetes cluster with `kubectl` configured to talk to it. If you do not already have
+  one, you can create one with [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install the `KubeDB` operator in your cluster following the steps
+  [here](/docs/setup/README.md). Two extra Helm values are needed for this guide:
+  - `--set kubedb-crd-manager.installGitOpsCRDs=true` to install the GitOps CRDs and enable the
+    GitOps operator.
+  - `--set featureGates.Etcd=true` — etcd support is an alpha feature gate and is off by default.
+
+- Install a GitOps tool such as `ArgoCD` or `FluxCD` and point it at a Git repository. This guide
+  uses `ArgoCD`; you can install it by following the steps
+  [here](https://argo-cd.readthedocs.io/en/stable/getting_started/), and the `argocd` CLI
+  [here](https://argo-cd.readthedocs.io/en/stable/cli_installation/).
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: the YAML files used in this tutorial are stored in
+> [docs/examples/etcd/gitops](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/gitops)
+> of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Register the repository with ArgoCD
+
+### Public repository
+
+```bash
+argocd app create kubedb --repo <repo-url> --path kubedb --dest-server https://kubernetes.default.svc --dest-namespace demo
+```
+
+### Private repository over HTTPS
+
+```bash
+argocd app create kubedb --repo <repo-url> --path kubedb --dest-server https://kubernetes.default.svc --dest-namespace demo --username <username> --password <github-token>
+```
+
+### Private repository over SSH
+
+```bash
+argocd repo add <ssh-repo-url> \
+  --ssh-private-key-path <path-to-private-key>
+
+argocd app create <application-name> \
+  --repo <repository-url> \
+  --path <repository-path> \
+  --dest-server <kubernetes-api-server> \
+  --dest-namespace <target-namespace>
+```
+
+## Create an Etcd cluster using GitOps
+
+Commit the following manifest to your repository:
+
+```yaml
+apiVersion: gitops.kubedb.com/v1alpha1
+kind: Etcd
+metadata:
+  name: ha-etcd
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Lay the repository out like this:
+
+```bash
+$ tree .
+├── kubedb
+    └── etcd.yaml
+
+1 directory, 1 file
+```
+
+Commit and push. ArgoCD syncs the repository and creates the `gitops.kubedb.com/v1alpha1` `Etcd`
+object in the cluster. The gitops operator validates it and creates the actual
+`kubedb.com/v1alpha2` `Etcd` database:
+
+```bash
+$ kubectl get etcds.gitops.kubedb.com,etcds.kubedb.com -n demo
+NAME                             AGE
+etcd.gitops.kubedb.com/ha-etcd   2m11s
+
+NAME                      VERSION   STATUS   AGE
+etcd.kubedb.com/ha-etcd   3.6.4     Ready    2m11s
+```
+
+And the KubeDB provisioner creates the usual offshoot resources for the database. Note there is a
+single container per pod — etcd exposes its own Prometheus metrics on port `2381`, so KubeDB does not
+add an exporter sidecar:
+
+```bash
+$ kubectl get petset,pod,secret,service,appbinding -n demo -l 'app.kubernetes.io/instance=ha-etcd'
+NAME                                   AGE
+petset.apps.k8s.appscode.com/ha-etcd   3m26s
+
+NAME            READY   STATUS    RESTARTS   AGE
+pod/ha-etcd-0   1/1     Running   0          3m26s
+pod/ha-etcd-1   1/1     Running   0          3m04s
+pod/ha-etcd-2   1/1     Running   0          2m42s
+
+NAME                  TYPE                       DATA   AGE
+secret/ha-etcd-auth   kubernetes.io/basic-auth   2      3m29s
+
+NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
+service/ha-etcd        ClusterIP   10.43.169.122   <none>        2379/TCP                     3m29s
+service/ha-etcd-pods   ClusterIP   None            <none>        2379/TCP,2380/TCP,2381/TCP   3m29s
+
+NAME                                         TYPE              VERSION   AGE
+appbinding.appcatalog.appscode.com/ha-etcd   kubedb.com/etcd   3.6.4     3m26s
+```
+
+## Update the cluster using GitOps
+
+Every change below follows the same loop: edit `kubedb/etcd.yaml`, commit, push, let ArgoCD sync, and
+watch the gitops operator turn the drift into an `EtcdOpsRequest`. You never create an OpsRequest
+yourself.
+
+### Scale resources vertically
+
+Change the container resources in `etcd.yaml`:
+
+```yaml
+  podTemplate:
+    spec:
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: 700m
+              memory: 2Gi
+```
+
+Commit and push. The gitops operator detects the resource change and creates a `VerticalScaling`
+`EtcdOpsRequest`:
+
+```bash
+$ kubectl get etcds.gitops.kubedb.com,etcds.kubedb.com,etcdopsrequest -n demo
+NAME                             AGE
+etcd.gitops.kubedb.com/ha-etcd   13m
+
+NAME                      VERSION   STATUS   AGE
+etcd.kubedb.com/ha-etcd   3.6.4     Ready    13m
+
+NAME                                                           TYPE              STATUS        AGE
+etcdopsrequest.ops.kubedb.com/ha-etcd-verticalscaling-i0kr1l    VerticalScaling   Progressing   2s
+```
+
+Once the OpsRequest is `Successful`, verify the change on a pod:
+
+```bash
+$ kubectl get pod -n demo ha-etcd-0 -o json | jq '.spec.containers[0].resources'
+```
+
+> If an `EtcdAutoscaler` with a `spec.compute` section already targets `ha-etcd`, the gitops operator
+> deliberately leaves vertical scaling alone so the two controllers do not fight over the same field.
+
+### Scale the number of members
+
+Change `spec.replicas` from `3` to `5`:
+
+```yaml
+spec:
+  replicas: 5
+```
+
+Commit and push. The gitops operator creates a `HorizontalScaling` `EtcdOpsRequest`:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                             TYPE                STATUS        AGE
+ha-etcd-horizontalscaling-wvxu5x HorizontalScaling   Progressing   6s
+ha-etcd-verticalscaling-i0kr1l   VerticalScaling     Successful    7m54s
+```
+
+The OpsRequest itself just patches the replica count; the provisioner does the careful part. Each new
+ordinal is added to the etcd membership as a **learner** first, catches up with the leader, and is
+only then promoted to a voting member — one membership change per reconcile pass, so quorum is never
+put at risk. That is why members appear one at a time rather than all at once:
+
+```bash
+$ kubectl get pod -n demo -l 'app.kubernetes.io/instance=ha-etcd'
+NAME        READY   STATUS    RESTARTS   AGE
+ha-etcd-0   1/1     Running   0          9m4s
+ha-etcd-1   1/1     Running   0          10m
+ha-etcd-2   1/1     Running   0          9m44s
+ha-etcd-3   1/1     Running   0          2m58s
+ha-etcd-4   1/1     Running   0          2m23s
+```
+
+Scaling down works the same way, in reverse: the highest-ordinal member is removed from the etcd
+membership before the PetSet shrinks.
+
+> Keep the member count odd. etcd tolerates `(N-1)/2` failures, so a 4-member cluster tolerates
+> exactly as many failures as a 3-member one while costing more. The webhook does not reject an even
+> count, but it is not what you want.
+
+### Expand the volume
+
+Increase the storage request:
+
+```yaml
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+```
+
+Commit and push. The gitops operator creates a `VolumeExpansion` `EtcdOpsRequest`:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                            TYPE              STATUS        AGE
+ha-etcd-volumeexpansion-9cx1la  VolumeExpansion   Progressing   4s
+```
+
+Verify once it succeeds:
+
+```bash
+$ kubectl get pvc -n demo -l 'app.kubernetes.io/instance=ha-etcd'
+NAME                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   AGE
+data-ha-etcd-0      Bound    pvc-1a2b3c4d-0000-4a0a-9a3f-6d2b0c8a1e44   2Gi        RWO            41m
+data-ha-etcd-1      Bound    pvc-2b3c4d5e-0000-4a0a-9a3f-6d2b0c8a1e45   2Gi        RWO            40m
+data-ha-etcd-2      Bound    pvc-3c4d5e6f-0000-4a0a-9a3f-6d2b0c8a1e46   2Gi        RWO            40m
+```
+
+> Shrinking the volume is not supported. If the committed request is smaller than the live one, the
+> gitops operator refuses the change with a `downward scaling of volume is not supported` error
+> instead of generating an OpsRequest.
+
+### Reconfigure etcd tuning knobs
+
+Custom configuration for etcd in KubeDB means the typed `spec.configuration.tuning` block, and
+nothing else. Add it:
+
+```yaml
+spec:
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+```
+
+Commit and push. The gitops operator creates a `Reconfigure` `EtcdOpsRequest` carrying the new tuning
+block:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                         TYPE          STATUS        AGE
+ha-etcd-reconfigure-i4r23j   Reconfigure   Progressing   3s
+```
+
+etcd has no live-reload path for these flags, so the `Reconfigure` OpsRequest restarts the members —
+one at a time, moving raft leadership off the leader first, waiting for each pod to become Ready and
+for quorum to be healthy before touching the next.
+
+Removing the `tuning` block from Git generates another `Reconfigure` OpsRequest that resets etcd back
+to the operator defaults.
+
+> `spec.configuration.applyConfig` and `spec.configuration.configSecret` are **not** supported for
+> etcd — the `Reconfigure` webhook rejects them outright. etcd's `--config-file` is mutually
+> exclusive with the individual command line flags KubeDB must set for cluster bootstrap, so only the
+> typed tuning knobs can be reconciled.
+
+### Update the version
+
+Change `spec.version` to another version present in your `EtcdVersion` catalog — for example, from
+`3.5.21` to `3.6.4`:
+
+```yaml
+spec:
+  version: "3.6.4"
+```
+
+Commit and push. The gitops operator creates an `UpdateVersion` `EtcdOpsRequest`:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                           TYPE            STATUS        AGE
+ha-etcd-versionupdate-1wxgt9   UpdateVersion   Progressing   5s
+```
+
+Version updates are constrained: the target must be in the source `EtcdVersion`'s
+`spec.updateConstraints.allowlist`, which means same major, no downgrade, and at most one minor step
+at a time. A target outside that window is rejected by the OpsRequest webhook.
+
+### Rotate credentials and TLS
+
+Changing `spec.authSecret` generates a `RotateAuth` `EtcdOpsRequest`, and changing `spec.tls`
+generates a `ReconfigureTLS` one:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                             TYPE             STATUS       AGE
+ha-etcd-rotate-auth-zot83x       RotateAuth       Successful   170m
+ha-etcd-reconfiguretls-91fseg    ReconfigureTLS   Successful   16m
+```
+
+`RotateAuth` does **not** restart pods — etcd applies password changes live through its own RBAC
+API. `ReconfigureTLS` does require the leader-aware rolling restart, since the certificates are
+mounted files.
+
+### Migrate to another StorageClass
+
+Changing `spec.storage.storageClassName` generates a `StorageMigration` `EtcdOpsRequest`:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                              TYPE               STATUS        AGE
+ha-etcd-storagemigration-p2ku7z   StorageMigration   Progressing   8s
+```
+
+### Fields that trigger a Restart
+
+Two spec sections have no dedicated OpsRequest type and are applied through a `Restart` instead:
+
+- `spec.monitor`
+- `spec.archiver`
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                      TYPE      STATUS        AGE
+ha-etcd-restart-nhjk9u    Restart   Progressing   2s
+```
+
+The `Restart` OpsRequest is leader aware: if the pod being restarted currently holds raft leadership,
+the operator hands leadership off to another healthy, caught-up member first, then recreates pods one
+at a time.
+
+### Fields applied without an OpsRequest
+
+A few fields are cheap and safe to patch straight onto the live `Etcd` object, so no OpsRequest is
+generated for them: `spec.autoOps`, `spec.serviceTemplates`, `spec.halted`, `spec.healthChecker`,
+`spec.deletionPolicy` and `spec.allowedSchemas`.
+
+## Inspect what GitOps did
+
+The wrapper object records its own history:
+
+```bash
+$ kubectl get etcds.gitops.kubedb.com -n demo ha-etcd -o jsonpath='{.status.gitops}' | jq
+{
+  "gitOpsInfo": [
+    {
+      "observedGeneration": 2,
+      "operations": [
+        {
+          "name": "ha-etcd-verticalscaling-i0kr1l",
+          "status": "Successful"
+        }
+      ],
+      "changeRequestStatus": "Current"
+    }
+  ]
+}
+```
+
+`changeRequestStatus` is one of `Pending`, `InProgress`, `Current` or `Failed`.
+
+## Cleanup
+
+```bash
+$ kubectl delete etcds.gitops.kubedb.com -n demo ha-etcd
+$ kubectl delete ns demo
+```
+
+Deleting the wrapper deletes the live `Etcd` object it owns; what happens to the data then depends on
+`spec.deletionPolicy`.
+
+## Next Steps
+
+- Read the [Etcd GitOps Overview](/docs/guides/etcd/gitops/overview.md).
+- Back up and restore your etcd cluster with
+  [KubeStash](/docs/guides/etcd/backup/kubestash/overview/index.md).
+- Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/gitops/gitops.md
+++ b/docs/guides/etcd/gitops/gitops.md
@@ -82,7 +82,7 @@ metadata:
   name: ha-etcd
   namespace: demo
 spec:
-  version: "3.6.4"
+  version: "3.5.21"
   replicas: 3
   storageType: Durable
   storage:
@@ -125,7 +125,7 @@ NAME                             AGE
 etcd.gitops.kubedb.com/ha-etcd   2m11s
 
 NAME                      VERSION   STATUS   AGE
-etcd.kubedb.com/ha-etcd   3.6.4     Ready    2m11s
+etcd.kubedb.com/ha-etcd   3.5.21    Ready    2m11s
 ```
 
 And the KubeDB provisioner creates the usual offshoot resources for the database. Note there is a
@@ -147,10 +147,10 @@ secret/ha-etcd-auth   kubernetes.io/basic-auth   2      3m29s
 
 NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
 service/ha-etcd        ClusterIP   10.43.169.122   <none>        2379/TCP                     3m29s
-service/ha-etcd-pods   ClusterIP   None            <none>        2379/TCP,2380/TCP,2381/TCP   3m29s
+service/ha-etcd-pods   ClusterIP   None            <none>        2379/TCP,2380/TCP   3m29s
 
 NAME                                         TYPE              VERSION   AGE
-appbinding.appcatalog.appscode.com/ha-etcd   kubedb.com/etcd   3.6.4     3m26s
+appbinding.appcatalog.appscode.com/ha-etcd   kubedb.com/etcd   3.5.21    3m26s
 ```
 
 ## Update the cluster using GitOps
@@ -185,7 +185,7 @@ NAME                             AGE
 etcd.gitops.kubedb.com/ha-etcd   13m
 
 NAME                      VERSION   STATUS   AGE
-etcd.kubedb.com/ha-etcd   3.6.4     Ready    13m
+etcd.kubedb.com/ha-etcd   3.5.21    Ready    13m
 
 NAME                                                           TYPE              STATUS        AGE
 etcdopsrequest.ops.kubedb.com/ha-etcd-verticalscaling-i0kr1l    VerticalScaling   Progressing   2s
@@ -304,13 +304,14 @@ etcd has no live-reload path for these flags, so the `Reconfigure` OpsRequest re
 one at a time, moving raft leadership off the leader first, waiting for each pod to become Ready and
 for quorum to be healthy before touching the next.
 
-Removing the `tuning` block from Git generates another `Reconfigure` OpsRequest that resets etcd back
-to the operator defaults.
+Removing the `tuning` block from Git generates another `Reconfigure` OpsRequest that clears the knobs
+again. KubeDB has no defaults of its own for these: an unset knob simply renders no flag, so etcd's
+own built-in default applies.
 
-> `spec.configuration.applyConfig` and `spec.configuration.configSecret` are **not** supported for
-> etcd — the `Reconfigure` webhook rejects them outright. etcd's `--config-file` is mutually
-> exclusive with the individual command line flags KubeDB must set for cluster bootstrap, so only the
-> typed tuning knobs can be reconciled.
+> `spec.configuration.applyConfig` is **not** supported for etcd — the `Reconfigure` webhook rejects
+> it outright — and `spec.configuration.configSecret` is accepted but never mounted. etcd's
+> `--config-file` is mutually exclusive with the individual command line flags KubeDB must set for
+> cluster bootstrap, so only the typed tuning knobs can be reconciled.
 
 ### Update the version
 
@@ -330,9 +331,10 @@ NAME                           TYPE            STATUS        AGE
 ha-etcd-versionupdate-1wxgt9   UpdateVersion   Progressing   5s
 ```
 
-Version updates are constrained: the target must be in the source `EtcdVersion`'s
-`spec.updateConstraints.allowlist`, which means same major, no downgrade, and at most one minor step
-at a time. A target outside that window is rejected by the OpsRequest webhook.
+Version updates are constrained to the same major version, no downgrade, and at most one minor step
+at a time. Those rules are enforced by the ops-manager when the generated `UpdateVersion` request
+starts executing, not at admission — so a target outside that window produces an `EtcdOpsRequest`
+that is created and then reported `Failed`.
 
 ### Rotate credentials and TLS
 

--- a/docs/guides/etcd/gitops/overview.md
+++ b/docs/guides/etcd/gitops/overview.md
@@ -1,0 +1,122 @@
+---
+title: Etcd GitOps Overview
+description: Etcd GitOps Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-gitops-overview
+    name: Overview
+    parent: etcd-gitops
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# GitOps Overview for Etcd
+
+This guide gives you an overview of how the KubeDB `gitops` operator works with `Etcd` clusters
+through the `gitops.kubedb.com/v1alpha1` API.
+
+## Before You Begin
+
+- You should be familiar with the [Etcd](/docs/guides/etcd/concepts/etcd.md) and
+  [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) objects.
+
+## Two objects, one spec
+
+There are two `Etcd` kinds involved, and they are not the same object:
+
+| Kind | API group | Role |
+|---|---|---|
+| `Etcd` | `gitops.kubedb.com/v1alpha1` | The **desired state** you commit to Git. This is the object your GitOps tool applies. |
+| `Etcd` | `kubedb.com/v1alpha2` | The **live database**, created and owned by the gitops operator. |
+
+The wrapper is a thin one: its `spec` is literally the same `EtcdSpec` type as the live `Etcd`
+object, so anything you can write in a `kubedb.com/v1alpha2` `Etcd` you can write in the
+`gitops.kubedb.com/v1alpha1` one, unchanged. The wrapper adds only a `status.gitops` section on top
+of the normal database status.
+
+Because the spec types are identical, the gitops operator runs your object through the same
+defaulting and validation webhook the live `Etcd` object uses **before** it creates anything. An
+invalid spec is rejected up front rather than producing a broken database.
+
+## Workflow
+
+<figure align="center">
+  <img alt="GitOps Flow" src="/docs/images/gitops/gitops.jpg">
+  <figcaption align="center">Fig: GitOps process</figcaption>
+</figure>
+
+1. **Define a GitOps `Etcd`**: write a custom resource of kind `Etcd` using the
+   `gitops.kubedb.com/v1alpha1` API.
+2. **Store it in Git**: push the manifest to your Git repository.
+3. **Automated deployment**: a GitOps tool such as `ArgoCD` or `FluxCD` watches the repository and
+   applies the manifest to your cluster.
+4. **Create the database**: the gitops operator validates the spec and creates the corresponding
+   `kubedb.com/v1alpha2` `Etcd` object, which the KubeDB provisioner then turns into a real cluster.
+5. **Handle updates**: this is the important part — see below.
+
+## Drift becomes an OpsRequest, not a mutation
+
+When you change the committed manifest, the gitops operator does **not** patch the change straight
+onto the live `Etcd` object. Mutating a running etcd cluster's spec in place is exactly how you lose
+quorum. Instead the operator diffs the wrapper against the live database and, for each meaningful
+difference, generates an `EtcdOpsRequest` — the same safe, ordered, quorum-aware machinery you would
+use by hand.
+
+| What you changed in Git | Generated `EtcdOpsRequest` type | Generated name |
+|---|---|---|
+| `spec.podTemplate.spec.containers[etcd].resources`, or `spec.monitor.prometheus.exporter.resources` | `VerticalScaling` | `<name>-verticalscaling-<suffix>` |
+| `spec.replicas` | `HorizontalScaling` | `<name>-horizontalscaling-<suffix>` |
+| `spec.storage.resources.requests.storage` | `VolumeExpansion` | `<name>-volumeexpansion-<suffix>` |
+| `spec.storage.storageClassName` | `StorageMigration` | `<name>-storagemigration-<suffix>` |
+| `spec.configuration.tuning` | `Reconfigure` | `<name>-reconfigure-<suffix>` |
+| `spec.authSecret` | `RotateAuth` | `<name>-rotate-auth-<suffix>` |
+| `spec.tls` | `ReconfigureTLS` | `<name>-reconfiguretls-<suffix>` |
+| `spec.version` | `UpdateVersion` | `<name>-versionupdate-<suffix>` |
+| `spec.monitor` or `spec.archiver` | `Restart` | `<name>-restart-<suffix>` |
+
+The suffix is a random string, so a fresh OpsRequest is created for every change and the history
+stays readable.
+
+A handful of fields are not worth an OpsRequest and are patched onto the live object directly:
+`spec.autoOps`, `spec.serviceTemplates`, `spec.halted`, `spec.healthChecker`, `spec.deletionPolicy`
+and `spec.allowedSchemas`.
+
+Some things you should know about the etcd-specific behaviour:
+
+- **`spec.replicas` scaling goes through the membership state machine.** The generated
+  `HorizontalScaling` OpsRequest is a thin wrapper: it patches the replica count and waits for the
+  provisioner to converge. Scale-up adds the new ordinal as a raft *learner*, waits for it to catch
+  up with the leader, then promotes it. Scale-down removes the highest-ordinal member from the etcd
+  membership *before* the PetSet shrinks. Only one membership mutation happens per reconcile pass.
+- **Shrinking a volume is rejected.** If the committed `spec.storage` request is smaller than the
+  live one, the operator returns an error instead of generating a `VolumeExpansion`.
+- **Custom configuration means `spec.configuration.tuning` only.** etcd's `--config-file` is
+  mutually exclusive with the individual flags KubeDB must set for cluster bootstrap, so there is no
+  free-form config file to reconcile. Removing the `tuning` block from Git generates a `Reconfigure`
+  OpsRequest that resets etcd back to the operator defaults.
+- **Autoscaler wins.** If an `EtcdAutoscaler` in the same namespace targets this database with a
+  `spec.compute` section, the gitops operator will not generate `VerticalScaling` OpsRequests for it;
+  same for `spec.storage` and `VolumeExpansion`. Otherwise the two controllers would fight over the
+  same fields.
+- **The exporter row is structural.** `spec.monitor.prometheus.exporter.resources` maps onto
+  `EtcdVerticalScalingSpec.Exporter`, which exists for parity with other KubeDB databases. etcd
+  serves its own Prometheus metrics natively and KubeDB deploys **no exporter sidecar container**, so
+  there is nothing for those resources to apply to.
+
+## Status
+
+The wrapper's `status` inlines the live database's status (phase, conditions, and so on) and adds a
+`status.gitops` section recording, per observed generation, which OpsRequests were generated and
+where the change request stands — `Pending`, `InProgress`, `Current` or `Failed`.
+
+## Next Steps
+
+- Follow the step-by-step guide in
+  [GitOps Etcd using the KubeDB GitOps Operator](/docs/guides/etcd/gitops/gitops.md).
+- Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/maintenance/_index.md
+++ b/docs/guides/etcd/maintenance/_index.md
@@ -1,0 +1,12 @@
+---
+title: Etcd Maintenance Operations
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-maintenance
+    name: Maintenance Operations
+    parent: etcd-etcd-guides
+    weight: 95
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/maintenance/compact.md
+++ b/docs/guides/etcd/maintenance/compact.md
@@ -1,0 +1,298 @@
+---
+title: Compact Etcd Keyspace History
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-maintenance-compact
+    name: Compact
+    parent: etcd-maintenance
+    weight: 40
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Compact the Keyspace History of an Etcd Cluster
+
+KubeDB supports compacting the keyspace history of an etcd cluster through an `EtcdOpsRequest` of
+type `Compact`. Compaction discards superseded versions of keys, which is what stops a busy
+cluster's MVCC history from growing without bound.
+
+For the background on what a revision is and what compaction throws away, see the
+[Maintenance Operations Overview](/docs/guides/etcd/maintenance/overview.md#compaction).
+
+> **Important:** compaction on its own does **not** shrink anything on disk. It makes the space
+> reusable inside the backend file; returning it to the filesystem requires a
+> [Defragment](/docs/guides/etcd/maintenance/defragment.md) afterwards. Plan for the pair.
+
+## Before You Begin
+
+- At first, you need a Kubernetes cluster, and the `kubectl` command-line tool must be configured
+  to communicate with your cluster. If you do not already have a cluster, you can create one
+  using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install the `KubeDB` Provisioner and Ops-manager operators in your cluster following the steps
+  [here](/docs/setup/README.md). etcd support is behind an alpha feature gate, so make sure the
+  operators are installed with `Etcd=true` enabled (Helm value `featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Maintenance Operations Overview](/docs/guides/etcd/maintenance/overview.md)
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd)
+> folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Wait until the cluster reports `Ready`,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    2m
+```
+
+## Apply the Compact OpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-compact
+  namespace: demo
+spec:
+  type: Compact
+  databaseRef:
+    name: etcd-cluster
+  compact: {}
+  timeout: 5m
+```
+
+- `spec.type` specifies the type of the ops request, here `Compact`.
+- `spec.databaseRef` holds the name of the `Etcd` object. It must live in the same namespace as
+  the ops request.
+- `spec.compact` is **required** for this type, even when it is empty — a `Compact` request
+  without a `spec.compact` block is rejected by the validating webhook. Write `compact: {}` when
+  you have nothing to configure.
+- `spec.compact.revision` is optional. Omitting it, as above, means "compact up to the current
+  revision at execution time": the operator reads the cluster's current revision when the request
+  runs and compacts to that. This is what you want for the routine "reclaim everything that is
+  safe to reclaim right now" case.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/compact.yaml
+etcdopsrequest.ops.kubedb.com/etcd-compact created
+```
+
+### Compacting to a specific revision
+
+If you have consumers that read or watch from a known past revision, compacting to "now" would
+break them — a read below the compacted revision fails with
+`mvcc: required revision has been compacted`. In that case, name the revision explicitly:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-compact-revision
+  namespace: demo
+spec:
+  type: Compact
+  databaseRef:
+    name: etcd-cluster
+  compact:
+    revision: 128000
+  timeout: 5m
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/compact-revision.yaml
+etcdopsrequest.ops.kubedb.com/etcd-compact-revision created
+```
+
+The webhook rejects a negative `revision`. You can find the cluster's current revision — a useful
+starting point for choosing one — from any member:
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- etcdctl \
+    --endpoints=http://etcd-cluster-0.etcd-cluster-pods.demo.svc:2379 \
+    endpoint status -w table
+```
+
+> If the cluster has TLS or authentication enabled, add the corresponding `etcdctl` flags
+> (`--cacert`/`--cert`/`--key`, and `--user`) and use the `https` scheme.
+
+## What the operator does
+
+`Compact` never pauses the `Etcd` object, never patches the PetSet and never restarts a pod.
+
+Unlike defragmentation, compaction is a **cluster-wide** operation: the request goes through Raft
+and is replicated to every member, so the operator issues it exactly **once**, against any member
+it can reach — there is no per-member walk.
+
+The steps are:
+
+1. If `spec.compact.revision` is unset (or not positive), read the cluster's current revision
+   from the header of a linearizable response, and use that.
+2. Call etcd's `Compact` RPC for that revision, with the physical option set — meaning the call
+   only returns once the compaction has actually been applied to the backend, not merely
+   accepted.
+3. Treat "already compacted" as success. If the requested revision has already been compacted by
+   an earlier request or by automatic compaction, the cluster is already in the state you asked
+   for, so the operator records the step as done rather than failing.
+
+## Progress and status
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME           TYPE      STATUS       AGE
+etcd-compact   Compact   Successful   40s
+```
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-compact
+```
+
+The full object looks like this once it has finished:
+
+```yaml
+$ kubectl get etcdopsrequest -n demo etcd-compact -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  creationTimestamp: "2026-02-11T12:02:41Z"
+  generation: 1
+  name: etcd-compact
+  namespace: demo
+  resourceVersion: "68120"
+  uid: 4d1c9a77-6b3e-42fa-9c05-8f1a2b3c4d66
+spec:
+  apply: IfReady
+  compact: {}
+  databaseRef:
+    name: etcd-cluster
+  maxRetries: 1
+  timeout: 5m
+  type: Compact
+status:
+  conditions:
+  - lastTransitionTime: "2026-02-11T12:02:41Z"
+    message: Compacting the etcd keyspace history
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: Running
+  - lastTransitionTime: "2026-02-11T12:02:49Z"
+    message: Successfully compacted the etcd keyspace history
+    observedGeneration: 1
+    reason: EtcdCompacted
+    status: "True"
+    type: EtcdCompacted
+  - lastTransitionTime: "2026-02-11T12:02:50Z"
+    message: Successfully compacted the etcd keyspace history
+    observedGeneration: 1
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+The condition to look for is **`EtcdCompacted`**. Once it is `True`, the compaction has been
+applied cluster-wide and the ops request is marked `Successful`.
+
+## Reclaiming the disk space
+
+At this point the old revisions are gone from the keyspace, but every member's backend file is
+still exactly as large as it was. To actually return that space to the filesystem, follow up with
+a defragmentation:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/defragment.yaml
+etcdopsrequest.ops.kubedb.com/etcd-defragment created
+```
+
+Only one `EtcdOpsRequest` per database can be `Progressing` at a time, so wait for the `Compact`
+request to reach `Successful` before applying the `Defragment` one. See
+[Defragment the backends of an Etcd cluster](/docs/guides/etcd/maintenance/defragment.md) for the
+full walkthrough.
+
+## Automatic compaction
+
+For the routine case you usually do not want to apply an ops request by hand at all. etcd can
+compact on a schedule, and KubeDB exposes that on the `Etcd` object:
+
+```yaml
+spec:
+  configuration:
+    tuning:
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+```
+
+`autoCompactionMode` is `periodic` or `revision`, and `autoCompactionRetention` is interpreted
+accordingly — a duration of history to keep, or a number of revisions. These map directly onto
+etcd's `--auto-compaction-mode` and `--auto-compaction-retention` flags. Changing them on an
+existing cluster is a [Reconfigure](/docs/guides/etcd/reconfigure/reconfigure.md) operation.
+
+With automatic compaction configured, keep the `Compact` ops request for the cases it is good at:
+compacting right now ahead of a defragmentation, or compacting to a revision you have chosen
+deliberately.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-compact
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Defragment the member backends of an Etcd cluster](/docs/guides/etcd/maintenance/defragment.md) —
+  the follow-up that actually frees disk space.
+- [Move the Raft leadership of an Etcd cluster](/docs/guides/etcd/maintenance/move-leader.md).
+- Detail concepts of the [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/maintenance/compact.md
+++ b/docs/guides/etcd/maintenance/compact.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-maintenance-compact
     name: Compact
     parent: etcd-maintenance
-    weight: 40
+    weight: 30
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---
@@ -284,7 +284,7 @@ deliberately.
 To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
-kubectl delete etcdopsrequest -n demo etcd-compact
+kubectl delete etcdopsrequest -n demo etcd-compact etcd-compact-revision etcd-defragment
 kubectl delete etcd -n demo etcd-cluster
 kubectl delete ns demo
 ```

--- a/docs/guides/etcd/maintenance/defragment.md
+++ b/docs/guides/etcd/maintenance/defragment.md
@@ -1,0 +1,301 @@
+---
+title: Defragment Etcd Backends
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-maintenance-defragment
+    name: Defragment
+    parent: etcd-maintenance
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Defragment the Backends of an Etcd Cluster
+
+KubeDB supports defragmenting the backend database file of every etcd member through an
+`EtcdOpsRequest` of type `Defragment`. Defragmentation is what actually returns disk space to the
+operating system after keys have been deleted or the keyspace history has been compacted — etcd
+does not do that on its own.
+
+For the background on why compaction alone does not free disk, see the
+[Maintenance Operations Overview](/docs/guides/etcd/maintenance/overview.md#defragmentation).
+
+## Before You Begin
+
+- At first, you need a Kubernetes cluster, and the `kubectl` command-line tool must be configured
+  to communicate with your cluster. If you do not already have a cluster, you can create one
+  using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install the `KubeDB` Provisioner and Ops-manager operators in your cluster following the steps
+  [here](/docs/setup/README.md). etcd support is behind an alpha feature gate, so make sure the
+  operators are installed with `Etcd=true` enabled (Helm value `featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Maintenance Operations Overview](/docs/guides/etcd/maintenance/overview.md)
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd)
+> folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Wait until the cluster reports `Ready`,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    2m
+```
+
+Before defragmenting, it is worth looking at the current backend sizes so that you have something
+to compare against afterwards. `etcdctl endpoint status` reports each member's `DB SIZE` (the
+size of the file on disk) and `DB SIZE IN USE` (the part of it that holds live data). A large gap
+between the two is exactly what defragmentation removes.
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- etcdctl \
+    --endpoints=http://etcd-cluster-0.etcd-cluster-pods.demo.svc:2379,http://etcd-cluster-1.etcd-cluster-pods.demo.svc:2379,http://etcd-cluster-2.etcd-cluster-pods.demo.svc:2379 \
+    endpoint status -w table
+```
+
+> If the cluster has TLS or authentication enabled, add the corresponding `etcdctl` flags
+> (`--cacert`/`--cert`/`--key`, and `--user`) and use the `https` scheme.
+
+## Apply the Defragment OpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-defragment
+  namespace: demo
+spec:
+  type: Defragment
+  databaseRef:
+    name: etcd-cluster
+  defragment: {}
+```
+
+- `spec.type` specifies the type of the ops request, here `Defragment`.
+- `spec.databaseRef` holds the name of the `Etcd` object. It must live in the same namespace as
+  the ops request.
+- `spec.defragment` carries **no fields**. Defragmentation always applies to every member; there
+  is nothing to select or configure. The empty object `{}` is all you write.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/defragment.yaml
+etcdopsrequest.ops.kubedb.com/etcd-defragment created
+```
+
+### A note on `spec.timeout`
+
+`spec.timeout` is optional here, and it is worth understanding what it does before setting it.
+When it is omitted, a single member's defragmentation is allowed up to 10 minutes and the request
+as a whole up to 20 minutes. When it *is* set, that one value bounds **both** — each individual
+member's defragmentation and the whole walk across all members. On a large backend, a value that
+looks generous for one member can therefore be too tight for three of them in sequence. Unless
+you have a specific reason, leaving `spec.timeout` unset is the safer choice.
+
+## What the operator does
+
+`Defragment` never pauses the `Etcd` object, never patches the PetSet and never restarts a pod.
+It is a sequence of direct RPCs against the running members. The sequencing is the important
+part, because defragmentation **blocks the member it runs against** for its whole duration:
+
+1. **Resolve the leader.** For a multi-member cluster the operator first determines which pod
+   currently holds the Raft leadership.
+2. **Order the members, leader last.** Followers are visited in ordinal order, and the leader is
+   appended at the end. This is the same reason a rolling restart visits the leader last: it
+   keeps the cluster's write path available for as long as possible and avoids provoking an
+   election in the middle of the run.
+3. **Defragment one member at a time.** For each member in turn, the operator opens a client
+   pinned to that member's own endpoint and calls `Defragment` against it. It never issues the
+   call to more than one member concurrently.
+4. **Gate on quorum between members.** After each member finishes, the operator re-checks that
+   the cluster still has quorum before touching the next one. If it does not, the operator waits
+   rather than proceeding — so a cluster that is already degraded does not get pushed over the
+   edge by the defragmentation itself.
+5. **Disarm the alarms.** Once every member has been defragmented, the operator lists the
+   cluster's active alarms and disarms them. This is a genuine, necessary step, not a formality:
+   when a member's backend grows past `--quota-backend-bytes`
+   (`spec.configuration.tuning.quotaBackendBytes`), etcd raises a cluster-wide `NOSPACE` alarm and
+   goes read-only until it is disarmed — and disarming it *before* the space was actually
+   reclaimed would simply re-raise it. Doing it after the defragmentation is what makes the
+   cluster writable again. On a cluster with no active alarms, this step is a harmless no-op.
+
+## Progress and status
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME              TYPE         STATUS       AGE
+etcd-defragment   Defragment   Successful   4m
+```
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-defragment
+```
+
+The full object of a clean run looks like this:
+
+```yaml
+$ kubectl get etcdopsrequest -n demo etcd-defragment -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  creationTimestamp: "2026-02-11T12:20:03Z"
+  generation: 1
+  name: etcd-defragment
+  namespace: demo
+  resourceVersion: "70412"
+  uid: 9c4b7e11-1a26-4d0f-8b70-2e3f4a5b6c77
+spec:
+  apply: IfReady
+  databaseRef:
+    name: etcd-cluster
+  defragment: {}
+  maxRetries: 1
+  type: Defragment
+status:
+  conditions:
+  - lastTransitionTime: "2026-02-11T12:20:03Z"
+    message: Defragmenting the etcd backends
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: Running
+  - lastTransitionTime: "2026-02-11T12:23:47Z"
+    message: Successfully defragmented every etcd member
+    observedGeneration: 1
+    reason: EtcdDefragmented
+    status: "True"
+    type: EtcdDefragmented
+  - lastTransitionTime: "2026-02-11T12:23:52Z"
+    message: Successfully disarmed the etcd alarms
+    observedGeneration: 1
+    reason: EtcdAlarmCleared
+    status: "True"
+    type: EtcdAlarmCleared
+  - lastTransitionTime: "2026-02-11T12:23:53Z"
+    message: Successfully defragmented the etcd cluster
+    observedGeneration: 1
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Two conditions carry the outcome:
+
+- **`EtcdDefragmented`** — every member has been defragmented. This is a single, cluster-wide
+  condition that only flips to `True` after the last member (the leader) is done.
+- **`EtcdAlarmCleared`** — the alarm-disarming step has run.
+
+### Per-member progress conditions
+
+The walk across members also reports progress per member, using the same
+`<ConditionType>--<podName>` shape KubeDB uses elsewhere. These conditions are emitted when a
+step needs more than one attempt — which is common on a large backend, where the member is busy
+being rewritten — so on a small, fast cluster you may not see them at all:
+
+```yaml
+  - lastTransitionTime: "2026-02-11T12:21:11Z"
+    message: 'etcd defragmented; ConditionStatus:True; PodName:etcd-cluster-1'
+    observedGeneration: 1
+    status: "True"
+    type: EtcdDefragmented--etcd-cluster-1
+  - lastTransitionTime: "2026-02-11T12:21:16Z"
+    message: 'etcd cluster healthy; ConditionStatus:True; PodName:etcd-cluster-1'
+    observedGeneration: 1
+    status: "True"
+    type: EtcdClusterHealthy--etcd-cluster-1
+  - lastTransitionTime: "2026-02-11T12:22:30Z"
+    message: 'etcd defragmented; ConditionStatus:True; PodName:etcd-cluster-2'
+    observedGeneration: 1
+    status: "True"
+    type: EtcdDefragmented--etcd-cluster-2
+  - lastTransitionTime: "2026-02-11T12:23:47Z"
+    message: 'etcd defragmented; ConditionStatus:True; PodName:etcd-cluster-0'
+    observedGeneration: 1
+    status: "True"
+    type: EtcdDefragmented--etcd-cluster-0
+```
+
+Reading those in order tells you the walk order the operator chose. In the excerpt above,
+`etcd-cluster-0` was the Raft leader, so it was defragmented last.
+
+## Verify the reclaimed space
+
+Run `endpoint status` again and compare `DB SIZE` with what you recorded before:
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- etcdctl \
+    --endpoints=http://etcd-cluster-0.etcd-cluster-pods.demo.svc:2379,http://etcd-cluster-1.etcd-cluster-pods.demo.svc:2379,http://etcd-cluster-2.etcd-cluster-pods.demo.svc:2379 \
+    endpoint status -w table
+```
+
+`DB SIZE` should now be close to `DB SIZE IN USE` on every member. How much it drops depends
+entirely on how much dead history there was — if you have never compacted, defragmentation has
+little to reclaim, because the old revisions are still live data as far as the backend is
+concerned. Which is the whole point of pairing the two: see
+[Compact](/docs/guides/etcd/maintenance/compact.md).
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-defragment
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Compact the keyspace history of an Etcd cluster](/docs/guides/etcd/maintenance/compact.md) —
+  run this *before* a defragmentation to give it something to reclaim.
+- [Move the Raft leadership of an Etcd cluster](/docs/guides/etcd/maintenance/move-leader.md).
+- Detail concepts of the [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/maintenance/defragment.md
+++ b/docs/guides/etcd/maintenance/defragment.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-maintenance-defragment
     name: Defragment
     parent: etcd-maintenance
-    weight: 30
+    weight: 40
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---
@@ -131,12 +131,15 @@ etcdopsrequest.ops.kubedb.com/etcd-defragment created
 
 ### A note on `spec.timeout`
 
-`spec.timeout` is optional here, and it is worth understanding what it does before setting it.
-When it is omitted, a single member's defragmentation is allowed up to 10 minutes and the request
-as a whole up to 20 minutes. When it *is* set, that one value bounds **both** — each individual
-member's defragmentation and the whole walk across all members. On a large backend, a value that
-looks generous for one member can therefore be too tight for three of them in sequence. Unless
-you have a specific reason, leaving `spec.timeout` unset is the safer choice.
+`spec.timeout` is optional here, and it is worth understanding what it does before setting it. It
+does **not** bound the request as a whole — it is the budget for each individual step, measured from
+the moment that step first reported "not done yet". So on a three member cluster, each member's
+defragmentation and each quorum re-check gets its own full `spec.timeout`.
+
+When `spec.timeout` is omitted, each step gets a default budget of 10 minutes, and the `Defragment`
+RPC issued against a single member is additionally capped at 10 minutes of its own. Unless you have
+a specific reason — a backend large enough that one member takes longer than ten minutes to rewrite —
+leaving `spec.timeout` unset is the safer choice.
 
 ## What the operator does
 
@@ -236,9 +239,11 @@ Two conditions carry the outcome:
 ### Per-member progress conditions
 
 The walk across members also reports progress per member, using the same
-`<ConditionType>--<podName>` shape KubeDB uses elsewhere. These conditions are emitted when a
-step needs more than one attempt — which is common on a large backend, where the member is busy
-being rewritten — so on a small, fast cluster you may not see them at all:
+`<ConditionType>--<podName>` shape KubeDB uses elsewhere. `EtcdDefragmented--<pod>` and
+`EtcdClusterHealthy--<pod>` are written for **every** member on every run — they are what the
+operator reads back to know which members it has already defragmented, so a restart of the operator
+resumes rather than starts over. While a step is still in flight the same condition is present with
+`Status: False`, which is common on a large backend where the member is busy being rewritten:
 
 ```yaml
   - lastTransitionTime: "2026-02-11T12:21:11Z"

--- a/docs/guides/etcd/maintenance/move-leader.md
+++ b/docs/guides/etcd/maintenance/move-leader.md
@@ -248,10 +248,12 @@ The condition to look for is **`EtcdLeaderMoved`**. It flips to `True` once the 
 issued *and* the cluster has confirmed that the requested member holds the leadership; the ops
 request is then marked `Successful`.
 
-If the transfer has to be retried — for example because the cluster was momentarily without a
-leader — you will also see interim conditions from the individual sub-steps, such as `GetLeader`
-and `VerifyLeader`, with messages of the shape `get leader; ConditionStatus:False`. Those are
-progress markers, not failures.
+Alongside it, the individual sub-steps record their own conditions on every run: `GetLeader` (the
+current leader was resolved), `EtcdLeaderMoved--<pod-name>` (the transfer was issued at that
+specific member) and `VerifyLeader` (the cluster confirmed the new leader). They are elided from the
+excerpt above. If a step is still in flight — for example because the cluster is momentarily without
+a leader — the same condition is present with `Status: False` and a message of the shape
+`get leader; ConditionStatus:False`. Those are progress markers, not failures.
 
 ## Verify the new leader
 
@@ -275,7 +277,7 @@ The `IS LEADER` column of that table will show `true` for `etcd-cluster-1`.
 To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
-kubectl delete etcdopsrequest -n demo etcd-move-leader
+kubectl delete etcdopsrequest -n demo etcd-move-leader etcd-move-leader-auto
 kubectl delete etcd -n demo etcd-cluster
 kubectl delete ns demo
 ```

--- a/docs/guides/etcd/maintenance/move-leader.md
+++ b/docs/guides/etcd/maintenance/move-leader.md
@@ -1,0 +1,288 @@
+---
+title: Move Etcd Raft Leadership
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-maintenance-move-leader
+    name: Move Leader
+    parent: etcd-maintenance
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Move the Raft Leadership of an Etcd Cluster
+
+KubeDB supports transferring the Raft leadership of an etcd cluster to another member through an
+`EtcdOpsRequest` of type `MoveLeader`. This is useful when you are about to disturb the node that
+currently hosts the leader — draining it, restarting its pod, replacing the machine — and would
+rather hand leadership over deliberately than let the cluster hold an election after the fact.
+
+For the background on what a leadership transfer is and when to reach for it, see the
+[Maintenance Operations Overview](/docs/guides/etcd/maintenance/overview.md#raft-leadership-transfer).
+
+## Before You Begin
+
+- At first, you need a Kubernetes cluster, and the `kubectl` command-line tool must be configured
+  to communicate with your cluster. If you do not already have a cluster, you can create one
+  using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install the `KubeDB` Provisioner and Ops-manager operators in your cluster following the steps
+  [here](/docs/setup/README.md). etcd support is behind an alpha feature gate, so make sure the
+  operators are installed with `Etcd=true` enabled (Helm value `featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Maintenance Operations Overview](/docs/guides/etcd/maintenance/overview.md)
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd)
+> folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd
+
+A leadership transfer only makes sense with more than one voting member, so we deploy a three
+member cluster.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Wait until the cluster reports `Ready`,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    2m
+```
+
+The members are the ordinal pods of the PetSet, and each member's etcd `--name` is its pod name.
+Those pod names are what you refer to in `spec.moveLeader.newLeader`.
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME             READY   STATUS    RESTARTS   AGE
+etcd-cluster-0   1/1     Running   0          2m
+etcd-cluster-1   1/1     Running   0          2m
+etcd-cluster-2   1/1     Running   0          2m
+```
+
+## Apply the MoveLeader OpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-move-leader
+  namespace: demo
+spec:
+  type: MoveLeader
+  databaseRef:
+    name: etcd-cluster
+  moveLeader:
+    newLeader: etcd-cluster-1
+  timeout: 5m
+```
+
+- `spec.type` specifies the type of the ops request, here `MoveLeader`.
+- `spec.databaseRef` holds the name of the `Etcd` object. It must live in the same namespace as
+  the ops request.
+- `spec.moveLeader.newLeader` names the member that should become the new leader. It accepts the
+  member's pod name (which is also its etcd member name).
+- The meaning of `spec.timeout` and `spec.apply` is described
+  [here](/docs/guides/etcd/concepts/etcdopsrequest.md#spectimeout).
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/move-leader.yaml
+etcdopsrequest.ops.kubedb.com/etcd-move-leader created
+```
+
+### Letting the operator pick the new leader
+
+`spec.moveLeader.newLeader` is optional. If you leave it out, the operator picks the transferee
+itself: it takes the first healthy **voting** member that is not the current leader. Learners are
+never eligible — a learner does not vote and cannot become leader — so a member that is still
+catching up after a scale-up is skipped.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-move-leader-auto
+  namespace: demo
+spec:
+  type: MoveLeader
+  databaseRef:
+    name: etcd-cluster
+  moveLeader: {}
+  timeout: 5m
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/maintenance/move-leader-auto.yaml
+etcdopsrequest.ops.kubedb.com/etcd-move-leader-auto created
+```
+
+Use the explicit form when you care *where* leadership lands (for example, moving it onto a
+member in a different failure domain than the node you are about to drain), and the automatic
+form when you only care that it moves *off* the current leader.
+
+## What the operator does
+
+`MoveLeader` is a pure control-plane operation on the Raft group. It does **not** pause the
+`Etcd` object, does not touch the PetSet, and does not restart or evict any pod — a leadership
+transfer is near instantaneous and does not interrupt the client API.
+
+The steps are:
+
+1. Resolve the current leader. Every member reports the ID of the member it believes is the
+   leader, and that ID is mapped back onto a pod through the member list.
+2. Resolve the transferee from `spec.moveLeader.newLeader`, or pick a healthy voting member if it
+   is empty. If the request names a member that does not exist (or names a learner), the request
+   fails immediately with an error — that is a mistake in the spec, not a transient condition
+   worth retrying.
+3. If the requested member is already the leader, the operator treats the request as satisfied
+   and does nothing.
+4. Issue the transfer. etcd only serves `MoveLeader` on the leader itself, so the operator opens
+   a client pinned to the current leader's own endpoint to make the call.
+5. Verify. The operator re-reads the leader until the cluster agrees that the requested member is
+   now the leader, and only then marks the step done.
+
+## Progress and status
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME               TYPE         STATUS       AGE
+etcd-move-leader   MoveLeader   Successful   35s
+```
+
+You can follow the individual steps through the ops request's conditions and events:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-move-leader
+```
+
+The full object looks like this once it has finished:
+
+```yaml
+$ kubectl get etcdopsrequest -n demo etcd-move-leader -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  creationTimestamp: "2026-02-11T11:04:18Z"
+  generation: 1
+  name: etcd-move-leader
+  namespace: demo
+  resourceVersion: "61240"
+  uid: 3f7a1c02-9d55-4a1e-8f6b-c0a1d2e3f455
+spec:
+  apply: IfReady
+  databaseRef:
+    name: etcd-cluster
+  maxRetries: 1
+  moveLeader:
+    newLeader: etcd-cluster-1
+  timeout: 5m
+  type: MoveLeader
+status:
+  conditions:
+  - lastTransitionTime: "2026-02-11T11:04:18Z"
+    message: Moving the etcd raft leadership
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: Running
+  - lastTransitionTime: "2026-02-11T11:04:24Z"
+    message: Successfully moved the etcd raft leadership
+    observedGeneration: 1
+    reason: EtcdLeaderMoved
+    status: "True"
+    type: EtcdLeaderMoved
+  - lastTransitionTime: "2026-02-11T11:04:25Z"
+    message: Successfully moved the etcd raft leadership
+    observedGeneration: 1
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+The condition to look for is **`EtcdLeaderMoved`**. It flips to `True` once the transfer has been
+issued *and* the cluster has confirmed that the requested member holds the leadership; the ops
+request is then marked `Successful`.
+
+If the transfer has to be retried — for example because the cluster was momentarily without a
+leader — you will also see interim conditions from the individual sub-steps, such as `GetLeader`
+and `VerifyLeader`, with messages of the shape `get leader; ConditionStatus:False`. Those are
+progress markers, not failures.
+
+## Verify the new leader
+
+The `EtcdLeaderMoved` condition is the operator's own confirmation, but you can check
+independently from inside a member pod using `etcdctl`:
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- etcdctl \
+    --endpoints=http://etcd-cluster-0.etcd-cluster-pods.demo.svc:2379,http://etcd-cluster-1.etcd-cluster-pods.demo.svc:2379,http://etcd-cluster-2.etcd-cluster-pods.demo.svc:2379 \
+    endpoint status -w table
+```
+
+The `IS LEADER` column of that table will show `true` for `etcd-cluster-1`.
+
+> If the cluster has TLS or authentication enabled, add the corresponding `etcdctl` flags
+> (`--cacert`/`--cert`/`--key`, and `--user`) and use the `https` scheme. See
+> [Etcd CRD](/docs/guides/etcd/concepts/etcd.md) for where KubeDB mounts those secrets.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-move-leader
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Compact the keyspace history of an Etcd cluster](/docs/guides/etcd/maintenance/compact.md).
+- [Defragment the member backends of an Etcd cluster](/docs/guides/etcd/maintenance/defragment.md).
+- Detail concepts of the [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/maintenance/overview.md
+++ b/docs/guides/etcd/maintenance/overview.md
@@ -1,0 +1,155 @@
+---
+title: Etcd Maintenance Operations Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-maintenance-overview
+    name: Overview
+    parent: etcd-maintenance
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Maintenance Operations
+
+etcd is unlike the other databases KubeDB manages in one important way: it is its own consensus
+layer, and it exposes its housekeeping as first-class RPCs on the cluster API rather than as
+shell commands or SQL. KubeDB surfaces three of those RPCs as `EtcdOpsRequest` types:
+
+| OpsRequest type | etcd RPC      | What it does                                                        |
+| --------------- | ------------- | ------------------------------------------------------------------- |
+| `MoveLeader`    | `MoveLeader`  | Hands Raft leadership to another member, deliberately.              |
+| `Compact`       | `Compact`     | Discards superseded key revisions from the keyspace history.        |
+| `Defragment`    | `Defragment`  | Shrinks the on-disk backend file so the freed pages return to the OS. |
+
+None of these three has an analogue in any other KubeDB database — there is no Postgres-style
+"force failover" or "reconnect standby" step for etcd, because Raft already handles failover on
+its own; what you occasionally want is to *schedule* the handover rather than wait for a failure.
+Likewise there is nothing like `VACUUM FULL` — but etcd's MVCC store has the same
+"deleting data does not free disk" property, which is what compaction and defragmentation
+address together.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## Raft leadership transfer
+
+Every etcd cluster elects one member as the Raft **leader**. The leader is the only member that
+appends new entries to the replicated log; the other members (**followers**) forward writes to it
+and replicate what it commits. Reads are served by any member, but a write always goes through
+the leader.
+
+If the leader disappears — the node is drained, the pod is evicted, the kubelet restarts — the
+remaining members notice the missing heartbeats, hold an election, and pick a new leader. That
+works, but it is not free: for the duration of the election timeout plus the campaign, there is
+no leader, and writes fail or block.
+
+A **leadership transfer** avoids that gap. The current leader tells a chosen follower "you take
+over now", the follower campaigns immediately with an up-to-date log, and the handover completes
+in roughly a round trip instead of an election timeout.
+
+You would use `MoveLeader` when you are about to do something disruptive to the node that
+currently hosts the leader, and you want to choose the moment yourself:
+
+- Before cordoning or draining a Kubernetes node for maintenance.
+- Before deliberately deleting or restarting the leader's pod.
+- To move leadership off a member that sits on a saturated or badly-placed node.
+
+Note that KubeDB already does this for you inside the operations it drives itself: a
+[Restart](/docs/guides/etcd/restart/restart.md), a `VerticalScaling` in `Restart` mode and the
+other rolling operations all move leadership off the leader before recreating its pod, and they
+visit the leader last. `MoveLeader` exists for the times when *you* are the one about to disturb
+the node.
+
+Read the guide: [Move the Raft leadership of an Etcd cluster](/docs/guides/etcd/maintenance/move-leader.md).
+
+## Compaction
+
+etcd is a multi-version store. Every write creates a new **revision** of the keyspace, and the
+older revisions are kept so that watches can be resumed from a past point and so that historical
+reads work. That history is not a rounding error — a workload that repeatedly overwrites the same
+few keys still accumulates one revision per write, forever, until something removes them.
+
+**Compaction** is that something. Compacting to revision *N* discards every superseded version of
+every key at revisions below *N*, keeping only the newest value of each key at or before *N*.
+Live data is never lost; only history is. After compaction, reads and watches at revisions below
+*N* fail with `mvcc: required revision has been compacted` — which is why you should not compact
+to "now" while a consumer is deliberately reading a lagging revision.
+
+etcd can compact on its own if you configure automatic compaction. In KubeDB, that is
+`spec.configuration.tuning.autoCompactionMode` (`periodic` or `revision`) together with
+`spec.configuration.tuning.autoCompactionRetention` on the `Etcd` object, which map onto etcd's
+own `--auto-compaction-mode` and `--auto-compaction-retention` flags. The `Compact`
+`EtcdOpsRequest` is the on-demand counterpart, for when you want to reclaim history right now, or
+at a precise revision.
+
+Read the guide: [Compact the keyspace history of an Etcd cluster](/docs/guides/etcd/maintenance/compact.md).
+
+## Defragmentation
+
+Here is the part that surprises people: **compaction alone does not shrink anything on disk.**
+
+Each etcd member stores its data in a bbolt file. When compaction drops old revisions, the pages
+those revisions occupied are marked free *inside* that file and become available for etcd to
+reuse — but the file itself keeps its size, and the operating system never sees the space come
+back. Over a long-lived cluster with a churny keyspace, the gap between "logical data size" and
+"backend file size" can become large.
+
+**Defragmentation** closes that gap. It rewrites a member's backend into a compact form and
+releases the freed space back to the filesystem. Two properties matter operationally:
+
+- It is a **per-member, local** operation. Unlike compaction, it does not go through Raft. Each
+  member has to be defragmented individually, and each ends up with its own file size.
+- It **blocks the member it runs against** for the whole duration. The member stops answering
+  while its backend is being rewritten, which on a large backend can take a while.
+
+That second property is why KubeDB never fires defragmentation at the whole cluster at once. The
+`Defragment` `EtcdOpsRequest` walks the members strictly one at a time, re-checking that the
+cluster still has quorum before moving on to the next one, and it defragments the leader last.
+
+Defragmentation also matters for a specific failure mode. When a member's backend exceeds
+`--quota-backend-bytes` (`spec.configuration.tuning.quotaBackendBytes`), etcd raises a cluster-wide
+`NOSPACE` alarm and refuses further writes until the alarm is disarmed. Disarming the alarm
+before actually reclaiming the space just re-raises it, so the correct order is compact, then
+defragment, then disarm — which is exactly what the `Defragment` ops request does as its final
+step.
+
+Read the guide: [Defragment the backends of an Etcd cluster](/docs/guides/etcd/maintenance/defragment.md).
+
+## Putting them together
+
+The three operations are commonly used as a sequence rather than in isolation:
+
+1. **`Compact`** — make the old revisions eligible for reuse.
+2. **`Defragment`** — actually return the freed space to the filesystem, and clear any alarm the
+   full backend had raised.
+3. **`MoveLeader`** — optional, and generally used the other way around: as preparation for
+   node-level maintenance rather than as a follow-up.
+
+A useful mental model: compaction decides *what data is allowed to go away*, defragmentation
+decides *when the disk space comes back*, and leadership transfer decides *which member is in
+charge while you work on the cluster*.
+
+Some practical guidance:
+
+- These three ops requests never pause the `Etcd` object, never patch the PetSet and never
+  restart a pod. They are pure control-plane calls against the running cluster.
+- Only one `EtcdOpsRequest` per database can be in the `Progressing` phase at a time, so run them
+  one after the other rather than applying all three at once.
+- Compaction and defragmentation both add load. Schedule them when the cluster is not at its
+  busiest, and prefer automatic compaction (`spec.configuration.tuning`) for the routine case,
+  reserving the ops requests for on-demand work.
+
+## Next Steps
+
+- [Move the Raft leadership](/docs/guides/etcd/maintenance/move-leader.md).
+- [Compact the keyspace history](/docs/guides/etcd/maintenance/compact.md).
+- [Defragment the member backends](/docs/guides/etcd/maintenance/defragment.md).
+- Detail concepts of the [Etcd object](/docs/guides/etcd/concepts/etcd.md).

--- a/docs/guides/etcd/monitoring/_index.md
+++ b/docs/guides/etcd/monitoring/_index.md
@@ -1,0 +1,12 @@
+---
+title: Monitoring Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-monitoring-guides
+    name: Monitoring
+    parent: etcd-etcd-guides
+    weight: 105
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/monitoring/overview.md
+++ b/docs/guides/etcd/monitoring/overview.md
@@ -25,7 +25,7 @@ This is the one thing to understand before you read any further, because it diff
 
 For PostgreSQL, MySQL, MongoDB and friends, KubeDB injects a **Prometheus exporter sidecar** into the database pod. The sidecar connects to the database, translates its statistics into Prometheus text format, and serves them on its own port.
 
-**etcd needs none of that.** etcd is written in Go and instrumented with the Prometheus client library directly, so it already speaks Prometheus natively. There is **no exporter sidecar container** in an etcd member pod — the pod contains a single `etcd` container (plus an `etcd-init` init container that does not survive startup). When you enable `spec.monitor`, KubeDB does not add anything to the pod at all; it only creates the Kubernetes objects that let a Prometheus server find the metrics etcd is already serving.
+**etcd needs none of that.** etcd is written in Go and instrumented with the Prometheus client library directly, so it already speaks Prometheus natively. There is **no exporter sidecar container** in an etcd member pod — the pod contains a single operator-managed `etcd` container and nothing else. When you enable `spec.monitor`, KubeDB does not add anything to the pod at all; it only creates the Kubernetes objects that let a Prometheus server find the metrics etcd is already serving.
 
 Practically, that means:
 
@@ -52,14 +52,14 @@ The container port is declared as `metrics` (`2381`) alongside `client` (`2379`)
 
 Keeping metrics on their own listener is deliberate. etcd also serves `/metrics` on the client port, but once TLS is enabled KubeDB renders `--client-cert-auth=true`, and a client that cannot present a certificate — kubelet running a readiness probe, or a Prometheus server that has not been given one — would be rejected there. The dedicated listener stays plain HTTP, so probes and scraping keep working unchanged after you turn TLS on. Note the consequence: **enabling `spec.tls` does not encrypt the metrics endpoint.** If your Prometheus server and your etcd cluster are in different trust domains, use a NetworkPolicy or a service mesh to control access to port `2381`.
 
-> When `spec.monitor` is set on a TLS-enabled `Etcd`, KubeDB does issue a certificate under the `metrics-exporter` alias (secret `<db-name>-metrics-exporter-cert`). The metrics listener itself is served over plain HTTP as described above, so the stats Service and the generated `ServiceMonitor` are configured with `scheme: http`.
+> KubeDB deliberately does **not** issue a `metrics-exporter` certificate for etcd. The alias is accepted by the `Etcd` schema, and defaulting even stamps an entry for it into `spec.tls.certificates`, but nothing ever creates or mounts that Secret — etcd's `--listen-metrics-urls` has no TLS flags of its own, so the listener is plain HTTP by design. The stats Service and the generated `ServiceMonitor` are therefore configured with `scheme: http`.
 
 ## The stats Service
 
 When `spec.monitor.agent` is a Prometheus agent, KubeDB creates a second Service next to the regular client Service, named `<etcd-crd-name>-stats`:
 
 - It selects the same pods as the client Service.
-- It publishes a single port named `metrics`, whose port number is `spec.monitor.prometheus.exporter.port` (default `56790`), targeting etcd's own metrics port on the pod.
+- It publishes a single port named `metrics`, whose port number is `spec.monitor.prometheus.exporter.port` (default `2381`), targeting etcd's own metrics port on the pod.
 - It is labelled with the standard KubeDB offshoot labels plus `kubedb.com/role: stats`, which is what a `ServiceMonitor` selects on.
 
 Everything else depends on which agent you chose.
@@ -69,7 +69,7 @@ Everything else depends on which agent you chose.
 | Field                                              | Type       | Uses                                                                                                                                    |
 |----------------------------------------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | `spec.monitor.agent`                               | `Required` | The monitoring agent. Either `prometheus.io/builtin` or `prometheus.io/operator`.                                                          |
-| `spec.monitor.prometheus.exporter.port`            | `Optional` | Port number published by the stats Service. Defaults to `56790`. (For etcd this is only the Service port — there is no exporter process.)  |
+| `spec.monitor.prometheus.exporter.port`            | `Optional` | Port number published by the stats Service. Defaults to `2381`. (For etcd this is only the Service port — there is no exporter process.)  |
 | `spec.monitor.prometheus.serviceMonitor.labels`    | `Optional` | Labels put on the generated `ServiceMonitor`, so your `Prometheus` object's `serviceMonitorSelector` matches it.                           |
 | `spec.monitor.prometheus.serviceMonitor.interval`  | `Optional` | Scrape interval on the generated `ServiceMonitor`.                                                                                        |
 
@@ -83,7 +83,7 @@ KubeDB annotates the stats Service so that a plain Prometheus server doing Kuber
 prometheus.io/scrape: "true"
 prometheus.io/scheme: http
 prometheus.io/path: /metrics
-prometheus.io/port: "56790"
+prometheus.io/port: "2381"
 monitoring.appscode.com/agent: prometheus.io/builtin
 ```
 

--- a/docs/guides/etcd/monitoring/overview.md
+++ b/docs/guides/etcd/monitoring/overview.md
@@ -1,0 +1,145 @@
+---
+title: Etcd Monitoring Overview
+description: Etcd Monitoring Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-monitoring-overview
+    name: Overview
+    parent: etcd-monitoring-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring Etcd with KubeDB
+
+KubeDB has native support for monitoring via [Prometheus](https://prometheus.io/). You can use the builtin [Prometheus](https://github.com/prometheus/prometheus) scraper or the [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator) to monitor a KubeDB-managed etcd cluster.
+
+## etcd is its own exporter
+
+This is the one thing to understand before you read any further, because it differs from almost every other database KubeDB manages.
+
+For PostgreSQL, MySQL, MongoDB and friends, KubeDB injects a **Prometheus exporter sidecar** into the database pod. The sidecar connects to the database, translates its statistics into Prometheus text format, and serves them on its own port.
+
+**etcd needs none of that.** etcd is written in Go and instrumented with the Prometheus client library directly, so it already speaks Prometheus natively. There is **no exporter sidecar container** in an etcd member pod — the pod contains a single `etcd` container (plus an `etcd-init` init container that does not survive startup). When you enable `spec.monitor`, KubeDB does not add anything to the pod at all; it only creates the Kubernetes objects that let a Prometheus server find the metrics etcd is already serving.
+
+Practically, that means:
+
+- `kubectl get pod` shows `1/1`, not `2/2`, on a monitored etcd member.
+- The `spec.monitor.prometheus.exporter` sub-fields that configure a sidecar — `args`, `env`, `resources`, `securityContext` — have **no effect** for etcd, because there is no container for them to configure. Only `spec.monitor.prometheus.exporter.port` is meaningful: it is the port number that the stats Service publishes.
+- There is no exporter container to size, so a `VerticalScaling` `EtcdOpsRequest` has nothing to do with `spec.verticalScaling.exporter` either. That field exists in the API for structural parity with the other databases.
+
+## Where the metrics come from
+
+Every etcd member is started with a dedicated metrics listener:
+
+```
+--listen-metrics-urls=http://0.0.0.0:2381
+```
+
+This is a separate socket from the client API (`2379`) and the Raft peer channel (`2380`). It serves two paths:
+
+| Path       | Purpose                                                                                                   |
+|------------|-----------------------------------------------------------------------------------------------------------|
+| `/metrics` | The Prometheus exposition endpoint. This is what gets scraped.                                             |
+| `/health`  | etcd's own health handler. KubeDB points the pod's readiness probe at it.                                  |
+
+The container port is declared as `metrics` (`2381`) alongside `client` (`2379`) and `peer` (`2380`).
+
+Keeping metrics on their own listener is deliberate. etcd also serves `/metrics` on the client port, but once TLS is enabled KubeDB renders `--client-cert-auth=true`, and a client that cannot present a certificate — kubelet running a readiness probe, or a Prometheus server that has not been given one — would be rejected there. The dedicated listener stays plain HTTP, so probes and scraping keep working unchanged after you turn TLS on. Note the consequence: **enabling `spec.tls` does not encrypt the metrics endpoint.** If your Prometheus server and your etcd cluster are in different trust domains, use a NetworkPolicy or a service mesh to control access to port `2381`.
+
+> When `spec.monitor` is set on a TLS-enabled `Etcd`, KubeDB does issue a certificate under the `metrics-exporter` alias (secret `<db-name>-metrics-exporter-cert`). The metrics listener itself is served over plain HTTP as described above, so the stats Service and the generated `ServiceMonitor` are configured with `scheme: http`.
+
+## The stats Service
+
+When `spec.monitor.agent` is a Prometheus agent, KubeDB creates a second Service next to the regular client Service, named `<etcd-crd-name>-stats`:
+
+- It selects the same pods as the client Service.
+- It publishes a single port named `metrics`, whose port number is `spec.monitor.prometheus.exporter.port` (default `56790`), targeting etcd's own metrics port on the pod.
+- It is labelled with the standard KubeDB offshoot labels plus `kubedb.com/role: stats`, which is what a `ServiceMonitor` selects on.
+
+Everything else depends on which agent you chose.
+
+## Configure Monitoring
+
+| Field                                              | Type       | Uses                                                                                                                                    |
+|----------------------------------------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `spec.monitor.agent`                               | `Required` | The monitoring agent. Either `prometheus.io/builtin` or `prometheus.io/operator`.                                                          |
+| `spec.monitor.prometheus.exporter.port`            | `Optional` | Port number published by the stats Service. Defaults to `56790`. (For etcd this is only the Service port — there is no exporter process.)  |
+| `spec.monitor.prometheus.serviceMonitor.labels`    | `Optional` | Labels put on the generated `ServiceMonitor`, so your `Prometheus` object's `serviceMonitorSelector` matches it.                           |
+| `spec.monitor.prometheus.serviceMonitor.interval`  | `Optional` | Scrape interval on the generated `ServiceMonitor`.                                                                                        |
+
+`spec.monitor.prometheus.exporter.args`, `.env`, `.resources` and `.securityContext` are accepted by the schema (the type is shared across all KubeDB databases) but have no effect for etcd — see above.
+
+### `prometheus.io/builtin`
+
+KubeDB annotates the stats Service so that a plain Prometheus server doing Kubernetes service-endpoint discovery picks it up:
+
+```
+prometheus.io/scrape: "true"
+prometheus.io/scheme: http
+prometheus.io/path: /metrics
+prometheus.io/port: "56790"
+monitoring.appscode.com/agent: prometheus.io/builtin
+```
+
+No CRD is involved. See [Monitor Etcd using builtin Prometheus](/docs/guides/etcd/monitoring/using-builtin-prometheus.md).
+
+### `prometheus.io/operator`
+
+KubeDB additionally creates a `ServiceMonitor` named `<etcd-crd-name>-stats`, **in the same namespace as the `Etcd` object**, selecting the stats Service. See [Monitor Etcd using Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+
+## Sample Configuration
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-monitoring
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+  deletionPolicy: WipeOut
+```
+
+## What you get to look at
+
+Because the metrics come from etcd itself rather than from a third-party exporter, you get upstream etcd's own metric names — the same ones the etcd documentation and community dashboards use. A few that are worth an alert:
+
+| Metric                                    | Why it matters                                                                                                                              |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `etcd_server_has_leader`                  | `1` if this member sees a leader, `0` if it does not. A `0` anywhere means that member cannot serve writes; `0` everywhere means quorum is lost. |
+| `etcd_server_leader_changes_seen_total`   | Cumulative leader elections. A rising counter means instability — usually disk or network latency.                                             |
+| `etcd_mvcc_db_total_size_in_bytes`        | Current backend database size. Compare it against the quota below.                                                                            |
+| `etcd_server_quota_backend_bytes`         | The configured `--quota-backend-bytes`. When the size metric approaches this, etcd is heading for a `NOSPACE` alarm and read-only mode.        |
+| `etcd_disk_wal_fsync_duration_seconds`    | WAL fsync latency histogram. etcd is unusually sensitive to slow disks; this is the first thing to check when elections start happening.       |
+| `etcd_disk_backend_commit_duration_seconds` | Backend commit latency histogram.                                                                                                           |
+| `etcd_network_peer_round_trip_time_seconds` | Raft peer RTT histogram, labelled `To`. Useful for spotting one bad member.                                                                 |
+
+The backend-size-versus-quota pair is the one most worth wiring an alert to, because hitting the quota puts the cluster into a read-only alarm state that needs manual intervention. See [custom configuration](/docs/guides/etcd/custom-configuration/using-config.md) for how to set the quota and the auto-compaction policy, and the `Compact`/`Defragment` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) types for reclaiming space.
+
+## Next Steps
+
+- Monitor your etcd cluster with KubeDB using [builtin Prometheus](/docs/guides/etcd/monitoring/using-builtin-prometheus.md).
+- Monitor your etcd cluster with KubeDB using the [Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+- Detail concepts of [Etcd object](/docs/guides/etcd/concepts/etcd.md).

--- a/docs/guides/etcd/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/etcd/monitoring/using-builtin-prometheus.md
@@ -1,0 +1,379 @@
+---
+title: Monitor Etcd using Builtin Prometheus Discovery
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-using-builtin-prometheus-monitoring
+    name: Builtin Prometheus
+    parent: etcd-monitoring-guides
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring Etcd with builtin Prometheus
+
+This tutorial shows how to monitor a KubeDB-managed etcd cluster with a plain [Prometheus](https://github.com/prometheus/prometheus) server — no Prometheus operator, no CRDs, just annotation-based service discovery.
+
+> **Read this first:** unlike most KubeDB databases, etcd has **no exporter sidecar**. etcd serves Prometheus metrics natively on its own metrics listener at port `2381`. When you set `spec.monitor`, KubeDB adds nothing to the pod; it only creates and annotates a stats `Service` so Prometheus can find what etcd is already serving. See the [monitoring overview](/docs/guides/etcd/monitoring/overview.md).
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the operator was installed with `--set featureGates.Etcd=true`.
+
+- If you are not familiar with how to configure Prometheus to scrape metrics from Kubernetes resources, please read the tutorial [here](https://github.com/appscode/third-party-tools/tree/master/monitoring/prometheus/builtin).
+
+- To learn how Prometheus monitoring works with KubeDB in general, please visit [here](/docs/guides/etcd/monitoring/overview.md).
+
+- To keep Prometheus resources isolated, we are going to use a separate namespace called `monitoring` for the monitoring stack, and deploy the database in `demo`.
+
+  ```bash
+  $ kubectl create ns monitoring
+  namespace/monitoring created
+
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd with Monitoring Enabled
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: builtin-prom-etcd
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/builtin
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.monitor.agent: prometheus.io/builtin` tells KubeDB to annotate the stats Service for annotation-based discovery.
+
+Create it:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/monitoring/builtin-prom-etcd.yaml
+etcd.kubedb.com/builtin-prom-etcd created
+```
+
+Wait for the cluster to become `Ready`:
+
+```bash
+$ kubectl get etcd -n demo builtin-prom-etcd
+NAME                VERSION   STATUS   AGE
+builtin-prom-etcd   3.6.4     Ready    2m
+```
+
+Note the member pods report `1/1`, not `2/2` — there is no exporter container:
+
+```bash
+$ kubectl get pod -n demo -l app.kubernetes.io/instance=builtin-prom-etcd
+NAME                  READY   STATUS    RESTARTS   AGE
+builtin-prom-etcd-0   1/1     Running   0          2m
+builtin-prom-etcd-1   1/1     Running   0          2m
+builtin-prom-etcd-2   1/1     Running   0          2m
+```
+
+## The stats Service
+
+KubeDB creates a separate stats Service named `{Etcd crd name}-stats`:
+
+```bash
+$ kubectl get svc -n demo --selector="app.kubernetes.io/instance=builtin-prom-etcd"
+NAME                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+builtin-prom-etcd         ClusterIP   10.102.7.190     <none>        2379/TCP            2m
+builtin-prom-etcd-pods    ClusterIP   None             <none>        2379/TCP,2380/TCP   2m
+builtin-prom-etcd-stats   ClusterIP   10.102.128.153   <none>        56790/TCP           2m
+```
+
+Let's describe the stats Service:
+
+```bash
+$ kubectl describe svc -n demo builtin-prom-etcd-stats
+Name:              builtin-prom-etcd-stats
+Namespace:         demo
+Labels:            app.kubernetes.io/component=database
+                   app.kubernetes.io/instance=builtin-prom-etcd
+                   app.kubernetes.io/managed-by=kubedb.com
+                   app.kubernetes.io/name=etcds.kubedb.com
+                   kubedb.com/role=stats
+Annotations:       monitoring.appscode.com/agent: prometheus.io/builtin
+                   prometheus.io/path: /metrics
+                   prometheus.io/port: 56790
+                   prometheus.io/scheme: http
+                   prometheus.io/scrape: true
+Selector:          app.kubernetes.io/instance=builtin-prom-etcd,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=etcds.kubedb.com
+Type:              ClusterIP
+IP:                10.102.128.153
+Port:              metrics  56790/TCP
+TargetPort:        metrics/TCP
+Endpoints:         10.244.1.7:2381,10.244.2.9:2381,10.244.3.5:2381
+Session Affinity:  None
+Events:            <none>
+```
+
+The annotations that matter for discovery are:
+
+```bash
+prometheus.io/scrape: true
+prometheus.io/scheme: http
+prometheus.io/path: /metrics
+prometheus.io/port: 56790
+```
+
+The Prometheus server will discover the Service endpoints using these and scrape metrics **straight from etcd** — the `TargetPort: metrics` resolves to port `2381` on each member pod. Note there is one endpoint per member: each etcd member reports its own view of the cluster, so scraping all of them is the point.
+
+`prometheus.io/scheme` is `http` even if you have TLS enabled on the cluster, because the metrics listener is a separate socket from the mutually authenticated client API. See the [monitoring overview](/docs/guides/etcd/monitoring/overview.md) for why.
+
+## Configure Prometheus Server
+
+Now we have to configure a Prometheus scraping job to scrape metrics using this Service. We are going to configure a scraping job similar to this [kubernetes-service-endpoints](https://github.com/appscode/third-party-tools/tree/master/monitoring/prometheus/builtin#kubernetes-service-endpoints) job that scrapes metrics from the endpoints of a service.
+
+```yaml
+- job_name: 'kubedb-databases'
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+  # by default Prometheus server selects all Kubernetes services as possible targets.
+  # relabel_config is used to filter only the desired endpoints
+  relabel_configs:
+  # keep only those services that have the "prometheus.io/scrape" and "prometheus.io/port" annotations
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape, __meta_kubernetes_service_annotation_prometheus_io_port]
+    separator: ;
+    regex: true;(.*)
+    action: keep
+  # KubeDB stats services use the "http" scheme, so drop any service that uses "https".
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    action: drop
+    regex: https
+  # only keep the stats services created by KubeDB for monitoring purposes, which have a "-stats" suffix
+  - source_labels: [__meta_kubernetes_service_name]
+    separator: ;
+    regex: (.*-stats)
+    action: keep
+  # services created by KubeDB have the "app.kubernetes.io/name" label. keep only those services.
+  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+    separator: ;
+    regex: (.*)
+    action: keep
+  # read the metric path from the "prometheus.io/path: <path>" annotation
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+  # read the port from the "prometheus.io/port: <port>" annotation and update the scraping address accordingly
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+)(?::\d+)?;(\d+)
+    replacement: $1:$2
+  # add the service namespace as a label on the scraped metrics
+  - source_labels: [__meta_kubernetes_namespace]
+    separator: ;
+    regex: (.*)
+    target_label: namespace
+    replacement: $1
+    action: replace
+  # add the service name as a label on the scraped metrics
+  - source_labels: [__meta_kubernetes_service_name]
+    separator: ;
+    regex: (.*)
+    target_label: service
+    replacement: $1
+    action: replace
+  # add the pod name as a label, so you can tell which etcd member a sample came from
+  - source_labels: [__meta_kubernetes_pod_name]
+    separator: ;
+    regex: (.*)
+    target_label: pod
+    replacement: $1
+    action: replace
+  # add the stats service's labels to the scraped metrics
+  - action: labelmap
+    regex: __meta_kubernetes_service_label_(.+)
+```
+
+The `pod` relabeling rule at the end is worth keeping for etcd specifically: every member is scraped separately and reports its own view of the cluster, so without a `pod` label you cannot tell which member reported `etcd_server_has_leader 0`.
+
+### Configure Existing Prometheus Server
+
+If you already have a Prometheus server running, add the scraping job above to the `ConfigMap` used to configure it, then restart it for the updated configuration to take effect.
+
+> If you don't use a persistent volume for Prometheus storage, you will lose your previously scraped data on restart.
+
+### Deploy New Prometheus Server
+
+If you don't have a Prometheus server yet, deploy one in the `monitoring` namespace to collect metrics using this stats Service.
+
+**Create ConfigMap:**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  labels:
+    app: prometheus-demo
+  namespace: monitoring
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+    - job_name: 'kubedb-databases'
+      honor_labels: true
+      scheme: http
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape, __meta_kubernetes_service_annotation_prometheus_io_port]
+        separator: ;
+        regex: true;(.*)
+        action: keep
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: drop
+        regex: https
+      - source_labels: [__meta_kubernetes_service_name]
+        separator: ;
+        regex: (.*-stats)
+        action: keep
+      - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+        separator: ;
+        regex: (.*)
+        action: keep
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      - source_labels: [__meta_kubernetes_namespace]
+        separator: ;
+        regex: (.*)
+        target_label: namespace
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_service_name]
+        separator: ;
+        regex: (.*)
+        target_label: service
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_name]
+        separator: ;
+        regex: (.*)
+        target_label: pod
+        replacement: $1
+        action: replace
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/monitoring/prom-config.yaml
+configmap/prometheus-config created
+```
+
+**Create RBAC:**
+
+If you are using an RBAC-enabled cluster, give Prometheus the necessary permissions:
+
+```bash
+$ kubectl apply -f https://github.com/appscode/third-party-tools/raw/master/monitoring/prometheus/builtin/artifacts/rbac.yaml
+clusterrole.rbac.authorization.k8s.io/prometheus created
+serviceaccount/prometheus created
+clusterrolebinding.rbac.authorization.k8s.io/prometheus created
+```
+
+> YAML for the RBAC resources created above can be found [here](https://github.com/appscode/third-party-tools/blob/master/monitoring/prometheus/builtin/artifacts/rbac.yaml).
+
+**Deploy Prometheus:**
+
+```bash
+$ kubectl apply -f https://github.com/appscode/third-party-tools/raw/master/monitoring/prometheus/builtin/artifacts/deployment.yaml
+deployment.apps/prometheus created
+```
+
+## Verify Monitoring Metrics
+
+Prometheus listens on port `9090`. Use [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) to reach its dashboard.
+
+```bash
+$ kubectl get pod -n monitoring -l=app=prometheus
+NAME                          READY   STATUS    RESTARTS   AGE
+prometheus-8568c86d86-95zhn   1/1     Running   0          77s
+```
+
+```bash
+$ kubectl port-forward -n monitoring prometheus-8568c86d86-95zhn 9090
+Forwarding from 127.0.0.1:9090 -> 9090
+```
+
+Open [http://localhost:9090/targets](http://localhost:9090/targets). Under the `kubedb-databases` job you should see **three** targets — one per etcd member — each with an address ending in `:2381`, and each carrying the `service="builtin-prom-etcd-stats"`, `namespace="demo"` and `pod="builtin-prom-etcd-N"` labels.
+
+Now try a few queries on the graph page. These are upstream etcd's own metric names, since etcd is doing the exporting:
+
+```promql
+# 1 for every member that currently sees a leader. Any 0 here is a problem.
+etcd_server_has_leader
+
+# Current backend database size, per member.
+etcd_mvcc_db_total_size_in_bytes
+
+# How close the backend is to its configured --quota-backend-bytes.
+etcd_mvcc_db_total_size_in_bytes / etcd_server_quota_backend_bytes
+
+# Leader elections over the last hour. Should be flat in a healthy cluster.
+increase(etcd_server_leader_changes_seen_total[1h])
+```
+
+You can also use this Prometheus server as a data source for [Grafana](https://grafana.com/). KubeDB does not ship a Grafana dashboard for etcd, but since these are upstream etcd metric names, community etcd dashboards work as-is.
+
+## Cleaning up
+
+```bash
+$ kubectl delete etcd -n demo builtin-prom-etcd
+
+$ kubectl delete -n monitoring deployment.apps/prometheus
+$ kubectl delete -n monitoring configmap/prometheus-config
+
+$ kubectl delete clusterrole.rbac.authorization.k8s.io/prometheus
+$ kubectl delete -n monitoring serviceaccount/prometheus
+$ kubectl delete clusterrolebinding.rbac.authorization.k8s.io/prometheus
+
+$ kubectl delete ns demo
+$ kubectl delete ns monitoring
+```
+
+## Next Steps
+
+- Monitor your etcd cluster with KubeDB using the [`out-of-the-box` Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+- Run your etcd cluster with [TLS/SSL encryption](/docs/guides/etcd/tls/configure-ssl.md).
+- Tune the backend quota and compaction policy with [custom configuration](/docs/guides/etcd/custom-configuration/using-config.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/etcd/monitoring/using-builtin-prometheus.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-using-builtin-prometheus-monitoring
     name: Builtin Prometheus
     parent: etcd-monitoring-guides
-    weight: 20
+    weight: 15
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---
@@ -104,7 +104,7 @@ $ kubectl get svc -n demo --selector="app.kubernetes.io/instance=builtin-prom-et
 NAME                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
 builtin-prom-etcd         ClusterIP   10.102.7.190     <none>        2379/TCP            2m
 builtin-prom-etcd-pods    ClusterIP   None             <none>        2379/TCP,2380/TCP   2m
-builtin-prom-etcd-stats   ClusterIP   10.102.128.153   <none>        56790/TCP           2m
+builtin-prom-etcd-stats   ClusterIP   10.102.128.153   <none>        2381/TCP           2m
 ```
 
 Let's describe the stats Service:
@@ -120,13 +120,13 @@ Labels:            app.kubernetes.io/component=database
                    kubedb.com/role=stats
 Annotations:       monitoring.appscode.com/agent: prometheus.io/builtin
                    prometheus.io/path: /metrics
-                   prometheus.io/port: 56790
+                   prometheus.io/port: 2381
                    prometheus.io/scheme: http
                    prometheus.io/scrape: true
 Selector:          app.kubernetes.io/instance=builtin-prom-etcd,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=etcds.kubedb.com
 Type:              ClusterIP
 IP:                10.102.128.153
-Port:              metrics  56790/TCP
+Port:              metrics  2381/TCP
 TargetPort:        metrics/TCP
 Endpoints:         10.244.1.7:2381,10.244.2.9:2381,10.244.3.5:2381
 Session Affinity:  None
@@ -139,7 +139,7 @@ The annotations that matter for discovery are:
 prometheus.io/scrape: true
 prometheus.io/scheme: http
 prometheus.io/path: /metrics
-prometheus.io/port: 56790
+prometheus.io/port: 2381
 ```
 
 The Prometheus server will discover the Service endpoints using these and scrape metrics **straight from etcd** — the `TargetPort: metrics` resolves to port `2381` on each member pod. Note there is one endpoint per member: each etcd member reports its own view of the cluster, so scraping all of them is the point.

--- a/docs/guides/etcd/monitoring/using-prometheus-operator.md
+++ b/docs/guides/etcd/monitoring/using-prometheus-operator.md
@@ -1,0 +1,315 @@
+---
+title: Monitor Etcd using Prometheus Operator
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-using-prometheus-operator-monitoring
+    name: Prometheus Operator
+    parent: etcd-monitoring-guides
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring Etcd Using Prometheus operator
+
+[Prometheus operator](https://github.com/prometheus-operator/prometheus-operator) provides a simple and Kubernetes-native way to deploy and configure a Prometheus server. This tutorial shows how to use it to monitor an etcd cluster deployed with KubeDB.
+
+> **Read this first:** unlike most KubeDB databases, etcd has **no exporter sidecar**. etcd serves Prometheus metrics natively on its own metrics listener at port `2381`. KubeDB only creates the stats `Service` and the `ServiceMonitor` that point at it — nothing is added to the pod. See the [monitoring overview](/docs/guides/etcd/monitoring/overview.md).
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the operator was installed with `--set featureGates.Etcd=true`.
+
+- To learn how Prometheus monitoring works with KubeDB in general, please visit [here](/docs/guides/etcd/monitoring/overview.md).
+
+- We need a [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator) instance running. If you don't already have one, deploy it following the docs [here](https://github.com/appscode/third-party-tools/blob/master/monitoring/prometheus/operator/README.md).
+
+- If you don't already have a Prometheus server running, deploy one following the tutorial [here](https://github.com/appscode/third-party-tools/blob/master/monitoring/prometheus/operator/README.md#deploy-prometheus-server).
+
+- To keep Prometheus resources isolated, we are going to use a separate namespace called `monitoring` for the monitoring stack, and deploy the database in `demo`.
+
+  ```bash
+  $ kubectl create ns monitoring
+  namespace/monitoring created
+
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Find out required labels for ServiceMonitor
+
+We need to know which labels a `Prometheus` object uses to select `ServiceMonitor` objects, so we can ask KubeDB to put those labels on the `ServiceMonitor` it generates.
+
+```bash
+$ kubectl get prometheus --all-namespaces
+NAMESPACE    NAME         AGE
+monitoring   prometheus   18m
+```
+
+```yaml
+$ kubectl get prometheus -n monitoring prometheus -o yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    prometheus: prometheus
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    matchLabels:
+      release: prometheus
+  serviceMonitorNamespaceSelector: {}
+```
+
+Notice `spec.serviceMonitorSelector`: the `release: prometheus` label is what selects a `ServiceMonitor`, so we will pass it through `spec.monitor.prometheus.serviceMonitor.labels`.
+
+> **Watch the namespace selector.** KubeDB creates the `ServiceMonitor` in the **same namespace as the `Etcd` object** — `demo` here, not `monitoring`. Your `Prometheus` object therefore needs a `serviceMonitorNamespaceSelector` that includes `demo` (an empty selector, as above, matches all namespaces). If yours is restricted to the `monitoring` namespace, the target will silently never appear.
+
+## Deploy Etcd with Monitoring Enabled
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: prom-etcd
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.monitor.agent: prometheus.io/operator` tells KubeDB to create a `ServiceMonitor`.
+- `spec.monitor.prometheus.serviceMonitor.labels` are the labels KubeDB puts on that `ServiceMonitor`.
+- `spec.monitor.prometheus.serviceMonitor.interval` is the scrape interval written onto the generated endpoint.
+
+Let's create it:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/monitoring/prom-etcd.yaml
+etcd.kubedb.com/prom-etcd created
+```
+
+Wait for the cluster to become `Ready`:
+
+```bash
+$ kubectl get etcd -n demo prom-etcd
+NAME        VERSION   STATUS   AGE
+prom-etcd   3.6.4     Ready    2m
+```
+
+Note that the member pods report `1/1` containers, not `2/2` — there is no exporter sidecar:
+
+```bash
+$ kubectl get pod -n demo -l app.kubernetes.io/instance=prom-etcd
+NAME          READY   STATUS    RESTARTS   AGE
+prom-etcd-0   1/1     Running   0          2m
+prom-etcd-1   1/1     Running   0          2m
+prom-etcd-2   1/1     Running   0          2m
+```
+
+The single container exposes three ports, of which `metrics` is the one we care about here:
+
+```bash
+$ kubectl get pod -n demo prom-etcd-0 -o jsonpath='{.spec.containers[0].ports}'
+[{"containerPort":2379,"name":"client","protocol":"TCP"},{"containerPort":2380,"name":"peer","protocol":"TCP"},{"containerPort":2381,"name":"metrics","protocol":"TCP"}]
+```
+
+## The stats Service
+
+KubeDB creates a separate stats Service named `{Etcd crd name}-stats`:
+
+```bash
+$ kubectl get svc -n demo --selector="app.kubernetes.io/instance=prom-etcd"
+NAME              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+prom-etcd         ClusterIP   10.102.7.190     <none>        2379/TCP            2m
+prom-etcd-pods    ClusterIP   None             <none>        2379/TCP,2380/TCP   2m
+prom-etcd-stats   ClusterIP   10.102.128.153   <none>        56790/TCP           2m
+```
+
+Here, `prom-etcd` is the load-balanced client Service, `prom-etcd-pods` is the headless governing Service that gives each member its ordinal DNS name, and `prom-etcd-stats` is the monitoring Service. Let's describe it:
+
+```bash
+$ kubectl describe svc -n demo prom-etcd-stats
+Name:              prom-etcd-stats
+Namespace:         demo
+Labels:            app.kubernetes.io/component=database
+                   app.kubernetes.io/instance=prom-etcd
+                   app.kubernetes.io/managed-by=kubedb.com
+                   app.kubernetes.io/name=etcds.kubedb.com
+                   kubedb.com/role=stats
+Annotations:       monitoring.appscode.com/agent: prometheus.io/operator
+Selector:          app.kubernetes.io/instance=prom-etcd,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=etcds.kubedb.com
+Type:              ClusterIP
+IP:                10.102.128.153
+Port:              metrics  56790/TCP
+TargetPort:        metrics/TCP
+Endpoints:         10.244.1.7:2381,10.244.2.9:2381,10.244.3.5:2381
+Session Affinity:  None
+Events:            <none>
+```
+
+Two things to notice:
+
+- The Service port is `56790` (the default `spec.monitor.prometheus.exporter.port`) but the **target port is `metrics`**, which resolves to `2381` on the pod — etcd's own metrics listener. There is no intermediate exporter process; Prometheus talks to etcd directly.
+- The endpoint list has one address **per member**. Each etcd member reports its own view of the cluster, so `etcd_server_has_leader` is a per-member metric and the whole point is to scrape all three.
+
+## The generated ServiceMonitor
+
+```bash
+$ kubectl get servicemonitor -n demo
+NAME              AGE
+prom-etcd-stats   2m
+```
+
+> The `ServiceMonitor` lives in `demo`, the database's namespace — not in `monitoring`.
+
+```yaml
+$ kubectl get servicemonitor -n demo prom-etcd-stats -o yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: prom-etcd
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: etcds.kubedb.com
+    release: prometheus
+  name: prom-etcd-stats
+  namespace: demo
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Service
+    name: prom-etcd-stats
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    path: /metrics
+    port: metrics
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_endpoint_address_target_name
+      targetLabel: pod
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - demo
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/instance: prom-etcd
+      app.kubernetes.io/managed-by: kubedb.com
+      app.kubernetes.io/name: etcds.kubedb.com
+      kubedb.com/role: stats
+```
+
+Here,
+
+- `labels` includes `release: prometheus`, exactly what we asked for in the `Etcd` CRD — that is what makes the `Prometheus` object adopt this `ServiceMonitor`.
+- `selector.matchLabels` matches the labels on the `prom-etcd-stats` Service, including `kubedb.com/role: stats`.
+- `endpoints[0].port: metrics` refers to the **Service port name**, not a number.
+- `scheme: http` — the metrics listener is plain HTTP even when `spec.tls` is enabled on the cluster, because it is a separate socket from the mutually authenticated client API. There is no `tlsConfig` on the endpoint.
+- The `relabelings` entry copies the pod name onto a `pod` label, so you can tell which member a sample came from.
+- The `ServiceMonitor` is owned by the stats Service, so deleting the `Etcd` object garbage-collects it.
+
+## Verify Monitoring Metrics
+
+Find the Prometheus pod:
+
+```bash
+$ kubectl get pod -n monitoring -l=app=prometheus
+NAME                      READY   STATUS    RESTARTS   AGE
+prometheus-prometheus-0   3/3     Running   1          63m
+```
+
+Forward its port:
+
+```bash
+$ kubectl port-forward -n monitoring prometheus-prometheus-0 9090
+Forwarding from 127.0.0.1:9090 -> 9090
+```
+
+Open [http://localhost:9090/targets](http://localhost:9090/targets). You should see three targets under the `serviceMonitor/demo/prom-etcd-stats/0` job — one per member — all `UP`, each with an address ending in `:2381`.
+
+Now try a few queries on the graph page:
+
+```promql
+# 1 for every member that currently sees a leader. Any 0 here is a problem.
+etcd_server_has_leader
+
+# How close the backend is to its quota. Alert well before this reaches 1.
+etcd_mvcc_db_total_size_in_bytes / etcd_server_quota_backend_bytes
+
+# Elections over the last hour. Should be flat in a healthy cluster.
+increase(etcd_server_leader_changes_seen_total[1h])
+
+# 99th percentile WAL fsync latency, per member.
+histogram_quantile(0.99, sum by (le, pod) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])))
+```
+
+Because the scrape hits each member individually, the `pod` label added by the relabeling rule lets you break any of these down per member — which is how you spot a single slow disk before it starts causing elections.
+
+You can also use this Prometheus server as a data source for [Grafana](https://grafana.com/). KubeDB does not ship a Grafana dashboard for etcd, but since these are upstream etcd metric names, the community etcd dashboards work as-is.
+
+## Cleaning up
+
+```bash
+# cleanup database
+$ kubectl delete etcd -n demo prom-etcd
+
+# cleanup prometheus resources
+$ kubectl delete -n monitoring prometheus prometheus
+$ kubectl delete -n monitoring clusterrolebinding prometheus
+$ kubectl delete -n monitoring clusterrole prometheus
+$ kubectl delete -n monitoring serviceaccount prometheus
+$ kubectl delete -n monitoring service prometheus-operated
+
+# cleanup prometheus operator resources
+$ kubectl delete -n monitoring deployment prometheus-operator
+$ kubectl delete -n monitoring serviceaccount prometheus-operator
+$ kubectl delete clusterrolebinding prometheus-operator
+$ kubectl delete clusterrole prometheus-operator
+
+# delete namespaces
+$ kubectl delete ns monitoring
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Monitor your etcd cluster with KubeDB using [builtin Prometheus](/docs/guides/etcd/monitoring/using-builtin-prometheus.md).
+- Run your etcd cluster with [TLS/SSL encryption](/docs/guides/etcd/tls/configure-ssl.md).
+- Tune the backend quota and compaction policy with [custom configuration](/docs/guides/etcd/custom-configuration/using-config.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/monitoring/using-prometheus-operator.md
+++ b/docs/guides/etcd/monitoring/using-prometheus-operator.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-using-prometheus-operator-monitoring
     name: Prometheus Operator
     parent: etcd-monitoring-guides
-    weight: 15
+    weight: 20
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---
@@ -152,7 +152,7 @@ $ kubectl get svc -n demo --selector="app.kubernetes.io/instance=prom-etcd"
 NAME              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
 prom-etcd         ClusterIP   10.102.7.190     <none>        2379/TCP            2m
 prom-etcd-pods    ClusterIP   None             <none>        2379/TCP,2380/TCP   2m
-prom-etcd-stats   ClusterIP   10.102.128.153   <none>        56790/TCP           2m
+prom-etcd-stats   ClusterIP   10.102.128.153   <none>        2381/TCP           2m
 ```
 
 Here, `prom-etcd` is the load-balanced client Service, `prom-etcd-pods` is the headless governing Service that gives each member its ordinal DNS name, and `prom-etcd-stats` is the monitoring Service. Let's describe it:
@@ -170,7 +170,7 @@ Annotations:       monitoring.appscode.com/agent: prometheus.io/operator
 Selector:          app.kubernetes.io/instance=prom-etcd,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=etcds.kubedb.com
 Type:              ClusterIP
 IP:                10.102.128.153
-Port:              metrics  56790/TCP
+Port:              metrics  2381/TCP
 TargetPort:        metrics/TCP
 Endpoints:         10.244.1.7:2381,10.244.2.9:2381,10.244.3.5:2381
 Session Affinity:  None
@@ -179,7 +179,7 @@ Events:            <none>
 
 Two things to notice:
 
-- The Service port is `56790` (the default `spec.monitor.prometheus.exporter.port`) but the **target port is `metrics`**, which resolves to `2381` on the pod — etcd's own metrics listener. There is no intermediate exporter process; Prometheus talks to etcd directly.
+- The Service port is `2381` (the default `spec.monitor.prometheus.exporter.port` for etcd) and the **target port is `metrics`**, which also resolves to `2381` on the pod — etcd's own metrics listener. There is no intermediate exporter process; Prometheus talks to etcd directly.
 - The endpoint list has one address **per member**. Each etcd member reports its own view of the cluster, so `etcd_server_has_leader` is a per-member metric and the whole point is to scrape all three.
 
 ## The generated ServiceMonitor

--- a/docs/guides/etcd/private-registry/_index.md
+++ b/docs/guides/etcd/private-registry/_index.md
@@ -1,0 +1,12 @@
+---
+title: Run Etcd using Private Registry
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-private-registry
+    name: Private Registry
+    parent: etcd-etcd-guides
+    weight: 62
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/private-registry/using-private-registry.md
+++ b/docs/guides/etcd/private-registry/using-private-registry.md
@@ -1,0 +1,201 @@
+---
+title: Run Etcd using Private Registry
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-private-registry-quickstart
+    name: Quickstart
+    parent: etcd-private-registry
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Using a private Docker registry
+
+The KubeDB operator supports using a private Docker registry. This tutorial shows you how to use
+KubeDB to run an `Etcd` cluster from private Docker images.
+
+## Before You Begin
+
+- Read the [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) concept to learn the details of
+  the `EtcdVersion` catalog object.
+
+- You need a Kubernetes cluster with `kubectl` configured to talk to it. If you do not already have a
+  cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- You will also need a private Docker [registry](https://docs.docker.com/registry/) or
+  [private repository](https://docs.docker.com/docker-hub/repos/#private-repositories).
+
+- You have to push the required images into your private registry. For etcd, push the `DB_IMAGE` of
+  every `EtcdVersion` where `deprecated` is not `true`:
+
+  ```bash
+  $ kubectl get etcdversions -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,DEPRECATED:.spec.deprecated
+  NAME     VERSION   DB_IMAGE                                  DEPRECATED
+  3.5.21   3.5.21    ghcr.io/appscode-images/etcd:v3.5.21      <none>
+  3.6.4    3.6.4     ghcr.io/appscode-images/etcd:v3.6.4       <none>
+  ```
+
+  `EtcdVersion` also carries a `spec.exporter.image`. For etcd it is set to the same etcd image,
+  because **KubeDB does not deploy a separate metrics exporter sidecar** — etcd serves its own
+  Prometheus metrics natively on port `2381`. There is no extra image to mirror for monitoring.
+
+- Update the KubeDB catalog to point at your private Docker registry. For example:
+
+  ```yaml
+  apiVersion: catalog.kubedb.com/v1alpha1
+  kind: EtcdVersion
+  metadata:
+    name: 3.6.4
+  spec:
+    version: 3.6.4
+    db:
+      image: PRIVATE_REGISTRY/etcd:v3.6.4
+    exporter:
+      image: PRIVATE_REGISTRY/etcd:v3.6.4
+    securityContext:
+      runAsUser: 1000
+    updateConstraints:
+      allowlist:
+        - '>= 3.6.4, <= 3.7.0'
+  ```
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`:
+
+  ```bash
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> Note: the YAML files used in this tutorial are stored in
+> [docs/examples/etcd/private-registry](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/private-registry)
+> of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Create ImagePullSecret
+
+An `imagePullSecret` is a Kubernetes `Secret` whose sole purpose is to pull private images from a
+Docker registry. It holds the URL of the registry and the credentials to log into it.
+
+Run the following command, substituting the appropriate uppercase values, to create an image pull
+secret for your private Docker registry:
+
+```bash
+$ kubectl create secret docker-registry -n demo myregistrykey \
+  --docker-server=DOCKER_REGISTRY_SERVER \
+  --docker-username=DOCKER_USER \
+  --docker-email=DOCKER_EMAIL \
+  --docker-password=DOCKER_PASSWORD
+secret/myregistrykey created
+```
+
+If you wish to follow other ways to pull private images, see the
+[official Kubernetes docs](https://kubernetes.io/docs/concepts/containers/images/).
+
+## Install the KubeDB operator
+
+When installing the KubeDB operator, set the `--docker-registry` and `--image-pull-secret` flags to
+the appropriate values so that the operator's own images also come from your registry. Follow the
+steps to [install the KubeDB operator](/docs/setup/README.md).
+
+etcd support is an alpha feature gate, so it must be enabled explicitly as well — pass
+`--set featureGates.Etcd=true` to the KubeDB Helm chart.
+
+## Deploy Etcd from the private registry
+
+While deploying an `Etcd` cluster from a private repository, add the `myregistrykey` secret to
+`spec.podTemplate.spec.imagePullSecrets`. Below is the `Etcd` object we will create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-pvt-reg
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      imagePullSecrets:
+        - name: myregistrykey
+      containers:
+        - name: etcd
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+  deletionPolicy: WipeOut
+```
+
+Now run the command to deploy this `Etcd` object:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/private-registry/etcd-pvt-reg.yaml
+etcd.kubedb.com/etcd-pvt-reg created
+```
+
+To check whether the images were pulled successfully, watch the pods come up. KubeDB brings the
+members up one ordinal at a time, waiting for each to become Ready before starting the next:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-pvt-reg -w
+NAME             READY   STATUS              RESTARTS   AGE
+etcd-pvt-reg-0   0/1     ContainerCreating   0          18s
+etcd-pvt-reg-0   1/1     Running             0          32s
+etcd-pvt-reg-1   1/1     Running             0          58s
+etcd-pvt-reg-2   1/1     Running             0          84s
+
+$ kubectl get etcd -n demo etcd-pvt-reg
+NAME           VERSION   STATUS   AGE
+etcd-pvt-reg   3.6.4     Ready    2m5s
+```
+
+If the images could not be pulled, the pods stay in `ImagePullBackOff` and the reason is visible in
+the pod events:
+
+```bash
+$ kubectl describe pod -n demo etcd-pvt-reg-0
+```
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl patch -n demo etcd/etcd-pvt-reg -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+etcd.kubedb.com/etcd-pvt-reg patched
+
+$ kubectl delete -n demo etcd/etcd-pvt-reg
+etcd.kubedb.com "etcd-pvt-reg" deleted
+
+$ kubectl delete -n demo secret myregistrykey
+secret "myregistrykey" deleted
+
+$ kubectl delete ns demo
+namespace "demo" deleted
+```
+
+## Next Steps
+
+- Run etcd with [custom RBAC resources](/docs/guides/etcd/custom-rbac/using-custom-rbac.md).
+- Back up and restore your etcd cluster with
+  [KubeStash](/docs/guides/etcd/backup/kubestash/overview/index.md).
+- Detail concepts of the [Etcd](/docs/guides/etcd/concepts/etcd.md) object.
+- Detail concepts of the [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) object.
+- Monitor your etcd cluster with KubeDB using the
+  [out-of-the-box Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/quickstart/_index.md
+++ b/docs/guides/etcd/quickstart/_index.md
@@ -1,0 +1,12 @@
+---
+title: Etcd Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-quickstart-etcd
+    name: Quickstart
+    parent: etcd-etcd-guides
+    weight: 15
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/quickstart/quickstart.md
+++ b/docs/guides/etcd/quickstart/quickstart.md
@@ -1,0 +1,506 @@
+---
+title: Etcd Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-quickstart-quickstart
+    name: Overview
+    parent: etcd-quickstart-etcd
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd QuickStart
+
+This tutorial will show you how to use KubeDB to run an [etcd](https://etcd.io/) cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install the KubeDB cli on your workstation and the KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). etcd support is behind an **alpha feature gate**, so you must set `global.featureGates.Etcd=true` to install the etcd CRDs and enable the controllers:
+
+  ```bash
+  helm upgrade -i kubedb oci://ghcr.io/appscode-charts/kubedb \
+    --namespace kubedb --create-namespace \
+    --set-file global.license=/path/to/the/license.txt \
+    --set global.featureGates.Etcd=true \
+    --wait --burst-limit=10000 --debug
+  ```
+
+  If you install the operator components separately, the equivalent operator flag is `--feature-gates=Etcd=true`, and it has to be set on the provisioner, the ops-manager, the autoscaler and the crd-manager alike.
+
+- [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) is required to run KubeDB. Check the available StorageClass in the cluster.
+
+  ```bash
+  $ kubectl get storageclasses
+  NAME                 PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+  standard (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  20h
+  ```
+
+  > etcd commits every write to disk before acknowledging it. For anything beyond this tutorial, use a StorageClass backed by SSD/NVMe.
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`. Run the following command to prepare your cluster for this tutorial:
+
+  ```bash
+  $ kubectl create namespace demo
+  namespace/demo created
+
+  $ kubectl get namespaces
+  NAME          STATUS    AGE
+  demo          Active    10s
+  ```
+
+> Note: The yaml files used in this tutorial are stored in [docs/examples](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Find Available EtcdVersion
+
+When you have installed KubeDB, it has created an `EtcdVersion` crd for every supported etcd version. Check:
+
+```bash
+$ kubectl get etcdversions
+NAME     VERSION   DB_IMAGE                              DEPRECATED   AGE
+3.5.21   3.5.21    ghcr.io/appscode-images/etcd:v3.5.21                94s
+3.6.4    3.6.4     ghcr.io/appscode-images/etcd:v3.6.4                 94s
+```
+
+`EtcdVersion` is a cluster-scoped resource, so it is not namespaced. You can inspect one to see the exact images and the allowed update path:
+
+```bash
+$ kubectl get etcdversion 3.6.4 -o yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: EtcdVersion
+metadata:
+  name: 3.6.4
+spec:
+  db:
+    image: ghcr.io/appscode-images/etcd:v3.6.4
+  exporter:
+    image: ghcr.io/appscode-images/etcd:v3.6.4
+  securityContext:
+    runAsUser: 1000
+  updateConstraints:
+    allowlist:
+    - '>= 3.6.4, <= 3.7.0'
+  version: 3.6.4
+```
+
+## Create an Etcd Cluster
+
+KubeDB implements an `Etcd` CRD to define the specification of an etcd cluster. Below is the `Etcd` object created in this tutorial.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    resources:
+      requests:
+        storage: "1Gi"
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+  deletionPolicy: "WipeOut"
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/quickstart/etcd.yaml
+etcd.kubedb.com/etcd-quickstart created
+```
+
+Here,
+
+- `spec.version` is the name of the [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) crd where the docker images are specified. In this tutorial, an etcd `3.6.4` cluster is created.
+- `spec.replicas` is the number of etcd members. It defaults to `3`. etcd replicates with Raft, so a `2n+1` member cluster tolerates `n` member failures — use an **odd** number.
+- `spec.storage` specifies the PVC spec that will be dynamically allocated to hold the etcd data directory (`/var/lib/etcd`). This storage spec will be passed to the PetSet created by the KubeDB operator to run the database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
+- `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of the `Etcd` crd, or which resources KubeDB should keep or delete when you delete the `Etcd` crd. If the admission webhook is enabled, it prevents users from deleting the database as long as `spec.deletionPolicy` is set to `DoNotTerminate`.
+
+> Note: The `spec.storage` section is used to create the PVC for the database pods. It will create a PVC with the storage size specified in the `storage.resources.requests` field. Don't specify limits here. PVCs do not get resized automatically.
+
+The KubeDB operator watches for `Etcd` objects using the Kubernetes api. When an `Etcd` object is created, the operator creates a PetSet, a client Service, a headless governing Service, an auth Secret, and the RBAC objects, all named after the `Etcd` object.
+
+Because etcd's bootstrap semantics require a single seed member, the PetSet is created with **one** replica. The operator then adds each further member through etcd's membership API — first as a non-voting **learner**, then promoting it to a voting member once it has caught up — so you will see the cluster grow from 1 to 3 members over the first few reconcile passes rather than all at once.
+
+```bash
+$ kubectl get etcd -n demo
+NAME              VERSION   STATUS         AGE
+etcd-quickstart   3.6.4     Provisioning   20s
+```
+
+Wait until `STATUS` becomes `Ready`. You can block on it:
+
+```bash
+$ kubectl wait --for=condition=Ready etcd/etcd-quickstart -n demo --timeout=10m
+etcd.kubedb.com/etcd-quickstart condition met
+
+$ kubectl get etcd -n demo
+NAME              VERSION   STATUS   AGE
+etcd-quickstart   3.6.4     Ready    3m2s
+```
+
+Describe the object to see the defaults the operator filled in, and the conditions it walked through:
+
+```bash
+$ kubectl describe etcd -n demo etcd-quickstart
+Name:         etcd-quickstart
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  kubedb.com/v1alpha2
+Kind:         Etcd
+Metadata:
+  Creation Timestamp:  2026-01-14T08:25:26Z
+  Finalizers:
+    kubedb.com
+  Generation:        3
+  Resource Version:  12345
+  UID:               dd69e514-3049-4d08-8b57-92f8246dda35
+Spec:
+  Auth Secret:
+    Kind:  Secret
+    Name:  etcd-quickstart-auth
+  Deletion Policy:  WipeOut
+  Health Checker:
+    Failure Threshold:  1
+    Period Seconds:     10
+    Timeout Seconds:    10
+  Pod Template:
+    Controller:
+    Metadata:
+    Spec:
+      Containers:
+        Name:  etcd
+        Resources:
+          Limits:
+            Memory:  1Gi
+          Requests:
+            Cpu:     500m
+            Memory:  1Gi
+        Security Context:
+          Allow Privilege Escalation:  false
+          Capabilities:
+            Drop:
+              ALL
+          Run As Group:     1000
+          Run As Non Root:  true
+          Run As User:      1000
+          Seccomp Profile:
+            Type:  RuntimeDefault
+      Init Containers:
+        Name:  etcd-init
+        Security Context:
+          Allow Privilege Escalation:  false
+          Capabilities:
+            Drop:
+              ALL
+          Run As Group:     1000
+          Run As Non Root:  true
+          Run As User:      1000
+          Seccomp Profile:
+            Type:  RuntimeDefault
+      Security Context:
+        Fs Group:            1000
+      Service Account Name:  etcd-quickstart
+  Replicas:                  3
+  Storage:
+    Access Modes:
+      ReadWriteOnce
+    Resources:
+      Requests:
+        Storage:         1Gi
+    Storage Class Name:  standard
+  Storage Type:          Durable
+  Version:               3.6.4
+Status:
+  Conditions:
+    Last Transition Time:  2026-01-14T08:25:26Z
+    Message:               The KubeDB operator has started the provisioning of Etcd: demo/etcd-quickstart
+    Observed Generation:   1
+    Reason:                DatabaseProvisioningStartedSuccessfully
+    Status:                True
+    Type:                  ProvisioningStarted
+    Last Transition Time:  2026-01-14T08:26:50Z
+    Message:               All replicas are ready for Etcd demo/etcd-quickstart
+    Observed Generation:   3
+    Reason:                AllReplicasReady
+    Status:                True
+    Type:                  ReplicaReady
+    Last Transition Time:  2026-01-14T08:27:10Z
+    Message:               The Etcd: demo/etcd-quickstart is accepting connection requests.
+    Observed Generation:   3
+    Reason:                DatabaseAcceptingConnectionRequest
+    Status:                True
+    Type:                  AcceptingConnection
+    Last Transition Time:  2026-01-14T08:27:10Z
+    Message:               The Etcd: demo/etcd-quickstart is ready.
+    Observed Generation:   3
+    Reason:                ReadinessCheckSucceeded
+    Status:                True
+    Type:                  Ready
+    Last Transition Time:  2026-01-14T08:27:13Z
+    Message:               Etcd: demo/etcd-quickstart is successfully provisioned.
+    Observed Generation:   3
+    Reason:                DatabaseSuccessfullyProvisioned
+    Status:                True
+    Type:                  Provisioned
+  Phase:                   Ready
+Events:                    <none>
+```
+
+The offshoot objects the operator created:
+
+```bash
+$ kubectl get petset -n demo
+NAME              AGE
+etcd-quickstart   3m14s
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-quickstart
+NAME                READY   STATUS    RESTARTS   AGE
+etcd-quickstart-0   1/1     Running   0          3m20s
+etcd-quickstart-1   1/1     Running   0          2m48s
+etcd-quickstart-2   1/1     Running   0          2m19s
+
+$ kubectl get pvc -n demo
+NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-etcd-quickstart-0   Bound    pvc-1e1850b8-4e5c-418c-a722-89df98f28998   1Gi        RWO            standard       3m40s
+data-etcd-quickstart-1   Bound    pvc-e2bb4b02-b138-4589-9e43-bcaf599b6513   1Gi        RWO            standard       3m08s
+data-etcd-quickstart-2   Bound    pvc-988ab6b2-e5ed-4c75-8418-31186bd1d3db   1Gi        RWO            standard       2m39s
+
+$ kubectl get service -n demo
+NAME                    TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
+etcd-quickstart         ClusterIP   10.96.26.38    <none>        2379/TCP            4m15s
+etcd-quickstart-pods    ClusterIP   None           <none>        2379/TCP,2380/TCP   4m15s
+```
+
+Here,
+
+- `etcd-quickstart` is the client Service on port `2379`. Every etcd member serves the client API and forwards writes to the current Raft leader, so a single Service over all members is correct — there is no primary/standby split to route around.
+- `etcd-quickstart-pods` is the headless governing Service. The stable per-member DNS names derived from it (`etcd-quickstart-0.etcd-quickstart-pods.demo.svc.cluster.local`) are what etcd uses as its peer (`2380`) and client (`2379`) URLs.
+
+The KubeDB operator sets `status.phase` to `Ready` once the cluster is successfully created. Run the following command to see the full, modified Etcd object:
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart -o yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"Etcd","metadata":{"annotations":{},"name":"etcd-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","version":"3.6.4"}}
+  creationTimestamp: "2026-01-14T08:25:26Z"
+  finalizers:
+  - kubedb.com
+  generation: 3
+  name: etcd-quickstart
+  namespace: demo
+  resourceVersion: "12345"
+  uid: dd69e514-3049-4d08-8b57-92f8246dda35
+spec:
+  authSecret:
+    kind: Secret
+    name: etcd-quickstart-auth
+  deletionPolicy: WipeOut
+  healthChecker:
+    failureThreshold: 1
+    periodSeconds: 10
+    timeoutSeconds: 10
+  podTemplate:
+    controller: {}
+    metadata: {}
+    spec:
+      containers:
+      - name: etcd
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      initContainers:
+      - name: etcd-init
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        fsGroup: 1000
+      serviceAccountName: etcd-quickstart
+  replicas: 3
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+    storageClassName: standard
+  storageType: Durable
+  version: 3.6.4
+status:
+  conditions:
+  - lastTransitionTime: "2026-01-14T08:25:26Z"
+    message: 'The KubeDB operator has started the provisioning of Etcd: demo/etcd-quickstart'
+    observedGeneration: 1
+    reason: DatabaseProvisioningStartedSuccessfully
+    status: "True"
+    type: ProvisioningStarted
+  - lastTransitionTime: "2026-01-14T08:26:50Z"
+    message: All replicas are ready for Etcd demo/etcd-quickstart
+    observedGeneration: 3
+    reason: AllReplicasReady
+    status: "True"
+    type: ReplicaReady
+  - lastTransitionTime: "2026-01-14T08:27:10Z"
+    message: 'The Etcd: demo/etcd-quickstart is accepting connection requests.'
+    observedGeneration: 3
+    reason: DatabaseAcceptingConnectionRequest
+    status: "True"
+    type: AcceptingConnection
+  - lastTransitionTime: "2026-01-14T08:27:10Z"
+    message: 'The Etcd: demo/etcd-quickstart is ready.'
+    observedGeneration: 3
+    reason: ReadinessCheckSucceeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2026-01-14T08:27:13Z"
+    message: 'Etcd: demo/etcd-quickstart is successfully provisioned.'
+    observedGeneration: 3
+    reason: DatabaseSuccessfullyProvisioned
+    status: "True"
+    type: Provisioned
+  observedGeneration: 3
+  phase: Ready
+```
+
+## Connect to the Cluster
+
+etcd ships its own CLI, `etcdctl`, inside the database image, so the simplest way to try the cluster is from inside a member pod.
+
+First, confirm that the cluster has three healthy members and that one of them is the Raft leader:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-0 -- etcdctl \
+    --endpoints=http://etcd-quickstart:2379 member list -w table
++------------------+---------+-------------------+--------------------------------------------------------+--------------------------------------------------------+------------+
+|        ID        | STATUS  |       NAME        |                       PEER ADDRS                       |                      CLIENT ADDRS                      | IS LEARNER |
++------------------+---------+-------------------+--------------------------------------------------------+--------------------------------------------------------+------------+
+| 8e9e05c52164694d | started | etcd-quickstart-0 | http://etcd-quickstart-0.etcd-quickstart-pods.demo:2380 | http://etcd-quickstart-0.etcd-quickstart-pods.demo:2379 |      false |
+| 91bc3c398fb3c146 | started | etcd-quickstart-1 | http://etcd-quickstart-1.etcd-quickstart-pods.demo:2380 | http://etcd-quickstart-1.etcd-quickstart-pods.demo:2379 |      false |
+| fd422379fda50e48 | started | etcd-quickstart-2 | http://etcd-quickstart-2.etcd-quickstart-pods.demo:2380 | http://etcd-quickstart-2.etcd-quickstart-pods.demo:2379 |      false |
++------------------+---------+-------------------+--------------------------------------------------------+--------------------------------------------------------+------------+
+```
+
+> The `IS LEARNER` column is worth knowing about: while KubeDB is scaling the cluster up, a freshly added member appears here as a learner (`true`). A learner replicates the log but does not vote and does not count toward quorum, so it cannot stall the cluster while it catches up. KubeDB promotes it to a voting member automatically once it has caught up with the leader.
+
+Now write and read a key:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-0 -- etcdctl \
+    --endpoints=http://etcd-quickstart:2379 put /hello "hello kubedb"
+OK
+
+$ kubectl exec -it -n demo etcd-quickstart-0 -- etcdctl \
+    --endpoints=http://etcd-quickstart:2379 get /hello
+/hello
+hello kubedb
+```
+
+Because the write went through Raft, the value is readable from any member — read it back through a different pod to see that:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-2 -- etcdctl \
+    --endpoints=http://etcd-quickstart-2.etcd-quickstart-pods.demo:2379 get /hello
+/hello
+hello kubedb
+```
+
+To reach the cluster from your workstation instead, port-forward the client Service:
+
+```bash
+$ kubectl port-forward -n demo svc/etcd-quickstart 2379
+Forwarding from 127.0.0.1:2379 -> 2379
+```
+
+### Credentials
+
+KubeDB provisions a credential for etcd's built-in RBAC superuser — which etcd requires to literally be named `root` — and stores it in the Secret `<etcd-object-name>-auth`:
+
+```bash
+$ kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
+root
+
+$ kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
+6q8u2jMOWOOZXk
+```
+
+Once etcd's RBAC is turned on for the cluster, pass those credentials to `etcdctl` with `--user=root:<password>`. Rotating the credential — and enabling RBAC in the first place — is done with a `RotateAuth` [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md), which does **not** restart the pods, because etcd applies a password change live.
+
+You can also bring your own credential instead of letting KubeDB generate one; see [spec.authSecret](/docs/guides/etcd/concepts/etcd.md#specauthsecret).
+
+## DoNotTerminate Property
+
+When `deletionPolicy` is `DoNotTerminate`, KubeDB takes advantage of the `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement the `DoNotTerminate` feature. If the admission webhook is enabled, it prevents users from deleting the database as long as `spec.deletionPolicy` is set to `DoNotTerminate`. You can see this below:
+
+```bash
+$ kubectl delete etcd etcd-quickstart -n demo
+The Etcd "etcd-quickstart" is invalid: spec.deletionPolicy: Invalid value: "etcd-quickstart": Can not delete as deletionPolicy is set to "DoNotTerminate"
+```
+
+Now, run `kubectl edit etcd etcd-quickstart -n demo` to set `spec.deletionPolicy` to `Halt`. Then you will be able to delete/halt the database.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl patch -n demo etcd/etcd-quickstart -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+etcd.kubedb.com/etcd-quickstart patched
+
+$ kubectl delete -n demo etcd/etcd-quickstart
+etcd.kubedb.com "etcd-quickstart" deleted
+
+$ kubectl delete ns demo
+namespace "demo" deleted
+```
+
+## Tips for Testing
+
+If you are just testing some basic functionality, you might want to avoid the additional hassle of some safety features that are great for a production environment. You can follow these tips to avoid them.
+
+- **Use `deletionPolicy: WipeOut`.** By default, KubeDB preserves your `PVCs` and auth `Secrets` so a database can be resumed from a previous one. If you don't want to resume the database, use `spec.deletionPolicy: WipeOut`. It deletes everything created by KubeDB for a particular Etcd crd when you delete the crd.
+- **Use `spec.replicas: 1`** for a throwaway cluster. etcd has no standalone mode — a single member is simply a one-member Raft cluster — so this is a supported configuration, just one with no fault tolerance at all.
+- **Use `spec.storageType: Ephemeral`** if you don't want PVCs at all. Note that this cannot be combined with `deletionPolicy: Halt`.
+
+## Next Steps
+
+- Detail concepts of the [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Detail concepts of the [EtcdVersion object](/docs/guides/etcd/concepts/etcdversion.md).
+- Detail concepts of the [EtcdOpsRequest object](/docs/guides/etcd/concepts/etcdopsrequest.md), including etcd's own `MoveLeader`, `Defragment` and `Compact` maintenance operations.
+- Detail concepts of the [EtcdAutoscaler object](/docs/guides/etcd/concepts/etcdautoscaler.md).
+- Snapshot backup with the [EtcdArchiver object](/docs/guides/etcd/concepts/etcdarchiver.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/quickstart/quickstart.md
+++ b/docs/guides/etcd/quickstart/quickstart.md
@@ -22,13 +22,13 @@ This tutorial will show you how to use KubeDB to run an [etcd](https://etcd.io/)
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-- Now, install the KubeDB cli on your workstation and the KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). etcd support is behind an **alpha feature gate**, so you must set `global.featureGates.Etcd=true` to install the etcd CRDs and enable the controllers:
+- Now, install the KubeDB cli on your workstation and the KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). etcd support is behind an **alpha feature gate**, so you must set `featureGates.Etcd=true` to install the etcd CRDs and enable the controllers:
 
   ```bash
   helm upgrade -i kubedb oci://ghcr.io/appscode-charts/kubedb \
     --namespace kubedb --create-namespace \
     --set-file global.license=/path/to/the/license.txt \
-    --set global.featureGates.Etcd=true \
+    --set featureGates.Etcd=true \
     --wait --burst-limit=10000 --debug
   ```
 
@@ -182,22 +182,10 @@ Spec:
         Name:  etcd
         Resources:
           Limits:
-            Memory:  1Gi
+            Memory:  2Gi
           Requests:
             Cpu:     500m
             Memory:  1Gi
-        Security Context:
-          Allow Privilege Escalation:  false
-          Capabilities:
-            Drop:
-              ALL
-          Run As Group:     1000
-          Run As Non Root:  true
-          Run As User:      1000
-          Seccomp Profile:
-            Type:  RuntimeDefault
-      Init Containers:
-        Name:  etcd-init
         Security Context:
           Allow Privilege Escalation:  false
           Capabilities:
@@ -230,25 +218,25 @@ Status:
     Status:                True
     Type:                  ProvisioningStarted
     Last Transition Time:  2026-01-14T08:26:50Z
-    Message:               All replicas are ready for Etcd demo/etcd-quickstart
+    Message:               All the members of Etcd demo/etcd-quickstart are ready.
     Observed Generation:   3
     Reason:                AllReplicasReady
     Status:                True
     Type:                  ReplicaReady
     Last Transition Time:  2026-01-14T08:27:10Z
-    Message:               The Etcd: demo/etcd-quickstart is accepting connection requests.
+    Message:               The Etcd: demo/etcd-quickstart is accepting client requests.
     Observed Generation:   3
     Reason:                DatabaseAcceptingConnectionRequest
     Status:                True
     Type:                  AcceptingConnection
     Last Transition Time:  2026-01-14T08:27:10Z
-    Message:               The Etcd: demo/etcd-quickstart is ready.
+    Message:               The Etcd: demo/etcd-quickstart has a healthy Raft quorum.
     Observed Generation:   3
-    Reason:                ReadinessCheckSucceeded
+    Reason:                AllReplicasReady
     Status:                True
     Type:                  Ready
     Last Transition Time:  2026-01-14T08:27:13Z
-    Message:               Etcd: demo/etcd-quickstart is successfully provisioned.
+    Message:               The Etcd: demo/etcd-quickstart is successfully provisioned.
     Observed Generation:   3
     Reason:                DatabaseSuccessfullyProvisioned
     Status:                True
@@ -320,24 +308,17 @@ spec:
     spec:
       containers:
       - name: etcd
+        resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: NotRequired
         resources:
           limits:
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 500m
             memory: 1Gi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
-          seccompProfile:
-            type: RuntimeDefault
-      initContainers:
-      - name: etcd-init
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -370,25 +351,25 @@ status:
     status: "True"
     type: ProvisioningStarted
   - lastTransitionTime: "2026-01-14T08:26:50Z"
-    message: All replicas are ready for Etcd demo/etcd-quickstart
+    message: All the members of Etcd demo/etcd-quickstart are ready.
     observedGeneration: 3
     reason: AllReplicasReady
     status: "True"
     type: ReplicaReady
   - lastTransitionTime: "2026-01-14T08:27:10Z"
-    message: 'The Etcd: demo/etcd-quickstart is accepting connection requests.'
+    message: 'The Etcd: demo/etcd-quickstart is accepting client requests.'
     observedGeneration: 3
     reason: DatabaseAcceptingConnectionRequest
     status: "True"
     type: AcceptingConnection
   - lastTransitionTime: "2026-01-14T08:27:10Z"
-    message: 'The Etcd: demo/etcd-quickstart is ready.'
+    message: 'The Etcd: demo/etcd-quickstart has a healthy Raft quorum.'
     observedGeneration: 3
-    reason: ReadinessCheckSucceeded
+    reason: AllReplicasReady
     status: "True"
     type: Ready
   - lastTransitionTime: "2026-01-14T08:27:13Z"
-    message: 'Etcd: demo/etcd-quickstart is successfully provisioned.'
+    message: 'The Etcd: demo/etcd-quickstart is successfully provisioned.'
     observedGeneration: 3
     reason: DatabaseSuccessfullyProvisioned
     status: "True"
@@ -464,14 +445,19 @@ You can also bring your own credential instead of letting KubeDB generate one; s
 
 ## DoNotTerminate Property
 
-When `deletionPolicy` is `DoNotTerminate`, KubeDB takes advantage of the `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement the `DoNotTerminate` feature. If the admission webhook is enabled, it prevents users from deleting the database as long as `spec.deletionPolicy` is set to `DoNotTerminate`. You can see this below:
+When `deletionPolicy` is `DoNotTerminate`, KubeDB takes advantage of the `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement the `DoNotTerminate` feature. If the admission webhook is enabled, it prevents users from deleting the database as long as `spec.deletionPolicy` is set to `DoNotTerminate`.
+
+The cluster we created above uses `deletionPolicy: WipeOut`, so to see this for yourself you first have to switch it:
 
 ```bash
+$ kubectl patch -n demo etcd/etcd-quickstart -p '{"spec":{"deletionPolicy":"DoNotTerminate"}}' --type="merge"
+etcd.kubedb.com/etcd-quickstart patched
+
 $ kubectl delete etcd etcd-quickstart -n demo
 The Etcd "etcd-quickstart" is invalid: spec.deletionPolicy: Invalid value: "etcd-quickstart": Can not delete as deletionPolicy is set to "DoNotTerminate"
 ```
 
-Now, run `kubectl edit etcd etcd-quickstart -n demo` to set `spec.deletionPolicy` to `Halt`. Then you will be able to delete/halt the database.
+To get the database back to a deletable state, set `spec.deletionPolicy` to something other than `DoNotTerminate` — `Halt`, `Delete` or `WipeOut`, depending on what you want kept. The cleanup below uses `WipeOut`, which removes everything.
 
 ## Cleaning up
 

--- a/docs/guides/etcd/recommendation/_index.md
+++ b/docs/guides/etcd/recommendation/_index.md
@@ -1,0 +1,12 @@
+---
+title: Etcd Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-recommendation
+    name: Recommendation
+    parent: etcd-etcd-guides
+    weight: 115
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/recommendation/recommendation.md
+++ b/docs/guides/etcd/recommendation/recommendation.md
@@ -50,7 +50,7 @@ Recommendation lifecycle, see:
 - [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md)
 - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
 - [Rotate Authentication](/docs/guides/etcd/rotate-authentication/overview.md)
-- [Reconfigure TLS](/docs/guides/etcd/tls/overview.md)
+- [Reconfigure TLS](/docs/guides/etcd/reconfigure-tls/overview.md)
 - [Update Version](/docs/guides/etcd/update-version/overview.md)
 
 ---
@@ -111,9 +111,10 @@ following conditions:
 * If the secret lifespan is less than one month, a recommendation is generated when approximately
   one-third of its validity remains.
 
-Note that for etcd this trigger is always live: KubeDB always provisions etcd with its RBAC
-enabled and a `root` user, so the engine treats authentication as unconditionally enabled — there
-is no "auth is off" case for an etcd cluster the way there is for some other databases.
+Note that for etcd this trigger is always live: KubeDB always provisions an auth `Secret` holding a
+`root` credential, so the engine has a secret to age out and treats the database as having
+authentication configured. That is independent of whether etcd's own RBAC has been switched on — see
+[Rotate Authentication](/docs/guides/etcd/rotate-authentication/overview.md).
 
 Once approved, the Supervisor creates an `EtcdOpsRequest` of type `RotateAuth`. For etcd this is
 an unusually cheap operation: an etcd RBAC password change is applied live through the
@@ -205,7 +206,7 @@ gated by an upgrade-path check (same major, no downgrade, at most one minor step
 rolls every member, so it is the one recommendation type that always waits for a human or an
 `ApprovalPolicy`.
 
-For example: recommending a version update from `3.6.4` to `3.6.5`.
+For example: recommending a version update from `3.5.21` to `3.6.4`.
 
 If the `Etcd` object's version changes to something other than what an outstanding recommendation
 targeted, the engine marks that recommendation **outdated** rather than leaving it to fire later
@@ -333,7 +334,7 @@ spec:
         name: etcd-recommendation
       type: UpdateVersion
       updateVersion:
-        targetVersion: 3.6.5
+        targetVersion: 3.6.4
     status: {}
 ```
 

--- a/docs/guides/etcd/recommendation/recommendation.md
+++ b/docs/guides/etcd/recommendation/recommendation.md
@@ -1,0 +1,402 @@
+---
+title: Etcd Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-recommendation-overview
+    name: Recommendation Overview
+    parent: etcd-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled
+by the **KubeDB Supervisor**. For an etcd cluster managed by KubeDB, the Ops-Manager watches the
+`Etcd` object's state and emits a Recommendation whenever it detects an action you should take —
+a newer version in the catalog, an expiring TLS certificate, or an authentication secret nearing
+its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you
+(`status.approvalStatus: Approved`) or automatically, through the deadline the Ops-Manager set or
+through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates
+the corresponding `EtcdOpsRequest` and tracks it to completion. **You do not write the
+`EtcdOpsRequest` yourself** — the fully-formed request is already carried inside the
+Recommendation's `spec.operation`.
+
+This page is the **etcd-specific intro**: which recommendations apply to etcd and which spec
+fields trigger them. For prerequisites, Helm flags that control generation timing, and the full
+Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [Etcd](/docs/guides/etcd/concepts/etcd.md)
+- [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md)
+- [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+- [Rotate Authentication](/docs/guides/etcd/rotate-authentication/overview.md)
+- [Reconfigure TLS](/docs/guides/etcd/tls/overview.md)
+- [Update Version](/docs/guides/etcd/update-version/overview.md)
+
+---
+
+## Recommendation types for Etcd
+
+| Type                               | Generated `EtcdOpsRequest` type | Triggered when                                                                    | Walkthrough                                                                                                       |
+| ---------------------------------- | ------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Version Update**                 | `UpdateVersion`                 | A newer major, minor, or patch `EtcdVersion` becomes available in the catalog      | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)              |
+| **Same-Version Update**            | `UpdateVersion`                 | The container image for your *current* `EtcdVersion` is refreshed                  | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)              |
+| **TLS Certificate Rotation**       | `ReconfigureTLS`                | An issued certificate is approaching its expiry threshold                          | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)        |
+| **Authentication Secret Rotation** | `RotateAuth`                    | The auth secret is approaching its `rotateAfter` deadline                          | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+The engine itself is the same one every KubeDB database uses; there is nothing etcd-specific about
+the mechanism. What *is* etcd-specific is which triggers apply, and what the resulting operation
+does to a Raft cluster.
+
+Two conditions gate generation for every type:
+
+- **`spec.autoOps.disabled`** on the `Etcd` object. Set it to `true` and no recommendations are
+  generated for that cluster at all.
+- **No other `EtcdOpsRequest` may be `Progressing`.** If the cluster is already in the middle of
+  an operation, the engine waits rather than stacking a second one on top.
+
+---
+
+## Triggers specific to Etcd
+
+This section shows the minimal `Etcd` CR fields that cause each recommendation to be generated.
+For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-recommendation
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  authSecret:
+    name: etcd-recommendation-auth
+    rotateAfter: 720h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid.
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the
+following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than
+  one month of validity remains.
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately
+  one-third of its validity remains.
+
+Note that for etcd this trigger is always live: KubeDB always provisions etcd with its RBAC
+enabled and a `root` user, so the engine treats authentication as unconditionally enabled — there
+is no "auth is off" case for an etcd cluster the way there is for some other databases.
+
+Once approved, the Supervisor creates an `EtcdOpsRequest` of type `RotateAuth`. For etcd this is
+an unusually cheap operation: an etcd RBAC password change is applied live through the
+`UserChangePassword` API, so **no pods are restarted** and there is no interruption to the client
+API.
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-recommendation
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+    certificates:
+      - alias: server
+        duration: 2160h
+      - alias: client
+        duration: 2160h
+      - alias: peer
+        duration: 2160h
+```
+
+In this configuration:
+
+* The `spec.tls.certificates[].duration` field defines how long each certificate remains valid.
+* The engine only tracks certificates when `spec.tls.issuerRef` is set — a cluster without an
+  issuer has no certificates for it to watch.
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the
+following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less
+  than one month of validity remains.
+
+* If the certificate duration is less than one month, a recommendation is generated when
+  approximately one-third of its validity remains.
+
+Pay particular attention to the `peer` certificate for etcd. Peer traffic is Raft traffic between
+members, and it is always mutually authenticated once TLS is enabled — an expired peer
+certificate does not degrade the cluster, it partitions it. That is the main reason to leave TLS
+rotation on automatic approval rather than gating it behind a human.
+
+Once approved, the Supervisor creates an `EtcdOpsRequest` of type `ReconfigureTLS` with
+`tls.rotateCertificates: true`. The Ops-manager re-issues the certificates through cert-manager
+and then performs a leader-aware rolling restart: leadership is moved off the leader before its
+pod is recreated, pods are restarted one at a time, and each must be Ready and the cluster
+quorum-healthy before the next one is touched.
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-recommendation
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database against the `EtcdVersion` catalog objects
+  installed in the cluster.
+
+KubeDB generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a patch version is released, a recommendation is generated.
+
+* If a newer minor or major version becomes available, a recommendation is generated.
+
+* Candidate versions are filtered through the current `EtcdVersion`'s
+  `spec.updateConstraints.allowlist` / `denylist`, deprecated versions are skipped, and only
+  versions built on the same base OS are considered.
+
+Version update recommendations for etcd are created with `spec.requireExplicitApproval: true` —
+they will **not** auto-approve on a deadline. That is deliberate: an etcd version update is
+gated by an upgrade-path check (same major, no downgrade, at most one minor step at a time) and
+rolls every member, so it is the one recommendation type that always waits for a human or an
+`ApprovalPolicy`.
+
+For example: recommending a version update from `3.6.4` to `3.6.5`.
+
+If the `Etcd` object's version changes to something other than what an outstanding recommendation
+targeted, the engine marks that recommendation **outdated** rather than leaving it to fire later
+against a version you no longer run.
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-recommendation
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+```
+
+In this configuration:
+
+* KubeDB compares the images pinned by the current `EtcdVersion` — the etcd server image, the
+  exporter image and, when present, the init container image — against what the running PetSet
+  actually references.
+
+* If the container image backing the current version is updated (a security patch or a rebuild
+  without a version bump), a recommendation is generated.
+
+Once approved, the Supervisor creates an `EtcdOpsRequest` targeting the same version, which rolls
+the members onto the refreshed image.
+
+---
+
+## Listing and inspecting Recommendations
+
+Recommendations are namespaced, and live in the same namespace as the database.
+
+```bash
+$ kubectl get recommendation -n demo
+NAME                                                     STATUS    OUTDATED   AGE
+etcd-recommendation-x-etcd-x-rotate-tls-p4k9zq           Pending   false      12m
+etcd-recommendation-x-etcd-x-update-version-h7m2ab       Pending   false      6m
+```
+
+The name follows the pattern `<db-name>-x-<db-kind>-x-<recommendation-type>-<random-suffix>`, so
+`etcd-recommendation-x-etcd-x-rotate-tls-p4k9zq` is a TLS rotation recommendation for the `Etcd`
+object named `etcd-recommendation`.
+
+Every Recommendation is labelled, which makes filtering easy:
+
+```bash
+# everything KubeDB generated for one particular Etcd cluster
+$ kubectl get recommendation -n demo -l app.kubernetes.io/instance=etcd-recommendation
+
+# only the version-update ones
+$ kubectl get recommendation -n demo -l app.kubernetes.io/type=version-update
+```
+
+The label values are `rotate-tls`, `rotate-auth` and `version-update`, and every KubeDB-generated
+Recommendation also carries `app.kubernetes.io/managed-by: kubedb.com`.
+
+To see what a Recommendation actually proposes, read its `spec.operation` — it holds the complete
+`EtcdOpsRequest` the Supervisor will create:
+
+```bash
+$ kubectl get recommendation -n demo etcd-recommendation-x-etcd-x-rotate-tls-p4k9zq -o yaml
+apiVersion: supervisor.appscode.com/v1alpha1
+kind: Recommendation
+metadata:
+  creationTimestamp: "2026-02-11T13:41:20Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: etcd-recommendation
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/type: rotate-tls
+  name: etcd-recommendation-x-etcd-x-rotate-tls-p4k9zq
+  namespace: demo
+  resourceVersion: "80311"
+  uid: c5d2e9b1-7a04-4f38-9e22-1b3c4d5e6f70
+spec:
+  deadline: "2026-03-06T09:00:00Z"
+  description: Recommending TLS certificate rotation, etcd-recommendation-peer-cert
+    Certificate is going to be expire on 2026-03-06 09:20:00 +0000 UTC
+  operation:
+    apiVersion: ops.kubedb.com/v1alpha1
+    kind: EtcdOpsRequest
+    metadata:
+      name: rotate-tls
+      namespace: demo
+    spec:
+      databaseRef:
+        name: etcd-recommendation
+      tls:
+        rotateCertificates: true
+      type: ReconfigureTLS
+    status: {}
+  recommender:
+    name: kubedb-ops-manager
+  rules:
+    failed: has(self.status) && has(self.status.phase) && self.status.phase == 'Failed'
+    inProgress: has(self.status) && has(self.status.phase) && self.status.phase == 'Progressing'
+    success: has(self.status) && has(self.status.phase) && self.status.phase == 'Successful'
+  target:
+    apiGroup: kubedb.com
+    kind: Etcd
+    name: etcd-recommendation
+status:
+  outdated: false
+  phase: Pending
+```
+
+A version update recommendation looks the same except for its `spec.operation` and the explicit
+approval flag:
+
+```yaml
+spec:
+  requireExplicitApproval: true
+  operation:
+    apiVersion: ops.kubedb.com/v1alpha1
+    kind: EtcdOpsRequest
+    metadata:
+      name: update-version
+      namespace: demo
+    spec:
+      databaseRef:
+        name: etcd-recommendation
+      type: UpdateVersion
+      updateVersion:
+        targetVersion: 3.6.5
+    status: {}
+```
+
+---
+
+## Acting on a Recommendation
+
+Approve it. That is the whole interaction — the Supervisor turns the approval into the
+`EtcdOpsRequest` for you.
+
+```bash
+$ kubectl patch recommendation etcd-recommendation-x-etcd-x-update-version-h7m2ab \
+     -n demo \
+     --type merge \
+     --subresource='status' \
+     -p '{"status":{"approvalStatus":"Approved","approvedWindow":{"window":"Immediate"}}}'
+recommendation.supervisor.appscode.com/etcd-recommendation-x-etcd-x-update-version-h7m2ab patched
+```
+
+Watch the Recommendation pick up the created operation:
+
+```bash
+$ kubectl get recommendation -n demo etcd-recommendation-x-etcd-x-update-version-h7m2ab -o jsonpath='{.status}'
+```
+
+`status.createdOperationRef.name` names the `EtcdOpsRequest` the Supervisor created, which you can
+then follow exactly like any hand-written one:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                                                  TYPE            STATUS       AGE
+etcd-recommendation-1780937248-update-version-auto    UpdateVersion   Successful   6m
+```
+
+If you want to skip a recommendation instead — for example because you are about to swap issuers,
+or you are pinning the version deliberately — reject it:
+
+```bash
+$ kubectl patch recommendation etcd-recommendation-x-etcd-x-update-version-h7m2ab \
+     -n demo \
+     --type merge \
+     --subresource='status' \
+     -p '{"status":{"approvalStatus":"Rejected"}}'
+recommendation.supervisor.appscode.com/etcd-recommendation-x-etcd-x-update-version-h7m2ab patched
+```
+
+A rejected version-update recommendation is remembered: the engine will not immediately re-create
+an identical one for the same target version.
+
+To take the approval decision off your hands entirely, pair an `ApprovalPolicy` with a
+`MaintenanceWindow` so that recommendations are auto-approved but only execute off-peak. That is
+the recommended setup for etcd, where the version update rolls every member of the Raft cluster.
+See [Approval Policy](/docs/operatormanual/recommendation/approval-policy.md) and
+[Maintenance Window](/docs/operatormanual/recommendation/maintenance-window.md).
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle,
+see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and
+[Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.
+
+## Next Steps
+
+- [Autoscale the compute resources of an Etcd cluster](/docs/guides/etcd/autoscaler/compute/compute-autoscale.md).
+- [Etcd Maintenance Operations](/docs/guides/etcd/maintenance/overview.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/reconfigure-tls/_index.md
+++ b/docs/guides/etcd/reconfigure-tls/_index.md
@@ -1,0 +1,12 @@
+---
+title: Reconfigure Etcd TLS/SSL
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-reconfigure-tls
+    name: Reconfigure TLS/SSL
+    parent: etcd-etcd-guides
+    weight: 46
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/reconfigure-tls/overview.md
+++ b/docs/guides/etcd/reconfigure-tls/overview.md
@@ -1,0 +1,69 @@
+---
+title: Reconfiguring Etcd TLS/SSL
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-reconfigure-tls-overview
+    name: Overview
+    parent: etcd-reconfigure-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfiguring TLS of Etcd
+
+This guide gives an overview of how the KubeDB Ops-manager operator reconfigures the TLS configuration of an `Etcd` cluster — adding TLS, removing TLS, changing the `Issuer`/`ClusterIssuer` or certificate specs, and rotating the certificates.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+    - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+    - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+    - [Etcd TLS/SSL overview](/docs/guides/etcd/tls/overview.md)
+
+## The three mutually exclusive operations
+
+`spec.tls` on an `EtcdOpsRequest` of type `ReconfigureTLS` describes exactly **one** operation per request. The admission webhook counts them and rejects a request that names more than one, with `only one TLS reconfiguration operation is allowed at a time`:
+
+| Operation             | Field(s)                        | Meaning                                                                                                                              |
+|-----------------------|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| **Remove TLS**        | `remove: true`                  | Clears `spec.tls` on the `Etcd` object, re-renders the members without any TLS flags, and deletes the now-orphaned `Certificate` objects. |
+| **Rotate**            | `rotateCertificates: true`      | Asks cert-manager to re-issue every existing certificate, keeping the same issuer and the same certificate specs.                       |
+| **Issue / update**    | `issuerRef` and/or `certificates` | Points the cluster at a different `Issuer`/`ClusterIssuer`, or changes the per-alias certificate specs. This is also how you add TLS to a cluster that does not have it yet. |
+
+Two further validations are worth knowing before you write the request:
+
+- `rotateCertificates: true` requires TLS to be enabled already — the webhook rejects it with `rotateCertificates requires TLS to already be enabled with issuerRef on Etcd`. There is nothing to rotate otherwise.
+- When you supply only `certificates` (no `issuerRef`), the `Etcd` object must already carry an `issuerRef`, otherwise the request is rejected with `tls.issuerRef is required for Etcd ReconfigureTLS`.
+
+## How the reconfiguring process works
+
+1. A user creates an `Etcd` Custom Resource Object (CRO).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CRO and creates the `PetSet` and the necessary secrets, services, etc.
+
+3. In order to change the TLS configuration, the user creates an `EtcdOpsRequest` CR of type `ReconfigureTLS`.
+
+4. The `KubeDB` Ops-manager operator watches the `EtcdOpsRequest` CR.
+
+5. When it finds one, it **pauses** the referenced `Etcd` object, so the Provisioner operator does not fight it for ownership of the `PetSet` during the operation.
+
+6. The operator folds the request into a copy of the `Etcd` object and reconciles the cert-manager `Certificate` objects from it — creating, updating or (for `remove`) preparing to delete them. For a rotation it puts cert-manager's `Issuing` condition on each `Certificate`, which is what makes cert-manager re-issue it.
+
+7. It then waits for cert-manager to finish, recording the `CertificateSynced` condition on the ops request once every certificate secret carries the new material.
+
+8. It re-renders the `PetSet` (condition `UpdateEtcdPetSet`). The TLS flags, volumes and volume mounts on the etcd container are all derived from `spec.tls`, so this single step covers adding, changing and removing TLS.
+
+9. It restarts the members (condition `RestartEtcdPods`). This is the **leader-aware rolling restart**: the operator identifies the current Raft leader, restarts every follower first — one at a time, waiting for each pod to become Ready and for the cluster to report quorum before moving to the next — and restarts the leader **last**, after handing its leadership to another voter with etcd's `MoveLeader` RPC. The ordering matters for etcd in a way it does not for a leader/follower SQL database: evicting the leader outright triggers an election, and an election makes the cluster unavailable for writes for an election timeout, whereas a deliberate transfer is near instantaneous. Peer traffic is mutually authenticated, so a member restarted with new material also has to rejoin the quorum before the next one is taken down.
+
+10. It writes the new `spec.tls` back onto the `Etcd` object (condition `UpdateDatabase`) and deletes any `Certificate` objects that are no longer referenced.
+
+11. Finally it resumes the `Etcd` object so the Provisioner operator returns to its usual duties, and marks the ops request `Successful`.
+
+Because step 9 restarts every member one at a time and waits for quorum in between, the cluster stays available for reads and writes throughout — a `ReconfigureTLS` is not a downtime operation for a 3-member (or larger) cluster. A single-member cluster (`replicas: 1`) has no quorum to preserve and will be briefly unavailable while its only member restarts.
+
+In the [next](/docs/guides/etcd/reconfigure-tls/reconfigure-tls.md) doc, we show a step-by-step guide for each of the four scenarios using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/etcd/reconfigure-tls/reconfigure-tls.md
@@ -1,0 +1,551 @@
+---
+title: Reconfigure Etcd TLS/SSL Encryption
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-reconfigure-tls-guide
+    name: Reconfigure TLS/SSL Encryption
+    parent: etcd-reconfigure-tls
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Etcd TLS/SSL (Transport Encryption)
+
+KubeDB supports adding, removing, updating and rotating the TLS configuration of a running `Etcd` cluster through an `EtcdOpsRequest`. This tutorial walks through all four.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install [`cert-manager`](https://cert-manager.io/docs/installation/) v1.0.0 or later in your cluster to manage your SSL/TLS certificates.
+
+- Install `KubeDB` Provisioner and Ops-manager operators in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the operators were installed with `--set featureGates.Etcd=true`.
+
+- You should be familiar with the following `KubeDB` concepts:
+    - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+    - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+    - [Reconfigure TLS Overview](/docs/guides/etcd/reconfigure-tls/overview.md)
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+  ```bash
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Add TLS to an Etcd cluster
+
+Here, we are going to deploy an `Etcd` cluster **without** TLS and then add TLS to it with an `EtcdOpsRequest`.
+
+### Deploy Etcd without TLS
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Wait until the cluster is `Ready`:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    3m
+```
+
+Verify that TLS is off — every advertised URL uses the `http` scheme, and there are no `--cert-file`/`--peer-cert-file` flags:
+
+```bash
+$ kubectl get pod -n demo etcd-cluster-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n'
+["--name=$(POD_NAME)"
+"--data-dir=/var/lib/etcd/data"
+"--initial-advertise-peer-urls=$(ETCD_MEMBER_PEER_URL)"
+"--listen-peer-urls=http://0.0.0.0:2380"
+"--listen-client-urls=http://0.0.0.0:2379"
+"--advertise-client-urls=$(ETCD_MEMBER_CLIENT_URL)"
+"--listen-metrics-urls=http://0.0.0.0:2381"]
+```
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
+http://127.0.0.1:2379 is healthy: successfully committed proposal: took = 1.9ms
+```
+
+### Create Issuer/ClusterIssuer
+
+Now we need an `Issuer` for cert-manager to sign the etcd certificates with.
+
+- Generate a CA certificate:
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./ca.key -out ./ca.crt -subj "/CN=etcd/O=kubedb"
+```
+
+- Create a secret from it:
+
+```bash
+$ kubectl create secret tls etcd-ca \
+     --cert=ca.crt \
+     --key=ca.key \
+     --namespace=demo
+secret/etcd-ca created
+```
+
+- Create the `Issuer`:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: etcd-ca
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcd-issuer.yaml
+issuer.cert-manager.io/etcd-ca-issuer created
+```
+
+### Create EtcdOpsRequest
+
+To add TLS, create an `EtcdOpsRequest` of type `ReconfigureTLS` that names the issuer:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+    certificates:
+      - alias: server
+        subject:
+          organizations:
+            - kubedb
+          organizationalUnits:
+            - server
+```
+
+Here,
+
+- `spec.databaseRef.name` refers to the `Etcd` object we want to reconfigure.
+- `spec.type: ReconfigureTLS` tells the Ops-manager operator that this request is about TLS.
+- `spec.tls.issuerRef` names the `Issuer` to sign the certificates. Supplying it is what adds TLS to a cluster that has none.
+- `spec.tls.certificates` is optional. Here it only customises the subject of the `server` certificate; the `client` and `peer` aliases get the defaults. You do not need to list an alias just to have it issued.
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcdops-add-tls.yaml
+etcdopsrequest.ops.kubedb.com/etcdops-add-tls created
+```
+
+### Verify TLS enabled successfully
+
+Let's watch the ops request. It moves `Pending` → `Progressing` → `Successful`:
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo etcdops-add-tls
+NAME              TYPE             STATUS       AGE
+etcdops-add-tls   ReconfigureTLS   Successful   4m
+```
+
+`kubectl describe` shows the individual steps as conditions. The condition types come straight from the operator's state machine, so they are a reliable way to see where a long-running request currently is:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcdops-add-tls
+Name:         etcdops-add-tls
+Namespace:    demo
+Kind:         EtcdOpsRequest
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:   etcd-cluster
+  Type:     ReconfigureTLS
+  Tls:
+    Issuer Ref:
+      API Group:  cert-manager.io
+      Kind:       Issuer
+      Name:       etcd-ca-issuer
+Status:
+  Conditions:
+    Type:                  Running
+    Status:                True
+    Reason:                Running
+    Message:               Etcd ops request is reconfiguring TLS
+
+    Type:                  CertificateSynced
+    Status:                True
+    Reason:                CertificateSynced
+    Message:               Successfully synced all the etcd certificates
+
+    Type:                  UpdateEtcdPetSet
+    Status:                True
+    Reason:                UpdateEtcdPetSet
+    Message:               Successfully re-rendered the petset with the new TLS configuration
+
+    Type:                  RestartEtcdPods
+    Status:                True
+    Reason:                RestartEtcdPods
+    Message:               Successfully restarted the etcd members with the new TLS configuration
+
+    Type:                  UpdateDatabase
+    Status:                True
+    Reason:                UpdateDatabase
+    Message:               Successfully updated the Etcd TLS configuration
+
+    Type:                  Successful
+    Status:                True
+    Reason:                Successful
+    Message:               Successfully reconfigured the etcd TLS configuration
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason           Message
+  ----    ------           -------
+  Normal  PauseDatabase    Pausing Etcd demo/etcd-cluster
+  Normal  Successful       Successfully restarted the etcd members with the new TLS configuration
+  Normal  ResumeDatabase   Successfully resumed Etcd demo/etcd-cluster
+  Normal  Successful       Successfully reconfigured the etcd TLS configuration
+```
+
+While the request is running, the `Etcd` object itself carries a `Paused` condition — that is the operator's way of telling the Provisioner operator to keep its hands off the `PetSet`. It is removed again when the request finishes.
+
+The certificates now exist:
+
+```bash
+$ kubectl get certificate -n demo
+NAME                        READY   SECRET                      AGE
+etcd-cluster-client-cert    True    etcd-cluster-client-cert    4m
+etcd-cluster-peer-cert      True    etcd-cluster-peer-cert      4m
+etcd-cluster-server-cert    True    etcd-cluster-server-cert    4m
+```
+
+And `spec.tls` has been written back onto the `Etcd` object:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.tls.issuerRef}'
+{"apiGroup":"cert-manager.io","kind":"Issuer","name":"etcd-ca-issuer"}
+```
+
+The members have been re-rendered with the TLS flags and the schemes have flipped to `https`:
+
+```bash
+$ kubectl get pod -n demo etcd-cluster-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n'
+["--name=$(POD_NAME)"
+"--data-dir=/var/lib/etcd/data"
+"--initial-advertise-peer-urls=$(ETCD_MEMBER_PEER_URL)"
+"--listen-peer-urls=https://0.0.0.0:2380"
+"--listen-client-urls=https://0.0.0.0:2379"
+"--advertise-client-urls=$(ETCD_MEMBER_CLIENT_URL)"
+"--listen-metrics-urls=http://0.0.0.0:2381"
+"--cert-file=/var/run/etcd/tls/server/tls.crt"
+"--key-file=/var/run/etcd/tls/server/tls.key"
+"--trusted-ca-file=/var/run/etcd/tls/server/ca.crt"
+"--client-cert-auth=true"
+"--peer-cert-file=/var/run/etcd/tls/peer/tls.crt"
+"--peer-key-file=/var/run/etcd/tls/peer/tls.key"
+"--peer-trusted-ca-file=/var/run/etcd/tls/peer/ca.crt"
+"--peer-client-cert-auth=true"]
+```
+
+Note that `--listen-metrics-urls` stays on plain `http` at port `2381` — that dedicated listener is what keeps the kubelet readiness probe working now that the client port demands a client certificate.
+
+Finally, confirm from inside a member that only a mutually authenticated client gets through:
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
+127.0.0.1:2379 is unhealthy: failed to commit proposal: context deadline exceeded
+Error: unhealthy cluster
+
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=https://127.0.0.1:2379 \
+      --cacert=/var/run/etcd/tls/client/ca.crt \
+      --cert=/var/run/etcd/tls/client/tls.crt \
+      --key=/var/run/etcd/tls/client/tls.key \
+      endpoint health
+https://127.0.0.1:2379 is healthy: successfully committed proposal: took = 2.0ms
+```
+
+And that all three members are back in the quorum after the rolling restart:
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=https://etcd-cluster.demo.svc:2379 \
+      --cacert=/var/run/etcd/tls/client/ca.crt \
+      --cert=/var/run/etcd/tls/client/tls.crt \
+      --key=/var/run/etcd/tls/client/tls.key \
+      endpoint health --cluster -w table
++----------------------------------------------------------+--------+-------+-------+
+|                         ENDPOINT                         | HEALTH | TOOK  | ERROR |
++----------------------------------------------------------+--------+-------+-------+
+| https://etcd-cluster-0.etcd-cluster-pods.demo.svc...:2379 |   true | 2.1ms |       |
+| https://etcd-cluster-1.etcd-cluster-pods.demo.svc...:2379 |   true | 2.3ms |       |
+| https://etcd-cluster-2.etcd-cluster-pods.demo.svc...:2379 |   true | 1.8ms |       |
++----------------------------------------------------------+--------+-------+-------+
+```
+
+## Rotate Certificates
+
+Rotating asks cert-manager to re-issue every existing certificate with the same issuer and the same specs. Use it when a certificate is nearing expiry, or when you suspect a key has been exposed.
+
+First, note the current expiry so you can tell the rotation apart afterwards:
+
+```bash
+$ kubectl get secret -n demo etcd-cluster-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -dates
+notBefore=Aug 15 06:12:00 2026 GMT
+notAfter=Nov 13 06:12:00 2026 GMT
+```
+
+### Create EtcdOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-rotate
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    rotateCertificates: true
+```
+
+Here, `spec.tls.rotateCertificates: true` is the **only** TLS field set. Combining it with `issuerRef`, `certificates` or `remove` is rejected by the webhook with `only one TLS reconfiguration operation is allowed at a time`. It also requires TLS to already be enabled — otherwise the webhook rejects it with `rotateCertificates requires TLS to already be enabled with issuerRef on Etcd`.
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcdops-rotate.yaml
+etcdopsrequest.ops.kubedb.com/etcdops-rotate created
+```
+
+### Verify certificates rotated successfully
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo etcdops-rotate
+NAME             TYPE             STATUS       AGE
+etcdops-rotate   ReconfigureTLS   Successful   3m
+```
+
+A rotation adds one extra step compared to adding TLS — the operator has to put cert-manager's `Issuing` condition on every `Certificate` first, which is recorded as the `IssueCertificatesSucceeded` condition:
+
+```bash
+$ kubectl get etcdopsrequest -n demo etcdops-rotate -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\n"}{end}'
+Running                       True
+IssueCertificatesSucceeded    True
+CertificateSynced             True
+UpdateEtcdPetSet              True
+RestartEtcdPods               True
+UpdateDatabase                True
+Successful                    True
+```
+
+The certificate now carries a new validity window:
+
+```bash
+$ kubectl get secret -n demo etcd-cluster-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -dates
+notBefore=Aug 15 06:41:00 2026 GMT
+notAfter=Nov 13 06:41:00 2026 GMT
+```
+
+Since the issuer — and therefore the CA — did not change, existing clients that trust the CA keep working across the rotation. Only the leaf certificates changed.
+
+## Change Issuer/ClusterIssuer
+
+You can migrate the cluster onto a different CA by pointing `spec.tls.issuerRef` at another `Issuer`/`ClusterIssuer`. This is the same "issue/update" operation as adding TLS.
+
+### Create a new Issuer
+
+```bash
+$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./ca.key -out ./ca.crt -subj "/CN=ca-updated/O=kubedb"
+
+$ kubectl create secret tls etcd-new-ca \
+     --cert=ca.crt \
+     --key=ca.key \
+     --namespace=demo
+secret/etcd-new-ca created
+```
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-new-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: etcd-new-ca
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcd-new-issuer.yaml
+issuer.cert-manager.io/etcd-new-issuer created
+```
+
+### Create EtcdOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-update-issuer
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-new-issuer
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcdops-update-issuer.yaml
+etcdopsrequest.ops.kubedb.com/etcdops-update-issuer created
+```
+
+### Verify the issuer changed successfully
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo etcdops-update-issuer
+NAME                    TYPE             STATUS       AGE
+etcdops-update-issuer   ReconfigureTLS   Successful   5m
+```
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.tls.issuerRef}'
+{"apiGroup":"cert-manager.io","kind":"Issuer","name":"etcd-new-issuer"}
+```
+
+Check the issuer recorded on a certificate secret:
+
+```bash
+$ kubectl get secret -n demo etcd-cluster-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -issuer
+issuer=CN = ca-updated, O = kubedb
+```
+
+> **Plan for the CA change.** Every member is restarted with the new CA in its `--trusted-ca-file`/`--peer-trusted-ca-file`, so the cluster ends up internally consistent. External clients, however, still trust the *old* CA and will fail to verify the server after this completes. Distribute the new `ca.crt` to your applications as part of the same change window. Within a single request the members are rolled one at a time with quorum checks in between, so the cluster itself stays available.
+
+## Remove TLS from the cluster
+
+To turn TLS off entirely, set `remove: true`.
+
+### Create EtcdOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-remove-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: etcd-cluster
+  tls:
+    remove: true
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure-tls/etcdops-remove.yaml
+etcdopsrequest.ops.kubedb.com/etcdops-remove-tls created
+```
+
+### Verify TLS removed successfully
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo etcdops-remove-tls
+NAME                 TYPE             STATUS       AGE
+etcdops-remove-tls   ReconfigureTLS   Successful   4m
+```
+
+Removing TLS skips the certificate-issuing steps entirely — there is nothing to sync — so the condition list is shorter:
+
+```bash
+$ kubectl get etcdopsrequest -n demo etcdops-remove-tls -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\n"}{end}'
+Running               True
+UpdateEtcdPetSet      True
+RestartEtcdPods       True
+UpdateDatabase        True
+Successful            True
+```
+
+`spec.tls` is gone from the `Etcd` object:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.tls}'
+
+```
+
+The now-orphaned `Certificate` objects are cleaned up by the operator:
+
+```bash
+$ kubectl get certificate -n demo
+No resources found in demo namespace.
+```
+
+And the members are back on plain `http`:
+
+```bash
+$ kubectl exec -it -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
+http://127.0.0.1:2379 is healthy: successfully committed proposal: took = 1.9ms
+```
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete etcdopsrequest -n demo etcdops-add-tls etcdops-rotate etcdops-update-issuer etcdops-remove-tls
+$ kubectl delete etcd -n demo etcd-cluster
+$ kubectl delete issuer -n demo etcd-ca-issuer etcd-new-issuer
+$ kubectl delete secret -n demo etcd-ca etcd-new-ca
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Deploy an etcd cluster with TLS from the start: [Run Etcd with TLS/SSL](/docs/guides/etcd/tls/configure-ssl.md).
+- Monitor your etcd cluster with [builtin Prometheus](/docs/guides/etcd/monitoring/using-builtin-prometheus.md) or the [Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+- Detail concepts of [EtcdOpsRequest object](/docs/guides/etcd/concepts/etcdopsrequest.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/reconfigure/_index.md
+++ b/docs/guides/etcd/reconfigure/_index.md
@@ -1,0 +1,12 @@
+---
+title: Reconfigure
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-reconfigure
+    name: Reconfigure
+    parent: etcd-etcd-guides
+    weight: 80
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/reconfigure/overview.md
+++ b/docs/guides/etcd/reconfigure/overview.md
@@ -1,0 +1,101 @@
+---
+title: Reconfiguring Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-reconfigure-overview
+    name: Overview
+    parent: etcd-reconfigure
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfiguring Etcd
+
+This guide gives an overview of how the KubeDB Ops-manager operator reconfigures a running `Etcd`
+cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## What "configuration" means for Etcd
+
+Most KubeDB databases are configured through a config file that is mounted into the pod — a
+`configSecret` whose contents are merged with the operator's defaults. **Etcd is different.**
+
+etcd's `--config-file` is *mutually exclusive* with individual command line flags: if you hand etcd
+a config file, that file has to own every single setting, including the bootstrap flags KubeDB
+computes per member (`--name`, `--initial-advertise-peer-urls`, `--listen-peer-urls`,
+`--listen-client-urls`, `--advertise-client-urls`, the TLS file paths, and so on). Silently taking
+over those would break membership management.
+
+So KubeDB exposes a small, typed set of tuning knobs instead, under `spec.configuration.tuning`,
+and renders them straight onto the etcd command line:
+
+| Field                     | etcd flag                     | Type     | Meaning                                                                               |
+|---------------------------|-------------------------------|----------|---------------------------------------------------------------------------------------|
+| `quotaBackendBytes`       | `--quota-backend-bytes`       | int64    | Maximum size of the backend database. etcd raises a `NOSPACE` alarm and goes read-only once the backend grows past it. |
+| `autoCompactionMode`      | `--auto-compaction-mode`      | string   | Either `periodic` or `revision`; selects how `autoCompactionRetention` is interpreted. |
+| `autoCompactionRetention` | `--auto-compaction-retention` | string   | A duration (e.g. `1h`) when the mode is `periodic`, a revision count (e.g. `1000`) when the mode is `revision`. |
+| `snapshotCount`           | `--snapshot-count`            | uint64   | Number of committed transactions that trigger a snapshot to disk.                      |
+
+Two consequences follow from this design, and they are the two things worth remembering about
+reconfiguring etcd:
+
+1. **`spec.configuration.applyConfig` is not supported.** `applyConfig` merges free-form key/value
+   pairs into a rendered config file, and there is no such file here — accepting it would silently
+   drop your settings. An `EtcdOpsRequest` that sets it is rejected with
+   `spec.configuration.applyConfig is not supported for etcd; use spec.configuration.tuning`.
+2. **A `Reconfigure` always requires a restart.** The knobs are process command line flags, and
+   etcd has no live-reload path for them (there is no equivalent of PostgreSQL's
+   `pg_reload_conf()`). The new values only take effect when the member process is started again.
+
+## How the Reconfiguring Etcd Process Works
+
+The reconfiguration process consists of the following steps:
+
+1. At first, a user creates an `Etcd` Custom Resource (CR).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CR.
+
+3. When the operator finds an `Etcd` CR, it creates the required `PetSet` and the related resources
+   like Secrets, Services, and so on.
+
+4. Then, in order to reconfigure the cluster, the user creates an `EtcdOpsRequest` CR of type
+   `Reconfigure`, carrying the desired `spec.configuration.tuning` values.
+
+5. The `KubeDB` Ops-manager operator watches the `EtcdOpsRequest` CR.
+
+6. When it finds an `EtcdOpsRequest` CR, it pauses the `Etcd` object referred to by the request, so
+   that the Provisioner operator does not perform any operation on it during reconfiguration.
+
+7. The Ops-manager operator folds the requested knobs into the `Etcd` object's
+   `spec.configuration.tuning`. Only the knobs the request actually names are touched, so a partial
+   reconfigure never silently resets the others.
+
+8. It then re-renders the `PetSet` from the patched spec, so the etcd container args carry the new
+   flags. This is tracked by the `UpdateEtcdPetSet` condition.
+
+9. Finally it rolls the member pods so that they come up with the new flags. This reuses exactly
+   the same leader-aware sequence as the [Restart](/docs/guides/etcd/restart/restart.md) ops
+   request: followers first, one at a time, quorum verified between each, and the Raft leader last,
+   after its leadership has been transferred away.
+
+10. After the members have restarted successfully, the Ops-manager operator resumes the `Etcd`
+    object so that the Provisioner operator resumes its usual operations.
+
+> Setting the tuning knobs at **creation time** — that is, on the `Etcd` object itself rather than
+> through an ops request — is covered by the Custom Configuration guide and by
+> [`spec.configuration`](/docs/guides/etcd/concepts/etcd.md#specconfiguration) in the Etcd concept
+> doc. This guide is only about changing them on an already running cluster with an
+> `EtcdOpsRequest`.
+
+In the [next](/docs/guides/etcd/reconfigure/reconfigure.md) doc, we are going to show a step by step
+guide on reconfiguring an Etcd cluster using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/reconfigure/overview.md
+++ b/docs/guides/etcd/reconfigure/overview.md
@@ -51,11 +51,15 @@ reconfiguring etcd:
 
 1. **`spec.configuration.applyConfig` is not supported.** `applyConfig` merges free-form key/value
    pairs into a rendered config file, and there is no such file here — accepting it would silently
-   drop your settings. An `EtcdOpsRequest` that sets it is rejected with
-   `spec.configuration.applyConfig is not supported for etcd; use spec.configuration.tuning`.
-2. **A `Reconfigure` always requires a restart.** The knobs are process command line flags, and
+   drop your settings. An `EtcdOpsRequest` that sets it is rejected at admission, telling you to use
+   `spec.configuration.tuning` instead. (`spec.configuration.configSecret` is accepted by the schema
+   but never mounted, so it has no effect either.)
+2. **A `Reconfigure` needs a restart to take effect.** The knobs are process command line flags, and
    etcd has no live-reload path for them (there is no equivalent of PostgreSQL's
-   `pg_reload_conf()`). The new values only take effect when the member process is started again.
+   `pg_reload_conf()`). The new values only take effect when the member process is started again, so
+   the ops request ends with a leader-aware rolling restart by default. Setting
+   `spec.configuration.restart: "false"` skips that restart — the `Etcd` object and the `PetSet` are
+   updated, but the running members keep their old values until something else restarts them.
 
 ## How the Reconfiguring Etcd Process Works
 

--- a/docs/guides/etcd/reconfigure/reconfigure.md
+++ b/docs/guides/etcd/reconfigure/reconfigure.md
@@ -1,0 +1,388 @@
+---
+title: Reconfigure Etcd Cluster
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-reconfigure-details
+    name: Reconfigure Configurations
+    parent: etcd-reconfigure
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Etcd Cluster
+
+This guide will show you how to use the `KubeDB` Ops-manager operator to reconfigure a running Etcd
+cluster with an `EtcdOpsRequest`.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure both operators are installed with `featureGates.Etcd=true`.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Reconfigure Overview](/docs/guides/etcd/reconfigure/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd
+
+In this section we deploy a 3 member `Etcd` cluster that already carries a few tuning knobs, so
+that we can watch them change. Below is the YAML of the `Etcd` CR we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  configuration:
+    tuning:
+      quotaBackendBytes: 2147483648
+      autoCompactionMode: periodic
+      autoCompactionRetention: "1h"
+      snapshotCount: 10000
+  deletionPolicy: WipeOut
+```
+
+Here, the backend quota is 2 GiB and etcd compacts the keyspace history every hour.
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure/etcd.yaml
+etcd.kubedb.com/etcd-quickstart created
+```
+
+Now, wait until `etcd-quickstart` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME              VERSION   STATUS   AGE
+etcd-quickstart   3.6.4     Ready    3m
+```
+
+### Check the current configuration
+
+The tuning knobs are rendered onto the etcd command line, so the authoritative place to look is the
+container args of a member pod:
+
+```bash
+$ kubectl get pod -n demo etcd-quickstart-0 -o jsonpath='{.spec.containers[?(@.name=="etcd")].args}' | jq .
+[
+  "--name=$(POD_NAME)",
+  "--data-dir=/var/lib/etcd/data",
+  "--initial-advertise-peer-urls=$(ETCD_MEMBER_PEER_URL)",
+  "--listen-peer-urls=http://0.0.0.0:2380",
+  "--listen-client-urls=http://0.0.0.0:2379",
+  "--advertise-client-urls=$(ETCD_MEMBER_CLIENT_URL)",
+  "--listen-metrics-urls=http://0.0.0.0:2381",
+  "--quota-backend-bytes=2147483648",
+  "--auto-compaction-mode=periodic",
+  "--auto-compaction-retention=1h",
+  "--snapshot-count=10000"
+]
+```
+
+The per-member flags (`--name`, the peer/client URLs) are resolved from the downward API inside the
+pod, which is why one PodSpec can serve every ordinal. The last four entries are the tuning knobs
+from `spec.configuration.tuning`.
+
+You can also confirm that the cluster itself is healthy before touching anything. Grab the
+credentials from the auth Secret first:
+
+```bash
+$ export ETCD_PASSWORD=$(kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.password}' | base64 -d)
+
+$ kubectl exec -it -n demo etcd-quickstart-0 -c etcd -- etcdctl \
+    --endpoints=http://127.0.0.1:2379 --user=root:$ETCD_PASSWORD endpoint status -w table
++------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+|        ENDPOINT        |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
++------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+| http://127.0.0.1:2379  | 8e9e05c52164694d | 3.6.4   |   20 kB |     false |      false |         2 |         14 |                 14 |        |
++------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+```
+
+> **Note:** `etcdctl endpoint status` reports runtime state (version, backend size, Raft term,
+> leadership) — it does not echo the process flags back. To verify a tuning change, read the
+> container args as shown above, or the `Etcd` object's `spec.configuration.tuning`.
+
+## Reconfigure using the tuning knobs
+
+Now we will reconfigure this cluster to raise the backend quota to 8 GiB and switch auto compaction
+from time based to revision based, keeping the last 1000 revisions.
+
+Note that `autoCompactionRetention` is interpreted differently depending on the mode: it is a
+duration (`1h`) in `periodic` mode and a revision count (`1000`) in `revision` mode. When you change
+the mode, change the retention value along with it.
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: etcd-quickstart
+  configuration:
+    tuning:
+      quotaBackendBytes: 8589934592
+      autoCompactionMode: revision
+      autoCompactionRetention: "1000"
+  timeout: 5m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are reconfiguring the `etcd-quickstart` cluster.
+- `spec.type` specifies that we are performing a `Reconfigure` operation.
+- `spec.configuration.tuning` carries the knobs to apply. Only the knobs named here are touched —
+  `snapshotCount` is not in the request, so it keeps its current value of `10000`.
+
+> **Note:** `spec.configuration.applyConfig` is **not** supported for etcd, and an ops request that
+> uses it fails with `spec.configuration.applyConfig is not supported for etcd; use
+> spec.configuration.tuning`. See the [overview](/docs/guides/etcd/reconfigure/overview.md#what-configuration-means-for-etcd)
+> for why.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/reconfigure/etcdops-reconfigure.yaml
+etcdopsrequest.ops.kubedb.com/etcd-reconfigure created
+```
+
+## This ops request always restarts the members
+
+Some KubeDB databases can apply a new configuration to a running server and only restart when the
+changed settings demand it. **Etcd cannot.** The tuning knobs are etcd process command line flags,
+and etcd has no live-reload path for them, so a `Reconfigure` on etcd is always a rolling restart:
+after re-rendering the PetSet, the operator rolls the member pods using the same leader-aware
+sequence as the [Restart](/docs/guides/etcd/restart/restart.md) ops request — followers first, one
+at a time, quorum verified between each, the Raft leader last and only after its leadership has been
+transferred away.
+
+That is why you will always see a `RestartEtcdPods` condition on a successful etcd `Reconfigure`.
+
+> Setting `spec.configuration.restart: "false"` does skip the rolling restart, but it does **not**
+> give you a live reconfiguration: the running members keep their old flags until something else
+> recreates them. Only the desired state on the `Etcd` object and the `PetSet` template change. Use
+> it only if you intend to schedule the restart yourself later.
+
+## Verify the new configuration
+
+Let's wait for the `EtcdOpsRequest` to be `Successful`. Run the following command to watch it,
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME               TYPE          STATUS       AGE
+etcd-reconfigure   Reconfigure   Successful   3m
+```
+
+We can see from the above output that the `EtcdOpsRequest` has succeeded. If we describe it, we get
+an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-reconfigure
+Name:         etcd-reconfigure
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-02-10T08:27:00Z
+  Generation:          1
+  Resource Version:    1548116
+  UID:                 4f3daa11-c41b-4079-a8d8-1040931284ef
+Spec:
+  Apply:  IfReady
+  Configuration:
+    Tuning:
+      Auto Compaction Mode:       revision
+      Auto Compaction Retention:  1000
+      Quota Backend Bytes:        8589934592
+  Database Ref:
+    Name:   etcd-quickstart
+  Timeout:  5m
+  Type:     Reconfigure
+Status:
+  Conditions:
+    Last Transition Time:  2026-02-10T08:27:00Z
+    Message:               Reconfigure is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-02-10T08:27:06Z
+    Message:               Successfully updated the Etcd configuration
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-02-10T08:27:08Z
+    Message:               Successfully re-rendered the petset with the new configuration
+    Observed Generation:   1
+    Reason:                UpdateEtcdPetSet
+    Status:                True
+    Type:                  UpdateEtcdPetSet
+    Last Transition Time:  2026-02-10T08:27:45Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-quickstart-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-quickstart-0
+    Last Transition Time:  2026-02-10T08:27:50Z
+    Message:               etcd cluster healthy; ConditionStatus:True; PodName:etcd-quickstart-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdClusterHealthy--etcd-quickstart-0
+    Last Transition Time:  2026-02-10T08:28:25Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-quickstart-2
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-quickstart-2
+    Last Transition Time:  2026-02-10T08:28:35Z
+    Message:               move leader; ConditionStatus:True; PodName:etcd-quickstart-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  MoveLeader--etcd-quickstart-1
+    Last Transition Time:  2026-02-10T08:29:10Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-quickstart-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-quickstart-1
+    Last Transition Time:  2026-02-10T08:29:16Z
+    Message:               Successfully restarted the etcd members with the new configuration
+    Observed Generation:   1
+    Reason:                RestartEtcdPods
+    Status:                True
+    Type:                  RestartEtcdPods
+    Last Transition Time:  2026-02-10T08:29:18Z
+    Message:               Successfully reconfigured the etcd cluster
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason            Age    From                         Message
+  ----    ------            ----   ----                         -------
+  Normal  PauseDatabase     3m     KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-quickstart
+  Normal  UpdateDatabase    2m54s  KubeDB Ops-manager Operator  Successfully updated the Etcd configuration
+  Normal  UpdateEtcdPetSet  2m52s  KubeDB Ops-manager Operator  Successfully re-rendered the petset with the new configuration
+  Normal  RestartEtcdPods   44s    KubeDB Ops-manager Operator  Successfully restarted the etcd members with the new configuration
+  Normal  ResumeDatabase    42s    KubeDB Ops-manager Operator  Resuming Etcd demo/etcd-quickstart
+  Normal  Successful        42s    KubeDB Ops-manager Operator  Successfully reconfigured the etcd cluster
+```
+
+The three phases of the request are visible in the conditions: `UpdateDatabase` (the `Etcd` object's
+`spec.configuration.tuning` is patched), `UpdateEtcdPetSet` (the PetSet template is re-rendered with
+the new flags) and `RestartEtcdPods` (the members are rolled, leader last).
+
+Now, wait until `etcd-quickstart` is `Ready` again. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME              VERSION   STATUS   AGE
+etcd-quickstart   3.6.4     Ready    12m
+```
+
+First, check the desired state on the `Etcd` object:
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart -o jsonpath='{.spec.configuration.tuning}' | jq .
+{
+  "autoCompactionMode": "revision",
+  "autoCompactionRetention": "1000",
+  "quotaBackendBytes": 8589934592,
+  "snapshotCount": 10000
+}
+```
+
+Note that `snapshotCount` is still `10000` — the ops request did not name it, so it was left alone.
+
+Then check that the running members actually carry the new flags:
+
+```bash
+$ kubectl get pod -n demo etcd-quickstart-0 -o jsonpath='{.spec.containers[?(@.name=="etcd")].args}' | jq .
+[
+  "--name=$(POD_NAME)",
+  "--data-dir=/var/lib/etcd/data",
+  "--initial-advertise-peer-urls=$(ETCD_MEMBER_PEER_URL)",
+  "--listen-peer-urls=http://0.0.0.0:2380",
+  "--listen-client-urls=http://0.0.0.0:2379",
+  "--advertise-client-urls=$(ETCD_MEMBER_CLIENT_URL)",
+  "--listen-metrics-urls=http://0.0.0.0:2381",
+  "--quota-backend-bytes=8589934592",
+  "--auto-compaction-mode=revision",
+  "--auto-compaction-retention=1000",
+  "--snapshot-count=10000"
+]
+```
+
+`--quota-backend-bytes` has been raised from `2147483648` to `8589934592` and the auto compaction
+has switched from `periodic`/`1h` to `revision`/`1000`, so the reconfiguration is complete.
+
+Finally, confirm that the cluster is still healthy and every member came back:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-0 -c etcd -- etcdctl \
+    --endpoints=http://127.0.0.1:2379 --user=root:$ETCD_PASSWORD endpoint health --cluster -w table
++---------------------------------------------------------------+--------+------------+-------+
+|                           ENDPOINT                            | HEALTH |    TOOK    | ERROR |
++---------------------------------------------------------------+--------+------------+-------+
+| http://etcd-quickstart-0.etcd-quickstart-pods.demo.svc:2379    |   true | 3.1ms      |       |
+| http://etcd-quickstart-1.etcd-quickstart-pods.demo.svc:2379    |   true | 3.4ms      |       |
+| http://etcd-quickstart-2.etcd-quickstart-pods.demo.svc:2379    |   true | 2.9ms      |       |
++---------------------------------------------------------------+--------+------------+-------+
+```
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-reconfigure
+kubectl delete etcd -n demo etcd-quickstart
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Detail concepts of [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Detail concepts of [EtcdOpsRequest object](/docs/guides/etcd/concepts/etcdopsrequest.md).
+- Restart the cluster without changing anything with [Restart](/docs/guides/etcd/restart/restart.md).
+- Rotate the etcd credentials with [Rotate Authentication](/docs/guides/etcd/rotate-authentication/rotateauth.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/reconfigure/reconfigure.md
+++ b/docs/guides/etcd/reconfigure/reconfigure.md
@@ -170,10 +170,9 @@ Here,
 - `spec.configuration.tuning` carries the knobs to apply. Only the knobs named here are touched —
   `snapshotCount` is not in the request, so it keeps its current value of `10000`.
 
-> **Note:** `spec.configuration.applyConfig` is **not** supported for etcd, and an ops request that
-> uses it fails with `spec.configuration.applyConfig is not supported for etcd; use
-> spec.configuration.tuning`. See the [overview](/docs/guides/etcd/reconfigure/overview.md#what-configuration-means-for-etcd)
-> for why.
+> **Note:** `spec.configuration.applyConfig` is **not** supported for etcd — an ops request that uses
+> it is rejected at admission and told to use `spec.configuration.tuning` instead. See the
+> [overview](/docs/guides/etcd/reconfigure/overview.md#what-configuration-means-for-etcd) for why.
 
 Let's create the `EtcdOpsRequest` CR we have shown above,
 
@@ -182,17 +181,17 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
 etcdopsrequest.ops.kubedb.com/etcd-reconfigure created
 ```
 
-## This ops request always restarts the members
+## This ops request restarts the members
 
 Some KubeDB databases can apply a new configuration to a running server and only restart when the
 changed settings demand it. **Etcd cannot.** The tuning knobs are etcd process command line flags,
-and etcd has no live-reload path for them, so a `Reconfigure` on etcd is always a rolling restart:
-after re-rendering the PetSet, the operator rolls the member pods using the same leader-aware
+and etcd has no live-reload path for them, so a `Reconfigure` on etcd is a rolling restart by
+default: after re-rendering the PetSet, the operator rolls the member pods using the same leader-aware
 sequence as the [Restart](/docs/guides/etcd/restart/restart.md) ops request — followers first, one
 at a time, quorum verified between each, the Raft leader last and only after its leadership has been
 transferred away.
 
-That is why you will always see a `RestartEtcdPods` condition on a successful etcd `Reconfigure`.
+That is why you will normally see a `RestartEtcdPods` condition on a successful etcd `Reconfigure`.
 
 > Setting `spec.configuration.restart: "false"` does skip the rolling restart, but it does **not**
 > give you a live reconfiguration: the running members keep their old flags until something else

--- a/docs/guides/etcd/recover-from-quorum-loss/_index.md
+++ b/docs/guides/etcd/recover-from-quorum-loss/_index.md
@@ -1,0 +1,12 @@
+---
+title: Recover from Quorum Loss
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-recover-from-quorum-loss
+    name: Recover from Quorum Loss
+    parent: etcd-etcd-guides
+    weight: 77
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/recover-from-quorum-loss/overview.md
+++ b/docs/guides/etcd/recover-from-quorum-loss/overview.md
@@ -1,0 +1,204 @@
+---
+title: Etcd Recover from Quorum Loss Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-recover-from-quorum-loss-overview
+    name: Overview
+    parent: etcd-recover-from-quorum-loss
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Recovery from Quorum Loss
+
+This guide gives an overview of how the KubeDB Ops-manager operator rebuilds an `Etcd` cluster that
+has **permanently** lost its Raft quorum, from a single surviving member.
+
+> **This is a break-glass, disaster-recovery procedure, not routine maintenance.** It destroys the
+> data of every member except the one you confirm, and it can lose writes. Read this whole page
+> before you create a `RecoverFromQuorumLoss` `EtcdOpsRequest`.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Horizontal Scaling Overview](/docs/guides/etcd/scaling/horizontal-scaling/overview.md) — the
+    learner-add/promote mechanism this recovery relies on to regrow the cluster.
+
+## What Quorum Loss Actually Is
+
+An etcd cluster is a Raft consensus group. Every write has to be acknowledged by a quorum of
+`N/2+1` **voting** members, so a 3-member cluster needs 2 and a 5-member cluster needs 3.
+
+When a *majority* of the voting members is gone **for good**, Raft can never make progress again:
+
+- the surviving minority cannot elect a leader, so no write — and no read that has to be
+  linearizable — can be served;
+- the dead members cannot be removed from the membership either, because a membership change is
+  itself a Raft proposal and therefore needs the very quorum that no longer exists.
+
+That deadlock is not something the cluster can heal from on its own. The only way out is etcd's own
+documented `--force-new-cluster` procedure, which rewrites one surviving member's data directory so
+that the cluster it describes consists of that member alone. `RecoverFromQuorumLoss` is the
+`EtcdOpsRequest` type that performs that procedure for you, safely and resumably.
+
+## When to Use It
+
+Use it when a **majority of members is permanently gone**, and there is no prospect of them coming
+back. In practice that means the member's node *and* its data volume are both gone:
+
+- several nodes were deleted, or their disks failed, and the PVs went with them;
+- a cloud availability zone holding two of three members was lost;
+- someone deleted the PVCs of a majority of the members.
+
+**Do not use it for any of the following** — in every one of these cases the cluster either still
+has quorum, or will heal on its own once the missing members come back, and running this recovery
+would throw away good data for nothing:
+
+| Situation | What to do instead |
+|---|---|
+| A single member of a 3-member cluster is down | Nothing. The cluster still has quorum. Fix the node or let the `PetSet` recreate the pod. |
+| A member is down but its PVC still exists | Wait. When the pod is rescheduled on the volume, it rejoins with its own data. |
+| Members are up but slow / flapping | Investigate disk latency and networking. See [monitoring](/docs/guides/etcd/monitoring/overview.md). |
+| Every member is down but every volume is intact | Wait, or perform a [Restart](/docs/guides/etcd/restart/restart.md). The members re-elect a leader as they come back. |
+| The data itself is bad, and you want a known-good copy back | Use an [in-place Restore](/docs/guides/etcd/restore/overview.md) from a KubeStash snapshot. |
+
+## The `QuorumLost` Signal
+
+The Provisioner operator's health checker dials every member and asks etcd whether a quorum is
+answering. When it is not, the operator sets a `QuorumLost` condition on the `Etcd` object:
+
+```yaml
+status:
+  conditions:
+    - type: QuorumLost
+      status: "True"
+      reason: RaftQuorumLost
+      message: >-
+        The Etcd: demo/etcd-cluster has lost its Raft quorum: 2 of 3 members are not answering.
+        ...
+```
+
+Two things about this condition matter:
+
+1. **Nothing acts on it automatically.** It is only ever a signal for a human (or for a
+   `RecoverFromQuorumLoss` ops request authored by one). Rebuilding a cluster from one survivor
+   throws data away, so KubeDB will never do it behind your back.
+2. **It is a live gate on the recovery.** The ops request reads the condition straight from the API
+   server, and refuses to run at all unless the `Etcd` currently reports `QuorumLost=True`. The
+   condition is flipped back to `False` (with reason `RaftQuorumHealthy`) rather than removed once
+   quorum returns, so a cluster that healed on its own cannot be torn down by a request that was
+   written while it was broken.
+
+## What Gets Lost
+
+Two distinct things:
+
+- **Every other member's data directory is discarded, permanently.** After the recovery the cluster
+  is a brand new one-member cluster with a new cluster ID, so a member still carrying the old
+  cluster ID could never rejoin it anyway. Those members come back as empty learners.
+- **Any write the lost majority had committed but which the survivor had not yet applied is gone.**
+  There is no way to get it back. This is inherent to `--force-new-cluster`, not a KubeDB
+  limitation — the writes only ever existed on machines you no longer have.
+
+Choosing the survivor with the highest Raft applied index is what minimises the second loss, which
+is exactly what the operator does when you do not name a member yourself.
+
+## The Confirmation Gate
+
+The recovery has a **mandatory two-step handshake**, and it is the most important thing to
+understand about this ops request:
+
+1. You create the `EtcdOpsRequest`. `spec.recoverFromQuorumLoss.member` is optional — leave it
+   empty and the operator picks the reachable member with the **highest Raft applied index**; set it
+   (a pod name, or a bare ordinal like `"0"`) to choose one yourself.
+
+2. The operator resolves the survivor **exactly once**, records it in an
+   `EtcdQuorumLossSurvivorResolved--<pod>` condition, and then **stops**. It reports the choice in
+   the `EtcdQuorumLossAwaitingConfirmation` condition and waits — indefinitely, with no timeout and
+   no failure — until `spec.recoverFromQuorumLoss.confirmMember` names exactly that pod.
+
+3. You read the resolved name, agree with it, and patch `confirmMember` to match. Only then does
+   anything destructive happen.
+
+This is deliberate. The gate exists so that a mistyped `member` — or a survivor you did not expect
+the operator to pick — cannot silently destroy the wrong member's data. And because the resolution
+happens only once and is never re-picked on a later pass, the member you confirmed is guaranteed to
+be the member the recovery keeps. If the resolved survivor is not the one you want, delete the ops
+request and create a new one naming the member you do want; there is no way to change the answer
+in place.
+
+## How the Recovery Process Works
+
+Every step is gated by its own condition on the ops request, so an operator restart resumes exactly
+where it left off rather than starting over.
+
+1. The user creates an `EtcdOpsRequest` of type `RecoverFromQuorumLoss` with a `spec.timeout`.
+
+2. **Admission.** The operator reads the `Etcd` object live and refuses the request outright unless
+   `QuorumLost=True`. A refusal is terminal — it does not burn `spec.maxRetries` and retrying it
+   cannot change the answer.
+
+3. The Ops-manager operator pauses the `Etcd` object, so the Provisioner operator does not fight
+   the recovery.
+
+4. **The survivor is resolved** and the request waits for `confirmMember`, as described above.
+
+5. **Preflight.** The last look at the cluster while everything is still intact: the quorum really
+   is still lost (a cluster that recovered on its own while the request waited for confirmation is
+   refused here), and the pod of ordinal 0 exists, since its manifest is what the rebuilt member is
+   recreated from.
+
+6. The `PetSet` is deleted **with an orphan propagation policy** — it would otherwise recreate
+   every pod the recovery deletes and re-provision every claim it discards.
+
+7. **The survivor is relocated onto ordinal 0.** If the survivor already *is* ordinal 0, its pod is
+   simply taken down. Otherwise its volume is rebound under ordinal 0's claim name: no data is
+   copied, only the name the volume answers to changes, and the rebuilt member is pinned to the node
+   the survivor was running on.
+
+8. **Every other member is discarded**, one per pass: the pod is taken down (tolerating members
+   whose pod object is already gone) and its claim is dropped.
+
+9. The cluster-state ConfigMap is rewritten for a **single member** cluster.
+
+10. **Ordinal 0 is booted with `--force-new-cluster`**, which is the step that actually rebuilds the
+    cluster. The operator then waits until it is `Ready` and reports exactly one member.
+
+11. **The flag is taken back off** by recreating the member once more without it.
+    `--force-new-cluster` is not self-clearing: left on the command line it would rewrite the data
+    directory into a fresh single-member cluster on *every* later restart, silently discarding every
+    member added back in the meantime.
+
+12. The reclaim policies parked while the volumes were being swapped are restored — **this is what
+    finally destroys the discarded members' data**, and it is deliberately left until the rebuilt
+    member is up and healthy, so a crash mid-recovery has thrown nothing away.
+
+13. The `PetSet` is recreated around the rebuilt member, the `Etcd` object is resumed, and the
+    request is marked `Successful`.
+
+Nothing in the recovery regrows the cluster. Once the database is resumed, the ordinary membership
+reconciliation sees one member against `spec.replicas` and adds the rest back through **exactly the
+same learner-add/promote path an ordinary scale up uses** — each new member joins as a learner,
+streams the recovered keyspace from the survivor, and is promoted to a voting member once it has
+caught up.
+
+## Preconditions
+
+- The `Etcd` object must currently report `QuorumLost=True`. Anything else is refused.
+- **`spec.timeout` is required.** Several steps — waiting for the rebuilt member to come up, waiting
+  for a volume to rebind — have no other deadline at all.
+- `spec.storageType` must be `Durable`. An ephemeral member's data died with its pod, so there is
+  nothing to rescue.
+- At least one member must still answer, and if you name one in `spec.recoverFromQuorumLoss.member`
+  it must be that one — a cluster cannot be rebuilt from a member that cannot be reached.
+
+In the [next](/docs/guides/etcd/recover-from-quorum-loss/recover-from-quorum-loss.md) doc, we are
+going to show a step-by-step guide on recovering an Etcd cluster from a permanent quorum loss using
+the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/recover-from-quorum-loss/overview.md
+++ b/docs/guides/etcd/recover-from-quorum-loss/overview.md
@@ -34,7 +34,7 @@ has **permanently** lost its Raft quorum, from a single surviving member.
 ## What Quorum Loss Actually Is
 
 An etcd cluster is a Raft consensus group. Every write has to be acknowledged by a quorum of
-`N/2+1` **voting** members, so a 3-member cluster needs 2 and a 5-member cluster needs 3.
+`floor(N/2) + 1` **voting** members, so a 3-member cluster needs 2 and a 5-member cluster needs 3.
 
 When a *majority* of the voting members is gone **for good**, Raft can never make progress again:
 

--- a/docs/guides/etcd/recover-from-quorum-loss/recover-from-quorum-loss.md
+++ b/docs/guides/etcd/recover-from-quorum-loss/recover-from-quorum-loss.md
@@ -364,8 +364,9 @@ Events:
   Normal  Successful                 17s    KubeDB Ops-manager Operator  Successfully recovered the etcd cluster from the loss of its quorum
 ```
 
-The per-resource progress conditions (`PVCDeleted--…`, `PodDeleted--…`, `PodReady--…`, and so on)
-are elided above; they appear for every step that had to wait and are useful when a recovery stalls.
+The per-resource progress conditions (`PetSetDeleted--…`, `PVCDeleted--…`, `GetPod--…`, `PodDeleted--…`, `PodCreated--…`, `PatchPV--…`,
+and so on) are elided above. They are written for every step the recovery completes, not only for
+steps that had to wait, and are useful when a recovery stalls.
 
 ## Watch the Cluster Regrow
 

--- a/docs/guides/etcd/recover-from-quorum-loss/recover-from-quorum-loss.md
+++ b/docs/guides/etcd/recover-from-quorum-loss/recover-from-quorum-loss.md
@@ -1,0 +1,465 @@
+---
+title: Etcd Recover from Quorum Loss
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-recover-from-quorum-loss-ops
+    name: Recover from Quorum Loss
+    parent: etcd-recover-from-quorum-loss
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Recover an Etcd Cluster from a Permanent Quorum Loss
+
+This guide shows how to rebuild an `Etcd` cluster that has permanently lost its Raft quorum, using
+an `EtcdOpsRequest` of type `RecoverFromQuorumLoss`. KubeDB keeps the single surviving member you
+confirm, force-boots it as a brand new one-member cluster with etcd's own `--force-new-cluster`
+procedure, and lets the ordinary membership reconciliation regrow the cluster from there.
+
+> **This is a destructive, break-glass procedure.** Every member except the confirmed survivor has
+> its data discarded permanently, and any write the lost majority had committed but the survivor had
+> not yet applied is gone for good. It is never triggered automatically. Read the
+> [overview](/docs/guides/etcd/recover-from-quorum-loss/overview.md) — especially
+> [when *not* to use it](/docs/guides/etcd/recover-from-quorum-loss/overview.md#when-to-use-it) —
+> before you run it.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster.
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Recover from Quorum Loss Overview](/docs/guides/etcd/recover-from-quorum-loss/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/recover-from-quorum-loss](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/recover-from-quorum-loss)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Deploy an Etcd Cluster
+
+Below is the YAML of the `Etcd` CR that we are going to create,
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/recover-from-quorum-loss/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Wait until `etcd-cluster` is `Ready` and all three voting members are healthy:
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    6m
+
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 endpoint health --cluster -w table
++---------------------------------------------------------------------+--------+-------------+-------+
+|                              ENDPOINT                               | HEALTH |    TOOK     | ERROR |
++---------------------------------------------------------------------+--------+-------------+-------+
+| http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |   true | 4.512103ms  |       |
+| http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |   true | 5.284917ms  |       |
+| http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |   true | 5.901442ms  |       |
++---------------------------------------------------------------------+--------+-------------+-------+
+```
+
+## Recognise a Permanent Quorum Loss
+
+For this walkthrough, assume the two nodes hosting `etcd-cluster-0` and `etcd-cluster-2` were lost
+together with their disks — their pods and their `PersistentVolumeClaim`s are gone and are not
+coming back. Only `etcd-cluster-1` is left, and 1 out of 3 is not a quorum.
+
+The `Etcd` object goes `NotReady`:
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS     AGE
+etcd-cluster   3.6.4     NotReady   41m
+```
+
+and the Provisioner operator's health checker raises the `QuorumLost` condition on it:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{range .status.conditions[?(@.type=="QuorumLost")]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\n"}{.message}{"\n"}{end}'
+QuorumLost	True	RaftQuorumLost
+The Etcd: demo/etcd-cluster has lost its Raft quorum: 2 of 3 members are not answering. http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379: context deadline exceeded; http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379: context deadline exceeded
+```
+
+> **This condition is only a signal.** KubeDB will never act on it by itself. It is also the gate on
+> the recovery: an ops request created against an `Etcd` that does *not* report `QuorumLost=True`
+> right now is refused outright.
+
+Before going any further, convince yourself the loss really is permanent — that the missing members'
+volumes are gone, not merely unmounted, and that no node is about to come back. If the members can
+return, waiting costs you nothing and loses no data; this procedure does both.
+
+## Create a RecoverFromQuorumLoss EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-recover-quorum
+  namespace: demo
+spec:
+  type: RecoverFromQuorumLoss
+  databaseRef:
+    name: etcd-cluster
+  recoverFromQuorumLoss: {}
+  timeout: 30m
+  apply: Always
+```
+
+Here,
+
+- `spec.recoverFromQuorumLoss.member` is **omitted**, so the operator picks the reachable member with
+  the highest Raft applied index — the survivor that is least behind, and therefore the one that
+  loses the fewest writes. Set it to a pod name (`etcd-cluster-1`) or a bare ordinal (`"1"`) if you
+  want to choose yourself.
+- `spec.recoverFromQuorumLoss.confirmMember` is **deliberately left unset for now**. It is the hard
+  confirmation gate: nothing destructive happens until it names exactly the survivor the operator
+  resolved. We fill it in a moment, once we have read that name.
+- `spec.timeout` is **required** for `RecoverFromQuorumLoss`. Every step is bounded by it, and
+  several — waiting for the rebuilt member to come up, waiting for a volume to rebind — have no
+  other deadline at all.
+- `spec.apply: Always` is what you want here. The default, `IfReady`, holds the request until the
+  database is `Ready` — which, by definition, a cluster that has lost its quorum is not.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/recover-from-quorum-loss/etcdops-recover-quorum.yaml
+etcdopsrequest.ops.kubedb.com/etcd-recover-quorum created
+```
+
+## Read the Resolved Survivor
+
+The operator admits the request, pauses the database, resolves the survivor, and then **stops and
+waits for you**:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                  TYPE                    STATUS        AGE
+etcd-recover-quorum   RecoverFromQuorumLoss   Progressing   45s
+```
+
+The resolved choice is reported in two places. As a condition:
+
+```bash
+$ kubectl get etcdopsrequest -n demo etcd-recover-quorum -o jsonpath='{range .status.conditions[?(@.type=="EtcdQuorumLossAwaitingConfirmation")]}{.message}{"\n"}{end}'
+Resolved etcd-cluster-1 as the surviving etcd member to rebuild demo/etcd-cluster from. Set spec.recoverFromQuorumLoss.confirmMember to "etcd-cluster-1" to allow the recovery to discard every other member's data; it currently reads "".
+```
+
+and as a companion condition that records the decision permanently:
+
+```bash
+$ kubectl get etcdopsrequest -n demo etcd-recover-quorum -o jsonpath='{range .status.conditions[*]}{.type}{"\n"}{end}' | grep EtcdQuorumLoss
+EtcdQuorumLossAdmitted
+EtcdQuorumLossSurvivorResolved--etcd-cluster-1
+EtcdQuorumLossAwaitingConfirmation
+```
+
+The request will sit here **indefinitely**. This wait is a gate, not a retry: it never times out and
+never fails the request, because what it is waiting for is a person reading the resolved survivor
+and agreeing to it.
+
+> The survivor is resolved **exactly once** and is never re-picked on a later pass. If
+> `etcd-cluster-1` is not the member you want to keep, delete this ops request and create a new one
+> with `spec.recoverFromQuorumLoss.member` naming the one you do want — there is no way to change
+> the answer in place.
+
+## Confirm the Survivor
+
+Now that you have read the name, agree to it:
+
+```bash
+$ kubectl patch etcdopsrequest -n demo etcd-recover-quorum --type=merge \
+    -p '{"spec":{"recoverFromQuorumLoss":{"confirmMember":"etcd-cluster-1"}}}'
+etcdopsrequest.ops.kubedb.com/etcd-recover-quorum patched
+```
+
+The value has to match the resolved pod name **exactly**. Anything else — including the ordinal
+form, if the operator resolved a pod name — leaves the request waiting.
+
+From this point on the recovery proceeds on its own, and it is destructive.
+
+## Verify the Recovery
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME                  TYPE                    STATUS       AGE
+etcd-recover-quorum   RecoverFromQuorumLoss   Successful   12m
+```
+
+While it runs you can watch the cluster shrink to a single member and come back. The `PetSet` is
+deleted up front (with orphaned pods), the survivor's volume is rebound under ordinal 0's claim
+name, and ordinal 0 is booted with `--force-new-cluster`:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME             READY   STATUS    RESTARTS   AGE
+etcd-cluster-0   1/1     Running   0          38s
+
+$ kubectl get pod -n demo etcd-cluster-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n' | tail -2
+"--listen-metrics-urls=http://0.0.0.0:2381"
+"--force-new-cluster"]
+```
+
+The flag is taken back off in a later step — it is not self-clearing, and left in place it would
+rewrite the data directory into a fresh single-member cluster on every subsequent restart.
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-recover-quorum
+Name:         etcd-recover-quorum
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T09:02:11Z
+  Generation:          2
+  Resource Version:    204518
+  UID:                 f2ad7a1e-1c94-4a4e-9d1e-4a2f7b6a9c31
+Spec:
+  Apply:  Always
+  Database Ref:
+    Name:  etcd-cluster
+  Recover From Quorum Loss:
+    Confirm Member:  etcd-cluster-1
+  Timeout:           30m
+  Type:              RecoverFromQuorumLoss
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T09:02:14Z
+    Message:               Etcd demo/etcd-cluster reports QuorumLost=True
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdQuorumLossAdmitted
+    Last Transition Time:  2026-08-15T09:02:16Z
+    Message:               Recovery from the etcd quorum loss is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T09:02:31Z
+    Message:               etcd quorum loss survivor resolved; ConditionStatus:True; PodName:etcd-cluster-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdQuorumLossSurvivorResolved--etcd-cluster-1
+    Last Transition Time:  2026-08-15T09:06:04Z
+    Message:               Confirmed etcd-cluster-1 as the surviving etcd member
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossAwaitingConfirmation
+    Last Transition Time:  2026-08-15T09:06:09Z
+    Message:               Etcd demo/etcd-cluster has still lost its quorum and etcd-cluster-0 is present; rebuilding it from etcd-cluster-1
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossPreflight
+    Last Transition Time:  2026-08-15T09:06:22Z
+    Message:               pet set deleted; ConditionStatus:True; PodName:etcd-cluster
+    Observed Generation:   2
+    Status:                True
+    Type:                  PetSetDeleted--etcd-cluster
+    Last Transition Time:  2026-08-15T09:07:41Z
+    Message:               Relocated the volume of the surviving member etcd-cluster-1 onto etcd-cluster-0
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossPVCRelocated
+    Last Transition Time:  2026-08-15T09:08:12Z
+    Message:               Discarded every etcd member outside the surviving etcd-cluster-1
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossStaleMembersRemoved
+    Last Transition Time:  2026-08-15T09:08:16Z
+    Message:               Rewrote the cluster state ConfigMap for a single member cluster
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossClusterStateSeeded
+    Last Transition Time:  2026-08-15T09:08:24Z
+    Message:               Recreated etcd-cluster-0 with --force-new-cluster
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossForceNewClusterBoot
+    Last Transition Time:  2026-08-15T09:09:02Z
+    Message:               etcd-cluster-0 is serving as a healthy single member cluster
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossSingleMemberHealthy
+    Last Transition Time:  2026-08-15T09:09:44Z
+    Message:               Recreated etcd-cluster-0 without --force-new-cluster
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossFlagRemoved
+    Last Transition Time:  2026-08-15T09:09:48Z
+    Message:               Restored the reclaim policy of every volume the recovery touched
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossVolumesReclaimed
+    Last Transition Time:  2026-08-15T09:09:53Z
+    Message:               Restored the PetSet of Etcd demo/etcd-cluster around the rebuilt member
+    Observed Generation:   2
+    Status:                True
+    Type:                  EtcdQuorumLossPetSetRestored
+    Last Transition Time:  2026-08-15T09:09:57Z
+    Message:               Successfully rebuilt the etcd cluster from the surviving member etcd-cluster-1
+    Observed Generation:   2
+    Reason:                RecoverEtcdFromQuorumLoss
+    Status:                True
+    Type:                  RecoverEtcdFromQuorumLoss
+    Last Transition Time:  2026-08-15T09:10:02Z
+    Message:               Successfully recovered the etcd cluster from the loss of its quorum
+    Observed Generation:   2
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     2
+  Phase:                   Successful
+Events:
+  Type    Reason                     Age    From                         Message
+  ----    ------                     ----   ----                         -------
+  Normal  PauseDatabase              12m    KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
+  Normal  RecoverEtcdFromQuorumLoss  22s    KubeDB Ops-manager Operator  Successfully rebuilt the etcd cluster from the surviving member etcd-cluster-1
+  Normal  ResumeDatabase             17s    KubeDB Ops-manager Operator  Successfully resumed Etcd demo/etcd-cluster
+  Normal  Successful                 17s    KubeDB Ops-manager Operator  Successfully recovered the etcd cluster from the loss of its quorum
+```
+
+The per-resource progress conditions (`PVCDeleted--…`, `PodDeleted--…`, `PodReady--…`, and so on)
+are elided above; they appear for every step that had to wait and are useful when a recovery stalls.
+
+## Watch the Cluster Regrow
+
+The recovery itself stops at a healthy **one-member** cluster. Growing it back to `spec.replicas` is
+not its job — once the `Etcd` object is resumed, the ordinary membership reconciliation notices one
+member against three replicas and adds the others back through exactly the same
+[learner-add/promote path](/docs/guides/etcd/scaling/horizontal-scaling/overview.md#learners) an
+ordinary scale up uses. Each new member joins as a learner, streams the recovered keyspace from
+`etcd-cluster-0`, and is promoted to a voting member once it has caught up:
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS     AGE
+etcd-cluster   3.6.4     Critical   1h
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME             READY   STATUS    RESTARTS   AGE
+etcd-cluster-0   1/1     Running   0          6m
+etcd-cluster-1   1/1     Running   0          2m
+etcd-cluster-2   0/1     Running   0          14s
+```
+
+The `Critical` phase here is expected — the client endpoint is serving, but not every member is
+ready yet because a learner is still catching up. Once all three are voting members the cluster goes
+back to `Ready`:
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    1h
+
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 member list -w table
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+|        ID        | STATUS  |      NAME      |                             PEER ADDRS                              |                            CLIENT ADDRS                             | IS LEARNER |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+| 8e9e05c52164694d | started | etcd-cluster-0 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| b2c6679ac05f2cf1 | started | etcd-cluster-1 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| ffc1c9a1a4b6ef2b | started | etcd-cluster-2 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+```
+
+Note that the member IDs and the cluster ID are new: `--force-new-cluster` minted a brand new
+cluster, which is exactly why the discarded members could never have rejoined with their old data
+directories.
+
+Finally, check that the `QuorumLost` condition has flipped back:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{range .status.conditions[?(@.type=="QuorumLost")]}{.status}{"\t"}{.reason}{"\n"}{end}'
+False	RaftQuorumHealthy
+```
+
+## Troubleshooting
+
+- **`Etcd demo/etcd-cluster does not currently report QuorumLost=True, so it has not permanently
+  lost its Raft quorum; refusing to run the destructive quorum loss recovery`** — the cluster still
+  has quorum. This refusal is terminal: it marks the request `Failed` immediately rather than
+  retrying, because retrying cannot change the answer.
+- **`Etcd demo/etcd-cluster has regained its Raft quorum on its own; refusing to run the destructive
+  quorum loss recovery`** — the cluster healed while the request was waiting for your confirmation.
+  That is the good outcome; nothing was destroyed.
+- **The request sits at `Progressing` and never moves** — check the
+  `EtcdQuorumLossAwaitingConfirmation` condition. It is almost always waiting for
+  `spec.recoverFromQuorumLoss.confirmMember` to match the resolved survivor exactly.
+- **`spec.timeout is required for a recovery from quorum loss`** — add `spec.timeout`. It is not
+  optional for this ops type.
+- **`recovery from quorum loss is not applicable to an ephemeral etcd`** — `spec.storageType` is
+  `Ephemeral`, so the members' data died with their pods and there is nothing to rescue.
+- **`no member of etcd demo/etcd-cluster answered; there is no surviving member to rebuild the
+  cluster from`** — nothing is left to recover from. Restore from a backup instead; see
+  [in-place Restore](/docs/guides/etcd/restore/restore.md).
+- **`the requested surviving member etcd-cluster-2 is not answering; a cluster cannot be rebuilt
+  from a member that cannot be reached`** — the member named in
+  `spec.recoverFromQuorumLoss.member` is one of the lost ones. Pick a member that still answers, or
+  omit the field and let the operator choose.
+- **The database is never picked up at all** — if `spec.apply` is left at its `IfReady` default, the
+  ops request waits for an `Etcd` that will never become `Ready`. Use `apply: Always`.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-recover-quorum
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Restore a snapshot](/docs/guides/etcd/restore/restore.md) into an existing Etcd cluster when the
+  data itself is the problem.
+- Take scheduled snapshot [backups](/docs/guides/etcd/backup/kubestash/overview/index.md) so you
+  always have something to fall back on.
+- Scale the cluster [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md)
+  to raise the number of failures it can tolerate.
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/restart/_index.md
+++ b/docs/guides/etcd/restart/_index.md
@@ -1,0 +1,12 @@
+---
+title: Restart Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-restart
+    name: Restart
+    parent: etcd-etcd-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/restart/restart.md
+++ b/docs/guides/etcd/restart/restart.md
@@ -1,0 +1,331 @@
+---
+title: Restart Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-restart-details
+    name: Restart Cluster
+    parent: etcd-restart
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Restart Etcd
+
+KubeDB supports restarting an Etcd cluster through an `EtcdOpsRequest`. Restarting is useful if
+some member pods are stuck, if a node has to be drained, or if you simply want the members to come
+up fresh. This tutorial shows you how to use it.
+
+Unlike a plain `kubectl delete pod`, this restart is **Raft aware**. Evicting the current Raft
+leader forces an election, and an election makes the whole cluster unavailable for writes until a
+new leader is elected. So the operator:
+
+1. Resolves which pod currently holds the Raft leadership.
+2. Restarts every **follower** first, one at a time, waiting for each pod to become `Ready` **and**
+   for the cluster to regain quorum before moving to the next one.
+3. Restarts the **leader last**, and only after transferring its leadership to another healthy
+   voting member with etcd's `MoveLeader` RPC — a transfer is near instantaneous, an election is
+   not.
+
+A single member cluster (`spec.replicas: 1`) has nowhere to hand the leadership to, so it is simply
+restarted like any other pod.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the KubeDB Provisioner and Ops-manager operators are installed with `featureGates.Etcd=true`.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Etcd
+
+In this section, we are going to deploy a 3 member Etcd cluster using KubeDB.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/restart/etcd.yaml
+etcd.kubedb.com/etcd-quickstart created
+```
+
+Now, wait until `etcd-quickstart` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME              VERSION   STATUS   AGE
+etcd-quickstart   3.6.4     Ready    3m
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-quickstart
+NAME                READY   STATUS    RESTARTS   AGE
+etcd-quickstart-0   1/1     Running   0          3m
+etcd-quickstart-1   1/1     Running   0          2m
+etcd-quickstart-2   1/1     Running   0          2m
+```
+
+## Apply Restart opsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: etcd-quickstart
+  timeout: 5m
+  apply: Always
+```
+
+- `spec.type` specifies the type of the ops request. Here it is `Restart`.
+- `spec.databaseRef` holds the name of the `Etcd` object. The database must be in the same namespace as the ops request.
+- `spec.timeout` bounds how long a single step (evicting a pod, waiting for it to be ready, waiting for quorum) may keep retrying before the request is failed.
+- The meaning of `spec.timeout` & `spec.apply` fields is described [here](/docs/guides/etcd/concepts/etcdopsrequest.md#spectimeout).
+
+> Note: Restarting a single member cluster and a multi member cluster is done exactly the same way. All you need is to point `spec.databaseRef.name` at the corresponding `Etcd` object.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/restart/ops.yaml
+etcdopsrequest.ops.kubedb.com/etcd-restart created
+```
+
+## Track the progress
+
+Now the Ops-manager operator will pause the `Etcd` object, restart the member pods one at a time —
+followers first, leader last — and finally resume the object.
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME           TYPE      STATUS       AGE
+etcd-restart   Restart   Progressing  35s
+```
+
+While it runs, you can watch the pods being recreated one at a time. The cluster keeps quorum
+throughout, because the operator never evicts the next pod until the previous one is back in the
+Raft quorum:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-quickstart -w
+NAME                READY   STATUS        RESTARTS   AGE
+etcd-quickstart-0   1/1     Terminating   0          8m
+etcd-quickstart-1   1/1     Running       0          8m
+etcd-quickstart-2   1/1     Running       0          7m
+```
+
+`kubectl describe` gives you the step-by-step view, including the events the operator records for
+each retryable step:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-restart
+Name:         etcd-restart
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-02-10T09:22:57Z
+  Generation:          1
+  Resource Version:    1072309
+  UID:                 6091d9fa-1c2b-4734-bdd1-1ace91460bea
+Spec:
+  Apply:  Always
+  Database Ref:
+    Name:   etcd-quickstart
+  Timeout:  5m
+  Type:     Restart
+Status:
+  Conditions:
+    Last Transition Time:  2026-02-10T09:22:57Z
+    Message:               Restart is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-02-10T09:23:10Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-quickstart-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-quickstart-0
+  Observed Generation:     1
+  Phase:                   Progressing
+Events:
+  Type     Reason                                                             Age   From                         Message
+  ----     ------                                                             ----  ----                         -------
+  Normal   PauseDatabase                                                      35s   KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-quickstart
+  Warning  check pod ready; ConditionStatus:False; PodName:etcd-quickstart-0  30s   KubeDB Ops-manager Operator  check pod ready; ConditionStatus:False; PodName:etcd-quickstart-0
+  Warning  check pod ready; ConditionStatus:True; PodName:etcd-quickstart-0   5s    KubeDB Ops-manager Operator  check pod ready; ConditionStatus:True; PodName:etcd-quickstart-0
+```
+
+Once every member has been recreated, the request reaches `Successful`:
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME           TYPE      STATUS       AGE
+etcd-restart   Restart   Successful   4m
+```
+
+Here is the full object after a successful run. In this example the Raft leader happened to be
+`etcd-quickstart-1`, so that pod was restarted **last**, after its leadership had been moved away:
+
+```bash
+$ kubectl get etcdopsrequest -n demo etcd-restart -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"ops.kubedb.com/v1alpha1","kind":"EtcdOpsRequest","metadata":{"annotations":{},"name":"etcd-restart","namespace":"demo"},"spec":{"apply":"Always","databaseRef":{"name":"etcd-quickstart"},"timeout":"5m","type":"Restart"}}
+  creationTimestamp: "2026-02-10T09:22:57Z"
+  generation: 1
+  name: etcd-restart
+  namespace: demo
+  resourceVersion: "1072471"
+  uid: 6091d9fa-1c2b-4734-bdd1-1ace91460bea
+spec:
+  apply: Always
+  databaseRef:
+    name: etcd-quickstart
+  maxRetries: 1
+  timeout: 5m
+  type: Restart
+status:
+  conditions:
+  - lastTransitionTime: "2026-02-10T09:22:57Z"
+    message: Restart is in progress
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: Running
+  - lastTransitionTime: "2026-02-10T09:23:35Z"
+    message: check pod ready; ConditionStatus:True; PodName:etcd-quickstart-0
+    observedGeneration: 1
+    status: "True"
+    type: CheckPodReady--etcd-quickstart-0
+  - lastTransitionTime: "2026-02-10T09:23:40Z"
+    message: etcd cluster healthy; ConditionStatus:True; PodName:etcd-quickstart-0
+    observedGeneration: 1
+    status: "True"
+    type: EtcdClusterHealthy--etcd-quickstart-0
+  - lastTransitionTime: "2026-02-10T09:24:15Z"
+    message: check pod ready; ConditionStatus:True; PodName:etcd-quickstart-2
+    observedGeneration: 1
+    status: "True"
+    type: CheckPodReady--etcd-quickstart-2
+  - lastTransitionTime: "2026-02-10T09:24:20Z"
+    message: etcd cluster healthy; ConditionStatus:True; PodName:etcd-quickstart-2
+    observedGeneration: 1
+    status: "True"
+    type: EtcdClusterHealthy--etcd-quickstart-2
+  - lastTransitionTime: "2026-02-10T09:24:30Z"
+    message: move leader; ConditionStatus:True; PodName:etcd-quickstart-1
+    observedGeneration: 1
+    status: "True"
+    type: MoveLeader--etcd-quickstart-1
+  - lastTransitionTime: "2026-02-10T09:25:05Z"
+    message: check pod ready; ConditionStatus:True; PodName:etcd-quickstart-1
+    observedGeneration: 1
+    status: "True"
+    type: CheckPodReady--etcd-quickstart-1
+  - lastTransitionTime: "2026-02-10T09:25:10Z"
+    message: etcd cluster healthy; ConditionStatus:True; PodName:etcd-quickstart-1
+    observedGeneration: 1
+    status: "True"
+    type: EtcdClusterHealthy--etcd-quickstart-1
+  - lastTransitionTime: "2026-02-10T09:25:15Z"
+    message: Successfully restarted all the etcd members
+    observedGeneration: 1
+    reason: RestartEtcdPods
+    status: "True"
+    type: RestartEtcdPods
+  - lastTransitionTime: "2026-02-10T09:25:16Z"
+    message: Successfully restarted the etcd cluster
+    observedGeneration: 1
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Reading the conditions:
+
+- **`Running`** is set as soon as the request leaves the `Pending` phase.
+- **`RestartEtcdPods`** tracks the whole rolling sequence. It is first written with
+  `status: "False"` when the sequence starts and flips to `"True"` once every member has been
+  recreated.
+- **`MoveLeader--<pod>`** is the leadership handoff. It appears for exactly one pod — whichever one
+  held the Raft leadership when the request started — and always before that pod is evicted. On a
+  single member cluster it never appears, because there is no other voter to hand the leadership
+  to.
+- **`CheckPodReady--<pod>`** and **`EtcdClusterHealthy--<pod>`** are the two gates the operator
+  waits on after evicting each pod: the pod must be recreated and `Ready`, and the cluster must
+  have quorum again (`healthy members >= N/2 + 1`), before the next member is touched.
+- **`Successful`** is the terminal condition, written after the `Etcd` object is resumed and handed
+  back to the Provisioner operator.
+
+> Note: the per-pod conditions above are recorded by the operator's retry bookkeeping — a step that
+> completes on its very first attempt may not leave a condition behind at all. So the exact set of
+> `EvictPod--<pod>` / `CheckPodReady--<pod>` / `EtcdClusterHealthy--<pod>` entries you see varies
+> between runs. `RestartEtcdPods` and `Successful` are always there.
+
+If you want to transfer the Raft leadership on its own, without restarting anything, use the
+dedicated `MoveLeader` ops request type instead — it records an `EtcdLeaderMoved` condition and
+optionally takes `spec.moveLeader.newLeader` to name the target member.
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-restart
+kubectl delete etcd -n demo etcd-quickstart
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Detail concepts of [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Detail concepts of [EtcdOpsRequest object](/docs/guides/etcd/concepts/etcdopsrequest.md).
+- Change the etcd tuning knobs of a running cluster with [Reconfigure](/docs/guides/etcd/reconfigure/reconfigure.md).
+- Rotate the etcd credentials with [Rotate Authentication](/docs/guides/etcd/rotate-authentication/rotateauth.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/restart/restart.md
+++ b/docs/guides/etcd/restart/restart.md
@@ -303,10 +303,12 @@ Reading the conditions:
 - **`Successful`** is the terminal condition, written after the `Etcd` object is resumed and handed
   back to the Provisioner operator.
 
-> Note: the per-pod conditions above are recorded by the operator's retry bookkeeping — a step that
-> completes on its very first attempt may not leave a condition behind at all. So the exact set of
-> `EvictPod--<pod>` / `CheckPodReady--<pod>` / `EtcdClusterHealthy--<pod>` entries you see varies
-> between runs. `RestartEtcdPods` and `Successful` are always there.
+> Note: the per-pod conditions are not just retry bookkeeping — they are how the operator remembers
+> where it got to. A completed step writes a `True` condition unconditionally, so `GetLeader--<pod>`,
+> `EvictPod--<pod>`, `CheckPodReady--<pod>` and `EtcdClusterHealthy--<pod>` are present for every pod
+> the restart touched, on every run, whether or not anything had to be retried. A step that *is*
+> still waiting shows up as the same condition with `Status: False`. Some of these are elided from
+> the output above for brevity.
 
 If you want to transfer the Raft leadership on its own, without restarting anything, use the
 dedicated `MoveLeader` ops request type instead — it records an `EtcdLeaderMoved` condition and

--- a/docs/guides/etcd/restore/_index.md
+++ b/docs/guides/etcd/restore/_index.md
@@ -1,0 +1,12 @@
+---
+title: In-place Restore
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-restore
+    name: In-place Restore
+    parent: etcd-etcd-guides
+    weight: 76
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/restore/overview.md
+++ b/docs/guides/etcd/restore/overview.md
@@ -1,0 +1,159 @@
+---
+title: Etcd In-place Restore Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-restore-overview
+    name: Overview
+    parent: etcd-restore
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd In-place Restore
+
+This guide gives an overview of how the KubeDB Ops-manager operator restores a
+[KubeStash](https://kubestash.com/) snapshot into an `Etcd` cluster that **already exists**, using an
+`EtcdOpsRequest` of type `Restore`.
+
+> **This operation is fully destructive to the database's current contents.** The entire existing
+> keyspace is replaced by the snapshot, and every member's current data directory is discarded. Full
+> data loss is not a failure mode here — it is the normal, successful outcome of the operation. There
+> is no undo.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md)
+  - [Backup & Restore with KubeStash](/docs/guides/etcd/backup/kubestash/overview/index.md)
+  - [Horizontal Scaling Overview](/docs/guides/etcd/scaling/horizontal-scaling/overview.md) — the
+    learner-add/promote mechanism this restore relies on to regrow the cluster.
+
+## Two Kinds of Restore
+
+KubeDB can restore an etcd snapshot in two different situations, and they are **not**
+interchangeable. Pick the one that matches what you have:
+
+| | Bootstrap-time restore | In-place restore (this guide) |
+|---|---|---|
+| Where you declare it | `spec.init.archiver` on a **new** `Etcd` object | an `EtcdOpsRequest` of type `Restore` |
+| When it works | only while the `Etcd` object is being created | on an `Etcd` that already exists, healthy or degraded |
+| What happens to existing data | there is none | **all of it is replaced by the snapshot** |
+| Guide | [Snapshot Backup & Restore](/docs/guides/etcd/backup/kubestash/snapshot/index.md#restore) | [In-place Restore walkthrough](/docs/guides/etcd/restore/restore.md) |
+
+If you are standing up a **new** cluster from a backup — a copy in another namespace, a clone for
+testing, a rebuild after the original object was deleted — use the bootstrap path. It is strictly
+safer, because there is nothing to lose.
+
+Use the in-place restore when the `Etcd` object has to survive: everything that references it (the
+`AppBinding`, the connection Secret, the archiver, the autoscaler, the applications that resolve its
+Service name) keeps working, because the object itself never goes away. Before this ops request
+existed, the only way to restore into an existing cluster was to delete the `Etcd` object and
+recreate it from the backup — which loses everything else about it.
+
+## When to Use It
+
+- The keyspace itself is the problem: data was deleted or corrupted by an application, and you want
+  a known-good copy back.
+- The cluster is degraded past the point of rescue — for example every member's volume is gone, so
+  there is no surviving member to rebuild from and
+  [`RecoverFromQuorumLoss`](/docs/guides/etcd/recover-from-quorum-loss/overview.md) has nothing to
+  work with.
+
+Do **not** reach for it when the data is fine and only the cluster is unhealthy. A cluster that has
+lost its quorum but still has one member holding good data should be rebuilt with
+[`RecoverFromQuorumLoss`](/docs/guides/etcd/recover-from-quorum-loss/overview.md), which keeps the
+survivor's data instead of discarding it and does not roll you back to the last backup.
+
+## Why the Cluster Has to Be Taken Apart
+
+There is no way to "restore into" a running etcd. A member's data directory has to *already be* a
+valid restored snapshot **before** the etcd process starts — restoring a snapshot is a filesystem
+operation on the data directory, not an RPC the cluster serves.
+
+So the restore deliberately reuses the bootstrap mechanism rather than inventing a second one: the
+cluster is taken apart down to a single empty volume, the snapshot is written into that volume by
+exactly the same KubeStash `RestoreSession` the bootstrap path uses, and the cluster is started
+again as a one-member cluster.
+
+**Only the seed member (ordinal 0) is ever restored into.** The other members are not restored
+independently — they are discarded and rejoin as fresh
+[learners](/docs/guides/etcd/scaling/horizontal-scaling/overview.md#learners), streaming the restored
+keyspace from the seed through etcd's own membership API. That pulls the snapshot out of the
+repository exactly once, touches one volume instead of all of them, and reuses a mechanism the
+membership reconciliation already runs on every scale up. Keeping their old data directories would
+be worse than useless: they describe a keyspace the restored one no longer relates to, so they could
+not rejoin anyway.
+
+## How the Restore Process Works
+
+Every step is gated by its own condition on the ops request, so an operator restart resumes exactly
+where it left off rather than starting over.
+
+1. The user creates an `EtcdOpsRequest` of type `Restore` with `spec.restore.fullDBRepository` and a
+   `spec.timeout`.
+
+2. The Ops-manager operator pauses the `Etcd` object, so the Provisioner operator does not fight the
+   restore.
+
+3. The `PetSet` is deleted **with an orphan propagation policy** — it would otherwise recreate every
+   pod the restore deletes and re-provision every claim it discards.
+
+4. **Every member except ordinal 0 is discarded**, one per pass: the pod is taken down (tolerating
+   members whose pod object is already gone, which a degraded cluster often has) and its claim is
+   dropped.
+
+5. **The seed volume is wiped.** Ordinal 0 is taken down, its claim is deleted, the operator waits
+   for the claim to actually disappear (a claim still held by the `pvc-protection` finalizer would
+   be adopted — data and all — instead of replaced), and a fresh empty claim is created under the
+   same name, specced exactly as the `PetSet`'s own volume claim template would have produced it.
+
+6. **The snapshot is applied.** The operator resolves which `Snapshot` to use from the repository,
+   creates a KubeStash `RestoreSession` named `<ops-request-name>-snapshot-restorer` against the
+   empty seed claim, and waits for it. The session is created once and never rewritten, so a backup
+   that completes while the restore is running cannot retarget a restore already under way.
+
+7. The cluster-state ConfigMap is rewritten for a **single member** cluster — the same call the
+   provisioner makes for a bootstrap restore, because the situation it has to describe is the
+   identical one.
+
+8. The `PetSet` is recreated with one replica, which brings the seed member back on top of the
+   restored volume, and the operator waits until it is `Ready` and answering.
+
+9. The reclaim policies parked while the old volumes were being discarded are restored — **this is
+   what finally destroys the data the restore replaced**, and it is deliberately left until the
+   restored member is up and healthy, so a crash or a failed `RestoreSession` has thrown nothing
+   away that a human could still go back to.
+
+10. The `Etcd` object is resumed and the request is marked `Successful`.
+
+Nothing in the restore regrows the cluster. Once the database is resumed, the ordinary membership
+reconciliation sees one member against `spec.replicas` and adds the rest back through **exactly the
+same learner-add/promote path an ordinary scale up uses**.
+
+## Preconditions
+
+- **`spec.restore.fullDBRepository` is required, and has no default.** The bootstrap restore can
+  afford to be lenient because it has nothing to lose; this one replaces the whole keyspace of a
+  live database, so there is no safe repository to guess at. The request fails immediately without
+  it.
+- **`spec.timeout` is required.** Several steps — waiting for the `RestoreSession`, waiting for the
+  restored member to come up — have no other deadline at all. Size it against how large the snapshot
+  is and how fast the backend storage is, not against how long a pod takes to restart.
+- `spec.storageType` must be `Durable` and `spec.storage` must be set. There is no PVC to restore
+  into before the seed member starts on an ephemeral cluster.
+- The repository must hold at least one **successful full** `Snapshot` for this database. Snapshots
+  are matched in the database's own namespace by repository name.
+- `spec.restore.recoveryTimestamp` is **optional**. Leave it out and the latest available snapshot
+  is used; set it and the operator picks the newest snapshot taken **at or before** that instant.
+- `spec.restore.encryptionSecret` must name the Secret holding the encryption key the snapshot was
+  backed up with, if the backup was encrypted.
+
+In the [next](/docs/guides/etcd/restore/restore.md) doc, we are going to show a step-by-step guide on
+restoring a snapshot into an existing Etcd cluster using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/restore/restore.md
+++ b/docs/guides/etcd/restore/restore.md
@@ -79,7 +79,7 @@ etcd-cluster   3.6.4     Ready    2h
 
 $ kubectl get repository -n demo
 NAME             INTEGRITY   SNAPSHOT-COUNT   SIZE     PHASE   LAST-SUCCESSFUL-BACKUP   AGE
-etcd-full-repo   true        3                2.204MiB Ready   6m32s                    1h
+etcd-full-repo   true        2                2.204MiB   Ready   6m32s                    1h
 
 $ kubectl get snapshots -n demo -l kubestash.com/repo-name=etcd-full-repo
 NAME                                     REPOSITORY       SESSION       SNAPSHOT-TIME   DELETION-POLICY   PHASE       AGE
@@ -279,8 +279,9 @@ Events:
 ```
 
 The per-member and per-resource progress conditions (`EtcdRestoreMembersDiscarded--…`,
-`PVCDeleted--…`, `CheckPVCDelete--…`, `PodDeleted--…`, `PodReady--…`, and so on) are elided above;
-they appear for every step that had to wait and are useful when a restore stalls.
+`PVCDeleted--…`, `CheckPVCDelete--…`, `PodDeleted--…`, `PodCreated--…`, and so on) are elided
+above. They are written for every step the restore completes, not only for steps that had to wait,
+and are useful when a restore stalls.
 
 ## Watch the Cluster Regrow
 
@@ -300,8 +301,12 @@ etcd-cluster-2   0/1     Running   0          11s
 
 $ kubectl get etcd -n demo
 NAME           VERSION   STATUS   AGE
-etcd-cluster   3.6.4     Ready    2h
+etcd-cluster   3.6.4     Critical 2h
 ```
+
+> The `Critical` phase is expected here: the client endpoint is reachable and quorum is healthy, but
+> `etcd-cluster-2` is still catching up as a learner. It becomes `Ready` once the last member is
+> promoted.
 
 ## Verify the Restored Data
 

--- a/docs/guides/etcd/restore/restore.md
+++ b/docs/guides/etcd/restore/restore.md
@@ -362,10 +362,18 @@ $ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
 
 ## Cleaning Up
 
-To clean up the Kubernetes resources created by this tutorial, run:
+`etcd-cluster` and the `demo` namespace are prerequisites this guide assumes were already there (see
+[Prerequisite: a Repository with a Snapshot in It](#prerequisite-a-repository-with-a-snapshot-in-it))
+rather than resources it created, so the default cleanup only removes the `EtcdOpsRequest`:
 
 ```bash
 kubectl delete etcdopsrequest -n demo etcd-restore
+```
+
+If `demo` really was a disposable environment set up just for this walkthrough, you can additionally
+remove the cluster and the namespace:
+
+```bash
 kubectl delete etcd -n demo etcd-cluster
 kubectl delete ns demo
 ```

--- a/docs/guides/etcd/restore/restore.md
+++ b/docs/guides/etcd/restore/restore.md
@@ -1,0 +1,376 @@
+---
+title: Etcd In-place Restore
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-restore-ops
+    name: Restore into an Existing Cluster
+    parent: etcd-restore
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Restore a Snapshot into an Existing Etcd Cluster
+
+This guide shows how to restore a [KubeStash](https://kubestash.com/) snapshot into an `Etcd` cluster
+that already exists, using an `EtcdOpsRequest` of type `Restore`. KubeDB takes the cluster apart down
+to a single empty volume, writes the snapshot into it with a KubeStash `RestoreSession`, brings the
+seed member back on the restored data, and lets the ordinary membership reconciliation regrow the
+cluster from there.
+
+> **This replaces the entire keyspace of the database.** Everything currently stored in
+> `etcd-cluster` is discarded and replaced by the contents of the snapshot, and every member's
+> current data directory is thrown away. Full data loss is not a failure mode here — it is the
+> normal, successful outcome of this operation. There is no undo, so make sure the snapshot you are
+> restoring really is the one you want **before** you create the request.
+
+> **Restoring into a brand-new cluster instead?** Use the bootstrap-time restore
+> (`spec.init.archiver` on a new `Etcd` object) documented in
+> [Snapshot Backup & Restore](/docs/guides/etcd/backup/kubestash/snapshot/index.md#restore). It is
+> strictly safer, because there is no existing data to lose. See
+> [Two Kinds of Restore](/docs/guides/etcd/restore/overview.md#two-kinds-of-restore).
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster.
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- Install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) — the restore is
+  driven by a KubeStash `RestoreSession`.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md)
+  - [In-place Restore Overview](/docs/guides/etcd/restore/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/restore](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/restore)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Prerequisite: a Repository with a Snapshot in It
+
+This guide assumes you already have a running `Etcd` cluster that is backed up by an
+[EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md), and therefore a KubeStash `Repository`
+holding at least one successful **full** snapshot. If you do not, follow
+[Snapshot Backup & Restore](/docs/guides/etcd/backup/kubestash/snapshot/index.md) first — the backup
+half of that guide is exactly what this one consumes.
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    2h
+
+$ kubectl get repository -n demo
+NAME             INTEGRITY   SNAPSHOT-COUNT   SIZE     PHASE   LAST-SUCCESSFUL-BACKUP   AGE
+etcd-full-repo   true        3                2.204MiB Ready   6m32s                    1h
+
+$ kubectl get snapshots -n demo -l kubestash.com/repo-name=etcd-full-repo
+NAME                                     REPOSITORY       SESSION       SNAPSHOT-TIME   DELETION-POLICY   PHASE       AGE
+etcd-full-repo-etcd-cluster-full-1755    etcd-full-repo   full-backup   2026-08-15T08:00:00Z   Delete     Succeeded   66m
+etcd-full-repo-etcd-cluster-full-1756    etcd-full-repo   full-backup   2026-08-15T09:00:00Z   Delete     Succeeded   6m
+```
+
+Only snapshots whose `spec.type` is `Full` and whose phase is `Succeeded` are candidates. They are
+matched **in the database's own namespace**, by repository name.
+
+## Create a Restore EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-restore
+  namespace: demo
+spec:
+  type: Restore
+  databaseRef:
+    name: etcd-cluster
+  restore:
+    fullDBRepository:
+      name: etcd-full-repo
+      namespace: demo
+    encryptionSecret:
+      name: encrypt-secret
+      namespace: demo
+  timeout: 30m
+  apply: Always
+```
+
+Here,
+
+- `spec.restore.fullDBRepository` names the KubeStash `Repository` to restore the etcd snapshot
+  from. It is **required and has no default**: unlike the bootstrap-time restore, this operation
+  destroys data that is already there, so there is no safe repository to guess at.
+- `spec.restore.recoveryTimestamp` is **optional** and omitted above, so the **latest** available
+  snapshot is used. Set it to pick a point in time instead — the operator restores the newest
+  successful full snapshot taken *at or before* that instant:
+
+  ```yaml
+    restore:
+      fullDBRepository:
+        name: etcd-full-repo
+        namespace: demo
+      recoveryTimestamp: "2026-08-15T08:30:00Z"
+  ```
+
+  Note this is snapshot selection, not point-in-time recovery. etcd has no continuous archiving
+  primitive, so you can only land on an instant at which a snapshot was actually taken — everything
+  written after it is gone.
+- `spec.restore.encryptionSecret` refers to the Secret holding the encryption key the snapshot was
+  backed up with. Omit it if the backup was not encrypted.
+- `spec.timeout` is **required** for `Restore`. Every step is bounded by it, and the
+  `RestoreSession` has no other deadline — so size it against how large the snapshot is, not against
+  how long a pod takes to restart.
+- `spec.apply: Always` is the safe choice here. The default, `IfReady`, holds the request until the
+  database is `Ready`, which a degraded cluster may never become. Keep `IfReady` only if you are
+  restoring into a perfectly healthy cluster and want that as an extra guard.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/restore/etcdops-restore.yaml
+etcdopsrequest.ops.kubedb.com/etcd-restore created
+```
+
+## Verify the Restore
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME           TYPE      STATUS       AGE
+etcd-restore   Restore   Successful   9m
+```
+
+While it runs you can watch the cluster collapse to a single member and come back. The `PetSet` is
+deleted up front (with orphaned pods), the other members are discarded, and the seed member's claim
+is replaced by an empty one for the snapshot to be written into:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+No resources found in demo namespace.
+
+$ kubectl get restoresession -n demo
+NAME                            REPOSITORY       FAILURE-POLICY   PHASE     DURATION   AGE
+etcd-restore-snapshot-restorer  etcd-full-repo                    Running              41s
+```
+
+The `RestoreSession` is named after the **ops request**, not after the database. That is deliberate:
+an `Etcd` that was itself bootstrapped from a backup already owns a succeeded session under the
+bootstrap name, and a session is never rewritten once it exists — reusing that name would make the
+operation read back `Succeeded` without a single byte having been restored.
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-restore
+Name:         etcd-restore
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T10:31:52Z
+  Generation:          1
+  Resource Version:    231904
+  UID:                 6b2f4c8d-2c11-4f0a-8f77-1d3e5a9b7c02
+Spec:
+  Apply:  Always
+  Database Ref:
+    Name:  etcd-cluster
+  Restore:
+    Encryption Secret:
+      Name:       encrypt-secret
+      Namespace:  demo
+    Full DB Repository:
+      Name:       etcd-full-repo
+      Namespace:  demo
+  Timeout:        30m
+  Type:           Restore
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T10:31:55Z
+    Message:               In-place restore of the etcd keyspace is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T10:32:11Z
+    Message:               Orphaned the PetSet of Etcd demo/etcd-cluster
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestorePetSetDeleted
+    Last Transition Time:  2026-08-15T10:33:04Z
+    Message:               Discarded every etcd member outside the seed etcd-cluster-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreMembersDiscarded
+    Last Transition Time:  2026-08-15T10:33:41Z
+    Message:               Replaced the data volume of etcd-cluster-0 with an empty PVC data-etcd-cluster-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreSeedPVCWiped
+    Last Transition Time:  2026-08-15T10:33:49Z
+    Message:               Created RestoreSession demo/etcd-restore-snapshot-restorer to restore Snapshot etcd-full-repo-etcd-cluster-full-1756 into PVC data-etcd-cluster-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreSessionCreated
+    Last Transition Time:  2026-08-15T10:36:12Z
+    Message:               RestoreSession demo/etcd-restore-snapshot-restorer restored the snapshot into PVC data-etcd-cluster-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreSnapshotApplied
+    Last Transition Time:  2026-08-15T10:36:16Z
+    Message:               Rewrote the cluster state ConfigMap for a single member cluster
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreClusterStateSeeded
+    Last Transition Time:  2026-08-15T10:36:22Z
+    Message:               Recreated the PetSet of Etcd demo/etcd-cluster around the restored seed member
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestorePetSetRestored
+    Last Transition Time:  2026-08-15T10:37:05Z
+    Message:               etcd-cluster-0 is serving the restored keyspace as a healthy single member cluster
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreSingleMemberHealthy
+    Last Transition Time:  2026-08-15T10:37:09Z
+    Message:               Restored the reclaim policy of every volume the restore discarded
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdRestoreVolumesReclaimed
+    Last Transition Time:  2026-08-15T10:37:13Z
+    Message:               Successfully restored Etcd demo/etcd-cluster from a snapshot of repository etcd-full-repo
+    Observed Generation:   1
+    Reason:                RestoreEtcdSnapshot
+    Status:                True
+    Type:                  RestoreEtcdSnapshot
+    Last Transition Time:  2026-08-15T10:37:18Z
+    Message:               Successfully restored Etcd demo/etcd-cluster from the snapshot
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason               Age   From                         Message
+  ----    ------               ----  ----                         -------
+  Normal  PauseDatabase        5m    KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
+  Normal  RestoreEtcdSnapshot  25s   KubeDB Ops-manager Operator  Successfully restored Etcd demo/etcd-cluster from a snapshot of repository etcd-full-repo
+  Normal  ResumeDatabase       20s   KubeDB Ops-manager Operator  Successfully resumed Etcd demo/etcd-cluster
+  Normal  Successful           20s   KubeDB Ops-manager Operator  Successfully restored Etcd demo/etcd-cluster from the snapshot
+```
+
+The per-member and per-resource progress conditions (`EtcdRestoreMembersDiscarded--…`,
+`PVCDeleted--…`, `CheckPVCDelete--…`, `PodDeleted--…`, `PodReady--…`, and so on) are elided above;
+they appear for every step that had to wait and are useful when a restore stalls.
+
+## Watch the Cluster Regrow
+
+The restore itself stops at a healthy **one-member** cluster. Growing it back to `spec.replicas` is
+not its job — once the `Etcd` object is resumed, the ordinary membership reconciliation notices one
+member against three replicas and adds the others back through exactly the same
+[learner-add/promote path](/docs/guides/etcd/scaling/horizontal-scaling/overview.md#learners) an
+ordinary scale up uses. Each new member joins as a learner, streams the **restored** keyspace from
+`etcd-cluster-0`, and is promoted to a voting member once it has caught up:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME             READY   STATUS    RESTARTS   AGE
+etcd-cluster-0   1/1     Running   0          4m
+etcd-cluster-1   1/1     Running   0          92s
+etcd-cluster-2   0/1     Running   0          11s
+
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    2h
+```
+
+## Verify the Restored Data
+
+Read back a key you know was in the snapshot:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 get /kubedb --prefix -w fields | grep -E '^"(Key|Value)"'
+"Key" : "/kubedb/demo"
+"Value" : "hello"
+```
+
+And confirm every member is serving the same restored keyspace:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 endpoint status --cluster -w table
++---------------------------------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+|                              ENDPOINT                               |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
++---------------------------------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+| http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 | 8e9e05c52164694d |   3.6.4 |   20 kB |      true |      false |         2 |         31 |                 31 |        |
+| http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 | b2c6679ac05f2cf1 |   3.6.4 |   20 kB |     false |      false |         2 |         31 |                 31 |        |
+| http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 | ffc1c9a1a4b6ef2b |   3.6.4 |   20 kB |     false |      false |         2 |         31 |                 31 |        |
++---------------------------------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+```
+
+## Troubleshooting
+
+- **`spec.restore.fullDBRepository is required for an in-place restore: it replaces the whole
+  keyspace of the database, so there is no safe repository to default to`** — name the repository.
+  There is deliberately no default.
+- **`spec.timeout is required for an in-place restore`** — add `spec.timeout`. It is not optional
+  for this ops type.
+- **`no successful full Snapshot found in repository <name> for Etcd demo/etcd-cluster`** — the
+  repository holds no `Succeeded`, `Full` snapshot in the database's namespace. Check the repository
+  name and that a backup has actually completed.
+- **`no full Snapshot in repository <name> was taken at or before the requested recoveryTimestamp`**
+  — your `recoveryTimestamp` predates every snapshot. Pick a later instant, or drop the field to use
+  the latest.
+- **`RestoreSession demo/<name>-snapshot-restorer failed to restore the snapshot into PVC
+  data-etcd-cluster-0`** — this is **not** retried. A `RestoreSession` is a one-shot object and is
+  never rewritten once it exists, so every later pass would read the same failure back. Look at the
+  session (`kubectl describe restoresession -n demo <name>-snapshot-restorer`) and its pods for the
+  real cause — a wrong or missing `encryptionSecret` is the usual one — then delete the failed ops
+  request and create a fresh one. Nothing has been reclaimed at that point, so the old volumes are
+  still there.
+- **`can not restore Etcd demo/etcd-cluster from a snapshot: spec.storageType is Ephemeral, so there
+  is no PVC to restore into before the seed member starts`** — an in-place restore needs a durable
+  volume to write the snapshot into before etcd starts.
+- **The request is never picked up at all** — if `spec.apply` is left at its `IfReady` default and
+  the cluster is degraded, the ops request waits for an `Etcd` that may never become `Ready`. Use
+  `apply: Always`.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-restore
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Set up scheduled snapshot [backups](/docs/guides/etcd/backup/kubestash/overview/index.md) with an
+  [EtcdArchiver](/docs/guides/etcd/concepts/etcdarchiver.md).
+- Bootstrap a **new** cluster from a snapshot instead: see
+  [Snapshot Backup & Restore](/docs/guides/etcd/backup/kubestash/snapshot/index.md#restore).
+- [Recover from a permanent quorum loss](/docs/guides/etcd/recover-from-quorum-loss/overview.md) when
+  the data is fine but the cluster is not.
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/rotate-authentication/_index.md
+++ b/docs/guides/etcd/rotate-authentication/_index.md
@@ -1,0 +1,12 @@
+---
+title: Rotate Authentication Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-rotate-authentication
+    name: Rotate Authentication
+    parent: etcd-etcd-guides
+    weight: 110
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/rotate-authentication/overview.md
+++ b/docs/guides/etcd/rotate-authentication/overview.md
@@ -1,0 +1,119 @@
+---
+title: Rotate Authentication Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-rotate-auth-overview
+    name: Overview
+    parent: etcd-rotate-authentication
+    weight: 5
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Authentication of Etcd
+
+This guide gives an overview of how the KubeDB Ops-manager operator rotates the credentials of an
+`Etcd` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## How etcd authentication is stored
+
+KubeDB creates a `kubernetes.io/basic-auth` shaped Secret named `<db-name>-auth` for every `Etcd`
+object (unless you point `spec.authSecret.name` somewhere else). It carries two keys:
+
+| Key        | Description                                                                        |
+|------------|------------------------------------------------------------------------------------|
+| `username` | The etcd RBAC user. It is always `root` for a KubeDB provisioned cluster.           |
+| `password` | That user's password.                                                              |
+
+These are the standard `core.BasicAuthUsernameKey` / `core.BasicAuthPasswordKey` keys, so the same
+Secret can be consumed directly by an application, by `etcdctl --user=<username>:<password>`, and by
+KubeDB's own health checker through the generated AppBinding.
+
+## Why rotating etcd credentials does not restart anything
+
+This is the one thing that makes etcd's `RotateAuth` different from most other KubeDB databases.
+
+An etcd RBAC user does not live in a config file or in an environment variable — it lives *inside
+the keyspace*, managed by etcd's own `UserChangePassword` / `UserAdd` / `UserGrantRole` RPCs. A
+password change therefore takes effect on the next authentication, with no process restart and no
+pod eviction involved. Compare that with PostgreSQL, where the credential is threaded through the
+pod's environment and the ops request has to roll every pod for the change to be picked up.
+
+So an `EtcdOpsRequest` of type `RotateAuth`:
+
+- writes the new password into etcd's RBAC store,
+- updates the auth Secret,
+- and reaches `Successful` **without evicting a single pod**.
+
+You will not see any `EvictPod--<pod>`, `CheckPodReady--<pod>` or `RestartEtcdPods` condition on an
+etcd `RotateAuth` request, and pod `AGE` / `RESTARTS` are unchanged when it finishes.
+
+## How the rotation is staged
+
+The rotation writes to two independent places — etcd's own RBAC store and a Kubernetes Secret — so
+it is deliberately staged, in order to stay crash safe:
+
+1. The new password is parked in a `password.next` key on the Secret, while `password` remains the
+   live one. Nothing that reads the Secret is disturbed yet.
+2. The operator applies the staged password inside etcd. If it is re-run after a crash, it first
+   probes whether the new credential already authenticates, so the step is idempotent.
+3. Only once etcd has accepted the change is the staged value promoted: it becomes `password`, the
+   superseded value is kept under `password.prev`, and `password.next`/`username.next` are removed.
+   The `Etcd` object's `spec.authSecret.activeFrom` timestamp is stamped at the same time.
+
+The `.prev` keys are kept for rollback purposes; nothing in KubeDB reads them afterwards.
+
+## Two ways to rotate
+
+1. **Operator generated.** Apply an `EtcdOpsRequest` of type `RotateAuth` with no
+   `spec.authentication`. KubeDB generates a random password, stages it and promotes it in the
+   existing auth Secret. The Secret's name does not change.
+
+2. **User provided.** Create your own `kubernetes.io/basic-auth` Secret containing the desired
+   `username` and `password`, and reference it from `spec.authentication.secretRef`. The operator
+   validates that both keys are present and non-empty, applies the password to etcd, records the
+   superseded credential in your Secret under `username.prev` / `password.prev`, and repoints
+   `spec.authSecret` of the `Etcd` object at your Secret with `externallyManaged: true`.
+
+## How the Rotate Authentication Process Works
+
+1. A user first creates an `Etcd` Custom Resource Object (CRO).
+
+2. The `KubeDB Provisioner` operator continuously watches for `Etcd` CROs.
+
+3. When the operator detects an `Etcd` CR, it provisions the required `PetSet` along with related
+   resources such as Secrets, Services and RBAC objects — including the `<db-name>-auth` Secret.
+
+4. To initiate a credential rotation, the user creates an `EtcdOpsRequest` CR of type `RotateAuth`,
+   optionally referring to their own Secret.
+
+5. The `KubeDB Ops-manager` operator watches for `EtcdOpsRequest` CRs.
+
+6. Upon detecting one, it pauses the referenced `Etcd` object so that the Provisioner operator does
+   not act on it during the rotation.
+
+7. The operator stages the new credential on the Secret (`UpdateCredential` condition).
+
+8. It then applies the credential to the cluster through etcd's RBAC API
+   (`EtcdCredentialApplied` condition). If the cluster has never had etcd authentication enabled,
+   this step bootstraps it: it creates the `root` user, grants it the `root` role and calls
+   `AuthEnable`.
+
+9. The staged credential is promoted to the live one, and the `Etcd` object's `spec.authSecret`
+   reference and `activeFrom` timestamp are updated (`UpdateDatabase` condition).
+
+10. Finally the operator resumes the `Etcd` object and marks the request `Successful`. No pod is
+    restarted at any point.
+
+In the [next](/docs/guides/etcd/rotate-authentication/rotateauth.md) doc, we walk through both
+rotation flows step by step.

--- a/docs/guides/etcd/rotate-authentication/overview.md
+++ b/docs/guides/etcd/rotate-authentication/overview.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-rotate-auth-overview
     name: Overview
     parent: etcd-rotate-authentication
-    weight: 5
+    weight: 10
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---

--- a/docs/guides/etcd/rotate-authentication/rotateauth.md
+++ b/docs/guides/etcd/rotate-authentication/rotateauth.md
@@ -5,7 +5,7 @@ menu:
     identifier: etcd-rotate-auth-details
     name: Guide
     parent: etcd-rotate-authentication
-    weight: 30
+    weight: 20
 menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---
@@ -307,10 +307,10 @@ First, create a Secret of type `kubernetes.io/basic-auth` holding the username a
 want the cluster to use. Both keys must be present and non-empty, otherwise the ops request fails
 validation.
 
-> **Note:** keep the username as `root`, which is the user KubeDB provisions and the one the
-> operator's health checker authenticates with. If the Secret names a *different* user, the operator
-> creates that etcd user and grants it the `root` role rather than renaming the existing one, which
-> leaves the old user behind in etcd's RBAC store.
+> **Note:** the username **must** be `root`. It is the user KubeDB provisions and the one the
+> operator's health checker authenticates with, so the admission webhook rejects a referenced Secret
+> that names anything else with `username in referenced secret <namespace>/<name> must be "root"`.
+> You may omit the `username` key entirely, in which case `root` is assumed.
 
 ```bash
 $ kubectl create secret generic etcd-quickstart-user-auth -n demo \

--- a/docs/guides/etcd/rotate-authentication/rotateauth.md
+++ b/docs/guides/etcd/rotate-authentication/rotateauth.md
@@ -1,0 +1,507 @@
+---
+title: Rotate Authentication Guide
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-rotate-auth-details
+    name: Guide
+    parent: etcd-rotate-authentication
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Authentication of Etcd
+
+**Rotate Authentication** is a feature of the KubeDB Ops-manager that lets you rotate the etcd
+credentials of a running cluster with an `EtcdOpsRequest`. There are two ways to perform the
+rotation:
+
+1. **Operator generated:** the KubeDB operator generates a random password, applies it to etcd and
+   updates the existing auth Secret with it.
+2. **User defined:** you create your own `kubernetes.io/basic-auth` Secret containing the desired
+   `password`, and reference it from the `EtcdOpsRequest`.
+
+> **etcd rotates live.** Unlike most KubeDB day-2 operations, this one does **not** restart any pod.
+> etcd RBAC users live inside the keyspace, so a password change takes effect on the next
+> authentication. See the [overview](/docs/guides/etcd/rotate-authentication/overview.md#why-rotating-etcd-credentials-does-not-restart-anything)
+> for the details.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Rotate Authentication Overview](/docs/guides/etcd/rotate-authentication/overview.md)
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the Provisioner and Ops-manager operators are installed with `featureGates.Etcd=true`.
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+  ```bash
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Create an Etcd cluster
+
+KubeDB implements an `Etcd` CRD to define the specification of an etcd cluster.
+
+You can apply this yaml file:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-quickstart
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/rotate-auth/etcd.yaml
+etcd.kubedb.com/etcd-quickstart created
+```
+
+Now, wait until `etcd-quickstart` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo -w
+NAME              VERSION   STATUS   AGE
+etcd-quickstart   3.6.4     Ready    3m
+```
+
+## Verify authentication
+
+The credentials live in the auth Secret referenced by `spec.authSecret`. It is named
+`<db-name>-auth` by default and holds a `username` and a `password` key. The username is always
+`root` for a KubeDB provisioned etcd cluster.
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart -ojson | jq .spec.authSecret.name
+"etcd-quickstart-auth"
+
+$ kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
+root
+$ kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
+yFj_WnVA9rxfQlLt
+```
+
+Now you can exec into a member pod and confirm that those credentials authenticate:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-0 -c etcd -- etcdctl \
+    --endpoints=http://127.0.0.1:2379 --user=root:yFj_WnVA9rxfQlLt put foo bar
+OK
+$ kubectl exec -it -n demo etcd-quickstart-0 -c etcd -- etcdctl \
+    --endpoints=http://127.0.0.1:2379 --user=root:yFj_WnVA9rxfQlLt get foo
+foo
+bar
+```
+
+If the read and the write succeed, the credentials in the Secret are working.
+
+Note the pod ages before rotating, so that you can convince yourself afterwards that nothing was
+restarted:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-quickstart
+NAME                READY   STATUS    RESTARTS   AGE
+etcd-quickstart-0   1/1     Running   0          8m
+etcd-quickstart-1   1/1     Running   0          7m
+etcd-quickstart-2   1/1     Running   0          7m
+```
+
+## Create a RotateAuth EtcdOpsRequest
+
+### 1. Using operator generated credentials
+
+To rotate the credentials with an operator generated password, create an `EtcdOpsRequest` of type
+`RotateAuth` and leave `spec.authentication` unset. Below is the YAML of the `EtcdOpsRequest` we are
+going to create:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-rotate-auth-generated
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: etcd-quickstart
+  timeout: 5m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are rotating the authentication of the `etcd-quickstart`
+  cluster.
+- `spec.type` specifies that we are performing a `RotateAuth` operation.
+- `spec.authentication` is omitted, which is what tells the operator to generate the new password
+  itself.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/rotate-auth/rotate-auth-generated.yaml
+etcdopsrequest.ops.kubedb.com/etcdops-rotate-auth-generated created
+```
+
+Let's wait for the `EtcdOpsRequest` to be `Successful`. Run the following command to watch it,
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                            TYPE         STATUS       AGE
+etcdops-rotate-auth-generated   RotateAuth   Successful   1m
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcdops-rotate-auth-generated
+Name:         etcdops-rotate-auth-generated
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-02-10T11:24:10Z
+  Generation:          1
+  Resource Version:    546623
+  UID:                 97a07133-c98e-457c-9249-85c0c690a82e
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:   etcd-quickstart
+  Timeout:  5m
+  Type:     RotateAuth
+Status:
+  Conditions:
+    Last Transition Time:  2026-02-10T11:24:10Z
+    Message:               Etcd ops request has started to rotate the authentication
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-02-10T11:24:13Z
+    Message:               Successfully staged the new credentials
+    Observed Generation:   1
+    Reason:                UpdateCredential
+    Status:                True
+    Type:                  UpdateCredential
+    Last Transition Time:  2026-02-10T11:24:18Z
+    Message:               Successfully applied the new credentials to the etcd RBAC store
+    Observed Generation:   1
+    Reason:                EtcdCredentialApplied
+    Status:                True
+    Type:                  EtcdCredentialApplied
+    Last Transition Time:  2026-02-10T11:24:20Z
+    Message:               Successfully updated the Etcd auth secret reference
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-02-10T11:24:21Z
+    Message:               Successfully rotated the etcd auth secret
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason                 Age  From                         Message
+  ----    ------                 ---- ----                         -------
+  Normal  PauseDatabase          1m   KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-quickstart
+  Normal  UpdateCredential       1m   KubeDB Ops-manager Operator  Successfully staged the new credentials
+  Normal  EtcdCredentialApplied  63s  KubeDB Ops-manager Operator  Successfully applied the new credentials to the etcd RBAC store
+  Normal  UpdateDatabase         61s  KubeDB Ops-manager Operator  Successfully updated the Etcd auth secret reference
+  Normal  ResumeDatabase         61s  KubeDB Ops-manager Operator  Resuming Etcd demo/etcd-quickstart
+  Normal  Successful             60s  KubeDB Ops-manager Operator  Successfully rotated the etcd auth secret
+```
+
+Notice what is **absent** from that condition list: there is no `RestartEtcdPods`, no
+`EvictPod--<pod>` and no `CheckPodReady--<pod>`. The whole rotation is three writes —
+`UpdateCredential` (stage), `EtcdCredentialApplied` (apply to etcd's RBAC store), `UpdateDatabase`
+(promote and repoint the `Etcd` object).
+
+**Verify that no pod was restarted**
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-quickstart
+NAME                READY   STATUS    RESTARTS   AGE
+etcd-quickstart-0   1/1     Running   0          11m
+etcd-quickstart-1   1/1     Running   0          10m
+etcd-quickstart-2   1/1     Running   0          10m
+```
+
+The `AGE` column keeps counting up from the original creation and `RESTARTS` is still `0` — the
+members were never evicted.
+
+**Verify that the auth is rotated**
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart -ojson | jq .spec.authSecret.name
+"etcd-quickstart-auth"
+
+$ kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
+root
+$ kubectl get secret -n demo etcd-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
+zGB9GF!NXwI.2HP9
+```
+
+The superseded credential is kept in the same Secret under the `username.prev` and `password.prev`
+keys, for rollback purposes:
+
+```bash
+$ kubectl get secret -n demo etcd-quickstart-auth -o go-template='{{ index .data "username.prev" }}' | base64 -d
+root
+$ kubectl get secret -n demo etcd-quickstart-auth -o go-template='{{ index .data "password.prev" }}' | base64 -d
+yFj_WnVA9rxfQlLt
+```
+
+The staging keys (`username.next` / `password.next`) are only present while the rotation is in
+flight; once the new password has been promoted they are removed again.
+
+The operator also stamps the moment the credential went live, both as an annotation on the Secret
+and as `spec.authSecret.activeFrom` on the `Etcd` object:
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart -o jsonpath='{.spec.authSecret.activeFrom}'
+2026-02-10T11:24:13Z
+```
+
+Finally, confirm the new password really is the live one inside etcd:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-0 -c etcd -- etcdctl \
+    --endpoints=http://127.0.0.1:2379 --user='root:zGB9GF!NXwI.2HP9' get foo
+foo
+bar
+```
+
+### 2. Using user created credentials
+
+First, create a Secret of type `kubernetes.io/basic-auth` holding the username and the password you
+want the cluster to use. Both keys must be present and non-empty, otherwise the ops request fails
+validation.
+
+> **Note:** keep the username as `root`, which is the user KubeDB provisions and the one the
+> operator's health checker authenticates with. If the Secret names a *different* user, the operator
+> creates that etcd user and grants it the `root` role rather than renaming the existing one, which
+> leaves the old user behind in etcd's RBAC store.
+
+```bash
+$ kubectl create secret generic etcd-quickstart-user-auth -n demo \
+                                                --type=kubernetes.io/basic-auth \
+                                                --from-literal=username=root \
+                                                --from-literal=password=etcd-secret
+secret/etcd-quickstart-user-auth created
+```
+
+Now create an `EtcdOpsRequest` of type `RotateAuth` that references it. Below is the YAML of the
+`EtcdOpsRequest` we are going to create:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcdops-rotate-auth-user
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: etcd-quickstart
+  authentication:
+    secretRef:
+      kind: Secret
+      name: etcd-quickstart-user-auth
+  timeout: 5m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are rotating the authentication of the `etcd-quickstart`
+  cluster.
+- `spec.type` specifies that we are performing a `RotateAuth` operation.
+- `spec.authentication.secretRef.name` names the Secret whose `password` should become the live
+  credential. After the rotation, this Secret becomes the cluster's `spec.authSecret`, marked
+  `externallyManaged: true`.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/rotate-auth/rotate-auth-user.yaml
+etcdopsrequest.ops.kubedb.com/etcdops-rotate-auth-user created
+```
+
+Let's wait for the `EtcdOpsRequest` to be `Successful`. Run the following command to watch it,
+
+```bash
+$ kubectl get etcdopsrequest -n demo
+NAME                            TYPE         STATUS       AGE
+etcdops-rotate-auth-generated   RotateAuth   Successful   19h
+etcdops-rotate-auth-user        RotateAuth   Successful   1m
+```
+
+We can see from the above output that the `EtcdOpsRequest` has succeeded. If we describe it, we get
+an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcdops-rotate-auth-user
+Name:         etcdops-rotate-auth-user
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-02-11T06:45:44Z
+  Generation:          1
+  Resource Version:    562328
+  UID:                 d25c3d36-cc15-4c82-8fe4-64e5ffc1467c
+Spec:
+  Apply:  IfReady
+  Authentication:
+    Secret Ref:
+      Kind:  Secret
+      Name:  etcd-quickstart-user-auth
+  Database Ref:
+    Name:   etcd-quickstart
+  Timeout:  5m
+  Type:     RotateAuth
+Status:
+  Conditions:
+    Last Transition Time:  2026-02-11T06:45:44Z
+    Message:               Etcd ops request has started to rotate the authentication
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-02-11T06:45:47Z
+    Message:               Successfully referenced the user provided authSecret
+    Observed Generation:   1
+    Reason:                UpdateCredential
+    Status:                True
+    Type:                  UpdateCredential
+    Last Transition Time:  2026-02-11T06:45:52Z
+    Message:               Successfully applied the new credentials to the etcd RBAC store
+    Observed Generation:   1
+    Reason:                EtcdCredentialApplied
+    Status:                True
+    Type:                  EtcdCredentialApplied
+    Last Transition Time:  2026-02-11T06:45:54Z
+    Message:               Successfully updated the Etcd auth secret reference
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-02-11T06:45:55Z
+    Message:               Successfully rotated the etcd auth secret
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason                 Age  From                         Message
+  ----    ------                 ---- ----                         -------
+  Normal  PauseDatabase          1m   KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-quickstart
+  Normal  UpdateCredential       1m   KubeDB Ops-manager Operator  Successfully referenced the user provided authSecret
+  Normal  EtcdCredentialApplied  63s  KubeDB Ops-manager Operator  Successfully applied the new credentials to the etcd RBAC store
+  Normal  UpdateDatabase         61s  KubeDB Ops-manager Operator  Successfully updated the Etcd auth secret reference
+  Normal  ResumeDatabase         61s  KubeDB Ops-manager Operator  Resuming Etcd demo/etcd-quickstart
+  Normal  Successful             60s  KubeDB Ops-manager Operator  Successfully rotated the etcd auth secret
+```
+
+Again, no pod was restarted — the condition list is the same three steps as before, with the
+`UpdateCredential` message reflecting that an existing, user provided Secret was referenced instead
+of a new password being generated.
+
+**Verify that the auth is rotated**
+
+The `Etcd` object now points at your Secret:
+
+```bash
+$ kubectl get etcd -n demo etcd-quickstart -ojson | jq .spec.authSecret
+{
+  "activeFrom": "2026-02-11T06:45:47Z",
+  "externallyManaged": true,
+  "kind": "Secret",
+  "name": "etcd-quickstart-user-auth"
+}
+
+$ kubectl get secret -n demo etcd-quickstart-user-auth -o jsonpath='{.data.username}' | base64 -d
+root
+$ kubectl get secret -n demo etcd-quickstart-user-auth -o jsonpath='{.data.password}' | base64 -d
+etcd-secret
+```
+
+The credential that was superseded is recorded inside your Secret, again under `username.prev` and
+`password.prev`:
+
+```bash
+$ kubectl get secret -n demo etcd-quickstart-user-auth -o go-template='{{ index .data "username.prev" }}' | base64 -d
+root
+$ kubectl get secret -n demo etcd-quickstart-user-auth -o go-template='{{ index .data "password.prev" }}' | base64 -d
+zGB9GF!NXwI.2HP9
+```
+
+And the new password authenticates against the running cluster:
+
+```bash
+$ kubectl exec -it -n demo etcd-quickstart-0 -c etcd -- etcdctl \
+    --endpoints=http://127.0.0.1:2379 --user=root:etcd-secret get foo
+foo
+bar
+```
+
+> The previously used `etcd-quickstart-auth` Secret is left in place; KubeDB simply stops referring
+> to it. Delete it yourself once you are sure you no longer need the old credential for a rollback.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete etcdopsrequest -n demo etcdops-rotate-auth-generated etcdops-rotate-auth-user
+etcdopsrequest.ops.kubedb.com "etcdops-rotate-auth-generated" deleted
+etcdopsrequest.ops.kubedb.com "etcdops-rotate-auth-user" deleted
+$ kubectl delete etcd -n demo etcd-quickstart
+etcd.kubedb.com "etcd-quickstart" deleted
+$ kubectl delete secret -n demo etcd-quickstart-user-auth
+secret "etcd-quickstart-user-auth" deleted
+$ kubectl delete ns demo
+namespace "demo" deleted
+```
+
+## Next Steps
+
+- Detail concepts of [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Detail concepts of [EtcdOpsRequest object](/docs/guides/etcd/concepts/etcdopsrequest.md).
+- Restart the members of a cluster with [Restart](/docs/guides/etcd/restart/restart.md).
+- Change the etcd tuning knobs of a running cluster with [Reconfigure](/docs/guides/etcd/reconfigure/reconfigure.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/scaling/_index.md
+++ b/docs/guides/etcd/scaling/_index.md
@@ -1,0 +1,12 @@
+---
+title: Scaling Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-scaling
+    name: Scaling
+    parent: etcd-etcd-guides
+    weight: 60
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/scaling/horizontal-scaling/_index.md
+++ b/docs/guides/etcd/scaling/horizontal-scaling/_index.md
@@ -1,0 +1,12 @@
+---
+title: Horizontal Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-horizontal-scaling
+    name: Horizontal Scaling
+    parent: etcd-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md
@@ -307,8 +307,10 @@ Reading that condition list:
   condition is met, which is why you see both polarities of `etcd learner promoted` in the events —
   the ops request observed a learner mid-promotion and waited for it. On a `3 → 5` scale up you will
   typically see that pair of events twice, once per added member.
-- `EtcdMemberListReady` only goes `True` when *all four* checks pass together: the `PetSet` carries 5
-  replicas, etcd reports exactly 5 members, none of them is a learner, and quorum is healthy.
+- `EtcdMemberListReady` goes `True` as soon as the `PetSet` carries 5 replicas and etcd reports
+  exactly 5 members. The no-learner and quorum checks that follow it report through
+  `EtcdLearnerPromoted` and `EtcdClusterHealthy`. It is the request's own top-level
+  `HorizontalScaling` condition — and the `Successful` phase — that means all four passed together.
 - There is **no** `PauseDatabase` / `ResumeDatabase` event pair here. `HorizontalScaling` is the one
   `EtcdOpsRequest` type that does not pause the database, because the Provisioner operator is the
   component doing the membership work.
@@ -398,8 +400,8 @@ that window.
 
 ```bash
 $ kubectl logs -n kubedb -l app.kubernetes.io/name=etcd-operator -f | grep etcd-cluster
-etcd demo/etcd-cluster: removed member 5e6f7a8b9c0d1e2f (etcd-cluster-4)
-etcd demo/etcd-cluster: removed member 4d5e6f7a8b9c0d1e (etcd-cluster-3)
+etcd demo/etcd-cluster: removed member 6804325408493731870 (etcd-cluster-4)
+etcd demo/etcd-cluster: removed member 5571401537629186833 (etcd-cluster-3)
 ```
 
 ### Verify the Scale Down
@@ -441,8 +443,11 @@ Status:
   Phase:      Successful
 ```
 
-Note that there is no `EtcdLearnerPromoted` gate on the way down — nothing is ever added as a learner
-during a scale down, so that check passes on the first poll and never records a condition.
+Note that the `EtcdLearnerPromoted` gate means something different on the way down: nothing is ever
+added as a learner during a scale down, so the check is simply "no member is still a learner", and it
+passes on the first poll. It still records a `True` condition — you just never see the `False`
+polarity that a scale up produces while it waits for a learner to catch up. The scale down also
+opens with an `EtcdMemberRemoved` condition, where a scale up opens with `EtcdMemberAdded`.
 
 ```bash
 $ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.replicas}'

--- a/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md
@@ -1,0 +1,510 @@
+---
+title: Horizontal Scaling Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-horizontal-scaling-ops
+    name: Scale Horizontally
+    parent: etcd-horizontal-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Horizontal Scale Etcd
+
+This guide will show you how to use the `KubeDB` Ops-manager operator to change the number of members
+of an `Etcd` cluster.
+
+Before you run any of this, read
+[Horizontal Scaling Overview](/docs/guides/etcd/scaling/horizontal-scaling/overview.md). Scaling an
+etcd cluster is a **sequence of Raft membership changes**, not an instant replica-count change, and
+the guide below will make a lot more sense once you know why.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster. If you do not already have a cluster, you can create
+  one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Horizontal Scaling Overview](/docs/guides/etcd/scaling/horizontal-scaling/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/scaling/horizontal-scaling](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/scaling/horizontal-scaling)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Deploy a 3-Member Etcd Cluster
+
+Below is the YAML of the `Etcd` CR that we are going to create,
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/scaling/horizontal-scaling/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Now, wait until `etcd-cluster` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    4m
+```
+
+Let's check the member count from the `Etcd` object and from the `PetSet`:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.replicas}'
+3
+
+$ kubectl get petset -n demo etcd-cluster -o jsonpath='{.spec.replicas}'
+3
+```
+
+Those two are Kubernetes' view of the world. etcd's own view — the one that actually decides quorum —
+is the member list:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 member list -w table
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+|        ID        | STATUS  |      NAME      |                             PEER ADDRS                              |                            CLIENT ADDRS                             | IS LEARNER |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+| 1a2b3c4d5e6f7a8b | started | etcd-cluster-0 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 2b3c4d5e6f7a8b9c | started | etcd-cluster-1 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 3c4d5e6f7a8b9c0d | started | etcd-cluster-2 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+```
+
+Three voting members (`IS LEARNER` is `false` for all of them), so quorum is 2 and the cluster
+tolerates one failure.
+
+> If you have enabled etcd's RBAC authentication (for example by running a `RotateAuth`
+> `EtcdOpsRequest`), add `--user=root:<password>` to the `etcdctl` calls, with the password read from
+> the auth Secret:
+> `kubectl get secret -n demo etcd-cluster-auth -o jsonpath='{.data.password}' | base64 -d`.
+> If TLS is enabled, use the `https://` scheme and pass the client certificate flags.
+
+## Scale Up: 3 → 5 Members
+
+### Create the EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-hscale-up
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: etcd-cluster
+  horizontalScaling:
+    replicas: 5
+  timeout: 20m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are scaling the `etcd-cluster` database.
+- `spec.type` specifies that we are performing `HorizontalScaling`.
+- `spec.horizontalScaling.replicas` is the desired **number of etcd members** after scaling. It must
+  be at least `1`; odd values are strongly recommended (see
+  [Choosing a Member Count](/docs/guides/etcd/scaling/horizontal-scaling/overview.md#choosing-a-member-count)).
+- `spec.timeout` bounds each polling step. Give a scale up room: every new member has to replicate the
+  whole keyspace before it can be promoted, so a large cluster legitimately takes a while.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/scaling/horizontal-scaling/etcdops-hscale-up.yaml
+etcdopsrequest.ops.kubedb.com/etcd-hscale-up created
+```
+
+### What Happens Now
+
+The ops request itself does very little: it patches `spec.replicas: 5` on the `Etcd` object and then
+waits. The actual member-by-member work is driven by the **Provisioner** operator's membership
+reconciler, which runs continuously and performs exactly one membership mutation per pass:
+
+| Pass | Provisioner action                                                       | Voting members | Learners |
+|------|--------------------------------------------------------------------------|:--------------:|:--------:|
+| 1    | ConfigMap rewritten, `MemberAddAsLearner` for `etcd-cluster-3`, `PetSet` → 4 | 3            | 1        |
+| 2..n | Poll `etcd-cluster-3`'s applied revision against the leader's             | 3              | 1        |
+| n+1  | `MemberPromote` `etcd-cluster-3`                                          | 4              | 0        |
+| n+2  | ConfigMap rewritten, `MemberAddAsLearner` for `etcd-cluster-4`, `PetSet` → 5 | 4            | 1        |
+| ...  | Poll, then `MemberPromote` `etcd-cluster-4`                               | 5              | 0        |
+
+Note the invariant across every row: **at most one learner exists at a time, and quorum is computed
+only over the voting members.** While `etcd-cluster-3` is catching up, the cluster still needs 2 of
+its 3 voters — the in-flight member cannot make things worse.
+
+You can watch the sequence in the Provisioner operator's log:
+
+```bash
+$ kubectl logs -n kubedb -l app.kubernetes.io/name=etcd-operator -f | grep etcd-cluster
+etcd demo/etcd-cluster: added etcd-cluster-3 as a learner
+etcd demo/etcd-cluster: promoted learner etcd-cluster-3 to a voting member
+etcd demo/etcd-cluster: added etcd-cluster-4 as a learner
+etcd demo/etcd-cluster: promoted learner etcd-cluster-4 to a voting member
+```
+
+And in the member list, mid-flight — note `IS LEARNER: true` on the member that is catching up:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 member list -w table
++------------------+-----------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+|        ID        |  STATUS   |      NAME      |                             PEER ADDRS                              |                            CLIENT ADDRS                             | IS LEARNER |
++------------------+-----------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+| 1a2b3c4d5e6f7a8b | started   | etcd-cluster-0 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 2b3c4d5e6f7a8b9c | started   | etcd-cluster-1 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 3c4d5e6f7a8b9c0d | started   | etcd-cluster-2 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 4d5e6f7a8b9c0d1e | started   | etcd-cluster-3 | http://etcd-cluster-3.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-3.etcd-cluster-pods.demo.svc.cluster.local:2379 |       true |
++------------------+-----------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+```
+
+> **The `Etcd` object may report `Critical` while a learner is catching up.** That is expected, not an
+> error: a learner cannot serve the linearizable read behind etcd's health endpoint, so its pod never
+> becomes `Ready`, and KubeDB reports `Critical` for "the client endpoint works but not every member
+> is ready". The phase returns to `Ready` once the learner is promoted. This is also exactly why
+> KubeDB gates promotion on the learner's **applied revision**, not on pod readiness — gating on
+> readiness would deadlock the scale up permanently.
+
+### Verify the Scale Up
+
+Let's wait for the `EtcdOpsRequest` to become `Successful`:
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME             TYPE                STATUS       AGE
+etcd-hscale-up   HorizontalScaling   Successful   6m41s
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-hscale-up
+Name:         etcd-hscale-up
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T10:02:11Z
+  Generation:          1
+  Resource Version:    131204
+  UID:                 5f6c0f21-95a2-4c7d-9a13-2f1b8e6d4c77
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:  etcd-cluster
+  Horizontal Scaling:
+    Replicas:  5
+  Timeout:     20m
+  Type:        HorizontalScaling
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T10:02:11Z
+    Message:               Horizontal Scaling is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T10:02:16Z
+    Message:               Successfully updated the desired member count
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-08-15T10:05:41Z
+    Message:               is pet set scaled; ConditionStatus:True
+    Observed Generation:   1
+    Status:                True
+    Type:                  IsPetSetScaled
+    Last Transition Time:  2026-08-15T10:07:56Z
+    Message:               etcd learner promoted; ConditionStatus:True
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdLearnerPromoted
+    Last Transition Time:  2026-08-15T10:08:01Z
+    Message:               etcd cluster healthy; ConditionStatus:True
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdClusterHealthy
+    Last Transition Time:  2026-08-15T10:08:06Z
+    Message:               The etcd member list has converged on the requested member count
+    Observed Generation:   1
+    Reason:                EtcdMemberListReady
+    Status:                True
+    Type:                  EtcdMemberListReady
+    Last Transition Time:  2026-08-15T10:08:08Z
+    Message:               Successfully horizontally scaled the etcd cluster
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type     Reason                                        Age    From                         Message
+  ----     ------                                        ----   ----                         -------
+  Warning  is pet set scaled; ConditionStatus:False      6m36s  KubeDB Ops-manager Operator  is pet set scaled; ConditionStatus:False
+  Warning  etcd member list ready; ConditionStatus:False 6m31s  KubeDB Ops-manager Operator  etcd member list ready; ConditionStatus:False
+  Warning  etcd learner promoted; ConditionStatus:False  3m06s  KubeDB Ops-manager Operator  etcd learner promoted; ConditionStatus:False
+  Warning  etcd learner promoted; ConditionStatus:True   52s    KubeDB Ops-manager Operator  etcd learner promoted; ConditionStatus:True
+  Normal   EtcdMemberListReady                           42s    KubeDB Ops-manager Operator  The etcd member list has converged on the requested member count
+  Normal   Successful                                    40s    KubeDB Ops-manager Operator  Successfully horizontally scaled the etcd cluster
+```
+
+Reading that condition list:
+
+- `UpdateDatabase` is the whole "action" the ops request takes — it wrote `spec.replicas: 5`.
+- `IsPetSetScaled`, `EtcdLearnerPromoted`, `EtcdClusterHealthy` and `EtcdMemberListReady` are the
+  **convergence gates**. They flip to `False` while the poller is waiting and back to `True` when the
+  condition is met, which is why you see both polarities of `etcd learner promoted` in the events —
+  the ops request observed a learner mid-promotion and waited for it. On a `3 → 5` scale up you will
+  typically see that pair of events twice, once per added member.
+- `EtcdMemberListReady` only goes `True` when *all four* checks pass together: the `PetSet` carries 5
+  replicas, etcd reports exactly 5 members, none of them is a learner, and quorum is healthy.
+- There is **no** `PauseDatabase` / `ResumeDatabase` event pair here. `HorizontalScaling` is the one
+  `EtcdOpsRequest` type that does not pause the database, because the Provisioner operator is the
+  component doing the membership work.
+
+Now let's verify the result from all three viewpoints:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.replicas}'
+5
+
+$ kubectl get petset -n demo etcd-cluster -o jsonpath='{.spec.replicas}'
+5
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME             READY   STATUS    RESTARTS   AGE
+etcd-cluster-0   1/1     Running   0          21m
+etcd-cluster-1   1/1     Running   0          20m
+etcd-cluster-2   1/1     Running   0          20m
+etcd-cluster-3   1/1     Running   0          6m
+etcd-cluster-4   1/1     Running   0          3m
+```
+
+And, most importantly, from etcd itself — five members, **all voting**:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 member list -w table
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+|        ID        | STATUS  |      NAME      |                             PEER ADDRS                              |                            CLIENT ADDRS                             | IS LEARNER |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+| 1a2b3c4d5e6f7a8b | started | etcd-cluster-0 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 2b3c4d5e6f7a8b9c | started | etcd-cluster-1 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 3c4d5e6f7a8b9c0d | started | etcd-cluster-2 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 4d5e6f7a8b9c0d1e | started | etcd-cluster-3 | http://etcd-cluster-3.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-3.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 5e6f7a8b9c0d1e2f | started | etcd-cluster-4 | http://etcd-cluster-4.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-4.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+```
+
+Quorum is now 3 of 5, so the cluster tolerates two simultaneous failures.
+
+## Scale Down: 5 → 3 Members
+
+### Create the EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-hscale-down
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: etcd-cluster
+  horizontalScaling:
+    replicas: 3
+  timeout: 20m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/scaling/horizontal-scaling/etcdops-hscale-down.yaml
+etcdopsrequest.ops.kubedb.com/etcd-hscale-down created
+```
+
+### Removal Comes Before the PetSet Shrinks
+
+This is the part that is easy to get wrong and that KubeDB gets right for you. For each member being
+dropped, the Provisioner operator:
+
+1. Picks the **highest-ordinal** member — `etcd-cluster-4` first. Members are mapped back to `PetSet`
+   ordinals by peer URL, because a member that has not finished starting reports an empty name.
+2. Calls **`MemberRemove` on that member while its pod is still running**. The cluster commits the
+   configuration change, and its quorum requirement immediately drops from 3-of-5 to 3-of-4.
+3. Rewrites the cluster-state ConfigMap and only *then* shrinks the `PetSet` to 4, which deletes the
+   pod.
+
+Then the whole thing repeats for `etcd-cluster-3`. One member per pass — never two removals in
+flight.
+
+If the pod were deleted first and the member removed afterwards, there would be a window in which
+etcd still counted a member whose process no longer exists: a 5-member cluster requiring 3 votes with
+only 4 live members, one failure away from losing quorum for no reason at all. Removing first closes
+that window.
+
+```bash
+$ kubectl logs -n kubedb -l app.kubernetes.io/name=etcd-operator -f | grep etcd-cluster
+etcd demo/etcd-cluster: removed member 5e6f7a8b9c0d1e2f (etcd-cluster-4)
+etcd demo/etcd-cluster: removed member 4d5e6f7a8b9c0d1e (etcd-cluster-3)
+```
+
+### Verify the Scale Down
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME               TYPE                STATUS       AGE
+etcd-hscale-down   HorizontalScaling   Successful   2m14s
+```
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-hscale-down
+...
+Status:
+  Conditions:
+    Message:  Horizontal Scaling is in progress
+    Reason:   Running
+    Status:   True
+    Type:     Running
+    Message:  Successfully updated the desired member count
+    Reason:   UpdateDatabase
+    Status:   True
+    Type:     UpdateDatabase
+    Message:  is pet set scaled; ConditionStatus:True
+    Status:   True
+    Type:     IsPetSetScaled
+    Message:  etcd cluster healthy; ConditionStatus:True
+    Status:   True
+    Type:     EtcdClusterHealthy
+    Message:  The etcd member list has converged on the requested member count
+    Reason:   EtcdMemberListReady
+    Status:   True
+    Type:     EtcdMemberListReady
+    Message:  Successfully horizontally scaled the etcd cluster
+    Reason:   Successful
+    Status:   True
+    Type:     Successful
+  Phase:      Successful
+```
+
+Note that there is no `EtcdLearnerPromoted` gate on the way down — nothing is ever added as a learner
+during a scale down, so that check passes on the first poll and never records a condition.
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.replicas}'
+3
+
+$ kubectl get petset -n demo etcd-cluster -o jsonpath='{.spec.replicas}'
+3
+
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 member list -w table
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+|        ID        | STATUS  |      NAME      |                             PEER ADDRS                              |                            CLIENT ADDRS                             | IS LEARNER |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+| 1a2b3c4d5e6f7a8b | started | etcd-cluster-0 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 2b3c4d5e6f7a8b9c | started | etcd-cluster-1 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
+| 3c4d5e6f7a8b9c0d | started | etcd-cluster-2 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2380 | http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |      false |
++------------------+---------+----------------+---------------------------------------------------------------------+---------------------------------------------------------------------+------------+
+```
+
+The `PetSet` no longer manages `etcd-cluster-3` and `etcd-cluster-4`, but their PVCs are **retained**:
+
+```bash
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=etcd-cluster \
+  -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,SIZE:.status.capacity.storage
+NAME                  STATUS    SIZE
+data-etcd-cluster-0   Bound     1Gi
+data-etcd-cluster-1   Bound     1Gi
+data-etcd-cluster-2   Bound     1Gi
+data-etcd-cluster-3   Bound     1Gi
+data-etcd-cluster-4   Bound     1Gi
+```
+
+Delete them by hand if you want the storage back — KubeDB keeps them so a later scale up (or a
+mistaken scale down) does not destroy data.
+
+## Troubleshooting
+
+- **The ops request sits in `Progressing` with `etcd learner promoted; ConditionStatus:False`.**
+  The new member is still replicating. Check its log (`kubectl logs -n demo etcd-cluster-3 -c etcd`)
+  and give the request a longer `spec.timeout`. Promotion happens once the learner's applied revision
+  reaches 90% of the leader's; a large keyspace or a slow disk simply takes longer.
+- **The new pod is `Running` but never `Ready`.** Expected while it is a learner — see the note
+  above. If it stays that way after promotion, look at the member's own log.
+- **The `PetSet` replica count and the etcd member list disagree.** The provisioner repairs this
+  itself on the next pass, realigning the `PetSet` with etcd's member list (`realigning petset
+  replicas (N) with the etcd member count (M)` in the operator log). etcd's member list is the
+  authority.
+- **Another `EtcdOpsRequest` is already running.** Only one ops request per database may be in
+  `Progressing`; the new one waits and retries rather than racing it.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-hscale-up etcd-hscale-down
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Scale the cluster [vertically](/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md).
+- [Expand the volume](/docs/guides/etcd/volume-expansion/volume-expansion.md) of an Etcd cluster.
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md
@@ -413,6 +413,9 @@ NAME               TYPE                STATUS       AGE
 etcd-hscale-down   HorizontalScaling   Successful   2m14s
 ```
 
+Abbreviated to the conditions that differ from the scale-up walkthrough above — `EtcdMemberRemoved`
+and `EtcdLearnerPromoted` are both present in the real output too, per the note below:
+
 ```bash
 $ kubectl describe etcdopsrequest -n demo etcd-hscale-down
 ...
@@ -446,8 +449,8 @@ Status:
 Note that the `EtcdLearnerPromoted` gate means something different on the way down: nothing is ever
 added as a learner during a scale down, so the check is simply "no member is still a learner", and it
 passes on the first poll. It still records a `True` condition — you just never see the `False`
-polarity that a scale up produces while it waits for a learner to catch up. The scale down also
-opens with an `EtcdMemberRemoved` condition, where a scale up opens with `EtcdMemberAdded`.
+polarity that a scale-up produces while it waits for a learner to catch up. The scale-down also
+opens with an `EtcdMemberRemoved` condition, where a scale-up opens with `EtcdMemberAdded`.
 
 ```bash
 $ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.replicas}'

--- a/docs/guides/etcd/scaling/horizontal-scaling/overview.md
+++ b/docs/guides/etcd/scaling/horizontal-scaling/overview.md
@@ -1,0 +1,158 @@
+---
+title: Etcd Horizontal Scaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-horizontal-scaling-overview
+    name: Overview
+    parent: etcd-horizontal-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Horizontal Scaling
+
+This guide gives an overview of how KubeDB changes the number of members of an `Etcd` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## Etcd Membership Is Not a Replica Count
+
+Read this section before anything else — horizontal scaling for etcd does not work the way it does
+for a stateless Deployment, or even for most other KubeDB databases.
+
+An etcd cluster is a Raft consensus group. Its membership lives **inside etcd itself**, not in the
+`PetSet`: every member holds a copy of the member list, and every write has to be acknowledged by a
+quorum of `N/2+1` **voting** members. Adding or removing a member is therefore a Raft configuration
+change that has to be committed by the cluster, not a number you increment on a controller object.
+
+Two consequences shape everything below:
+
+1. **A membership change and a pod change are two different writes** that must be ordered correctly.
+   Adding a pod without adding the member gives you a process that cannot join; adding the member
+   without the pod gives you a cluster whose quorum requirement has already grown while the new
+   member does not exist yet.
+2. **Scaling is never atomic.** A `3 → 5` scale up is two separate member additions, each with its own
+   catch-up period. KubeDB deliberately performs **one membership mutation at a time**, so a scale up
+   or down is a sequence of steps, not a single instantaneous change.
+
+### Learners
+
+etcd solves the "a brand new member drags the cluster down while it catches up" problem with
+**learners**. A learner:
+
+- receives the full Raft log and applies it, exactly like a voting member;
+- **does not count towards quorum** and cannot vote;
+- cannot serve linearizable reads.
+
+KubeDB adds every new member as a learner first (`MemberAddAsLearner`), waits for it to catch up, and
+only then **promotes** it to a voting member (`MemberPromote`). Because a learner is not part of
+quorum, the cluster's fault tolerance is completely unchanged while it is catching up — a 3-member
+cluster growing to 4 still needs 2 of its 3 voters, not 3 of 4.
+
+> **Why readiness is not the gate.** etcd's `/health` endpoint performs a linearizable read, which a
+> learner *cannot* serve — so a learner pod never becomes `Ready`. KubeDB therefore does **not** gate
+> promotion on pod readiness (that would deadlock the scale up). Instead it compares the learner's
+> applied revision against the leader's and promotes once the ratio reaches `0.9`, mirroring etcd's
+> own `IsLearnerReady` heuristic. etcd rejects a premature promotion anyway; the ratio check just
+> avoids hammering it with doomed calls.
+
+## Who Actually Does the Work
+
+The membership reconciliation lives in the **Provisioner** operator, not in the ops request. It runs
+continuously, comparing etcd's real member list against `spec.replicas` on the `Etcd` object, and
+performs **at most one mutation per reconcile pass**:
+
+- If a learner exists, finish that first — check whether it has caught up, and promote it. Nothing
+  else happens in that pass. A learner is never left in place while another member is added.
+- Otherwise, if the member count is below `spec.replicas`, add exactly one member as a learner.
+- Otherwise, if the member count is above `spec.replicas`, remove exactly one member.
+- If the `PetSet` replica count and the etcd member count disagree (for example because the operator
+  restarted between the two writes), realign the `PetSet` with the member list first. **etcd's member
+  list is the authority** on who is in the cluster.
+
+This is why membership converges even without an ops request: if you edit `spec.replicas` on the
+`Etcd` object directly, the same sequence runs. The `HorizontalScaling` `EtcdOpsRequest` is a thin,
+auditable wrapper around that edit — it patches `spec.replicas` and then waits for the provisioner to
+converge, reporting progress through its own status.
+
+> **The one ops type that does not pause the database.** Every other `EtcdOpsRequest` pauses the
+> `Etcd` object so the Provisioner operator keeps its hands off. `HorizontalScaling` deliberately
+> does **not** — pausing would stop the very controller that performs the membership changes, and the
+> convergence the ops request is waiting for would never happen. Mutual exclusion is still
+> guaranteed: only one `EtcdOpsRequest` per database may be in `Progressing` at a time.
+
+## How Scale Up Works
+
+For a `3 → 5` scale up, with pods `etcd-cluster-0..2` already running:
+
+1. The user creates an `EtcdOpsRequest` of type `HorizontalScaling` with
+   `spec.horizontalScaling.replicas: 5`.
+2. The Ops-manager operator moves the request to `Progressing` and patches `spec.replicas: 5` on the
+   `Etcd` object (`UpdateDatabase` condition).
+3. The Provisioner operator sees `3 members < 5 desired` and, in one pass:
+   - rewrites the cluster-state ConfigMap for 4 members with `--initial-cluster-state=existing` —
+     this is written **first**, because the new pod reads its bootstrap membership from it at start-up
+     and etcd validates that a joining member's `--initial-cluster` matches the cluster's member list
+     exactly;
+   - calls `MemberAddAsLearner` with the peer URL of the next ordinal
+     (`http://etcd-cluster-3.etcd-cluster-pods.demo.svc.cluster.local:2380`);
+   - bumps the `PetSet` to 4 replicas, so the pod is created and the learner starts syncing.
+4. On subsequent passes the provisioner sees a learner and does nothing but poll its revision against
+   the leader's. Once the ratio reaches `0.9` it calls `MemberPromote`. The cluster now has 4 voting
+   members.
+5. Only now does the provisioner add `etcd-cluster-4` as a learner, and the same catch-up/promote
+   cycle repeats.
+6. The ops request polls until **all** of the following hold, and only then reports `Successful`:
+   the `PetSet` carries 5 replicas, etcd's member list has exactly 5 members, **none of them is still
+   a learner**, and the cluster reports a healthy quorum.
+
+At no point is more than one membership change in flight, and at no point does the cluster contain
+more than one non-voting member — so quorum is never put at risk by the scale up itself.
+
+## How Scale Down Works
+
+Scale down is the mirror image, and the **ordering is the important part**:
+
+1. The provisioner identifies the **highest-ordinal** member. It maps each etcd member back to a
+   `PetSet` ordinal by peer URL (a member that has not started yet reports an empty `--name`, so the
+   peer URL is the reliable key), and picks the largest.
+2. It calls `MemberRemove` on that member **first**, while its pod is still running.
+3. Only after the removal is committed does it rewrite the cluster-state ConfigMap and shrink the
+   `PetSet` by one, which deletes the pod.
+
+Doing it the other way round — deleting the pod and then removing the member — would leave a member
+in the Raft configuration whose process is gone. A 5-member cluster would still require 3 votes while
+only 4 members exist, so the cluster would be one failure away from losing quorum for no reason. By
+removing first, the quorum requirement drops as soon as the configuration change commits, and etcd's
+membership never disagrees with the pod count for longer than the gap between two API writes (and
+even that gap is repaired on the next pass).
+
+One member is removed per pass, so a `5 → 3` scale down is two sequential removals. The provisioner
+refuses to scale below a single member.
+
+> **PVCs are retained.** Shrinking the `PetSet` does not delete the data volumes of the removed
+> members. `data-etcd-cluster-3` and `data-etcd-cluster-4` stay bound after a `5 → 3` scale down; if
+> you scale back up later they are adopted by the new pods (which is harmless — the member is added
+> fresh as a learner and re-syncs from the leader). Delete them by hand if you want the space back.
+
+## Choosing a Member Count
+
+- Only **voting** members count towards quorum, and quorum is `N/2+1`. So 3 members tolerate 1
+  failure, 4 members *also* tolerate only 1, and 5 members tolerate 2. **Odd counts are what you
+  want**; an even count buys you extra write latency without extra fault tolerance.
+- The webhook only rejects `spec.horizontalScaling.replicas < 1`. Even counts are allowed, just
+  discouraged.
+- Larger clusters are not faster. Every write has to be replicated to a quorum, so 7 members are
+  slower to write than 3. Scale out for fault tolerance and read capacity, not for write throughput.
+
+In the [next](/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md) doc, we are going
+to show a step-by-step guide on scaling an Etcd cluster up and down using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/scaling/vertical-scaling/_index.md
+++ b/docs/guides/etcd/scaling/vertical-scaling/_index.md
@@ -1,0 +1,12 @@
+---
+title: Vertical Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-vertical-scaling
+    name: Vertical Scaling
+    parent: etcd-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/scaling/vertical-scaling/overview.md
+++ b/docs/guides/etcd/scaling/vertical-scaling/overview.md
@@ -1,0 +1,108 @@
+---
+title: Etcd Vertical Scaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-vertical-scaling-overview
+    name: Overview
+    parent: etcd-vertical-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Vertical Scaling
+
+This guide gives an overview of how the KubeDB Ops-manager operator updates the compute resources
+(CPU and Memory) of the `etcd` container of an `Etcd` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## How Vertical Scaling Process Works
+
+The vertical scaling process consists of the following steps:
+
+1. At first, a user creates an `Etcd` Custom Resource (CR).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CR.
+
+3. When the operator finds an `Etcd` CR, it creates a `PetSet` and the related resources — Secrets,
+   Services, RBAC, and the cluster-state ConfigMap.
+
+4. Then, in order to update the resources of the `Etcd` cluster, the user creates an `EtcdOpsRequest`
+   CR of type `VerticalScaling` with the desired resources.
+
+5. The `KubeDB` Ops-manager operator watches the `EtcdOpsRequest` CR.
+
+6. When it finds a `VerticalScaling` `EtcdOpsRequest`, it pauses the referenced `Etcd` object, so the
+   `KubeDB` Provisioner operator does not reconcile it while the scaling is in progress.
+
+7. The Ops-manager operator patches the `PetSet` pod template with the new resources, so any pod
+   recreated from that point on — by this ops request or by a later failure — carries them.
+
+8. It also patches `spec.podTemplate.spec.containers[]` on the `Etcd` object, so the Provisioner
+   operator re-renders exactly the same template once the database is resumed.
+
+9. It then actuates the change on the running pods, in the mode selected by
+   `spec.verticalScaling.mode` (see below).
+
+10. Finally, the Ops-manager operator resumes the `Etcd` object so that the Provisioner operator
+    resumes its usual operations, and marks the `EtcdOpsRequest` `Successful`.
+
+## Vertical Scaling Modes
+
+KubeDB actuates vertical scaling in one of two modes, selected through the
+`spec.verticalScaling.mode` field of the `EtcdOpsRequest`:
+
+- **`Restart`** (default): The operator restarts the member pods so that they come back with the new
+  CPU and Memory. The restart is **leader-aware and sequential** — this is the part that is specific
+  to etcd:
+  - The operator first resolves the current Raft leader through etcd's `Status()` RPC.
+  - Every **follower** is evicted first, one at a time. After each eviction the operator waits for
+    the pod to become `Ready` *and* for the cluster to report a healthy quorum again before it
+    touches the next member. Without that gate, a second eviction in a 3-member cluster would take
+    quorum down.
+  - The **leader is restarted last**, and only after its leadership has been handed to another
+    voting member with etcd's `MoveLeader` RPC. A deliberate leadership transfer is near
+    instantaneous, whereas evicting the leader outright triggers an election, during which the whole
+    cluster is unavailable for writes for an election timeout.
+  - A single-member cluster has no one to hand leadership to, so it is simply restarted.
+
+- **`InPlace`**: The operator resizes the running containers using the Kubernetes
+  [in-place Pod resize](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+  (`pods/resize` subresource) — no pod restart, no leadership change, and no Raft election risk at
+  all. If a Node cannot accommodate the new request (the kubelet marks the resize `Infeasible`), the
+  operator automatically falls back to the `Restart` behavior **for those pods only**, using the same
+  leader-last ordering described above.
+
+If `spec.verticalScaling.mode` is omitted, it defaults to `Restart`.
+
+> **Note:** `InPlace` mode relies on the Kubernetes `InPlacePodVerticalScaling` feature gate, which
+> is enabled by default from Kubernetes v1.33. On older clusters, or when the feature gate is
+> disabled, use `Restart` mode.
+
+## Scalable Containers
+
+`spec.verticalScaling` for etcd has no node-selection or topology sub-fields — etcd has exactly one
+container role, so there is a single `etcd` entry:
+
+| Field                            | Container | Notes                                                                |
+|----------------------------------|-----------|----------------------------------------------------------------------|
+| `spec.verticalScaling.etcd`      | `etcd`    | The etcd member container. This is the field you normally want.       |
+| `spec.verticalScaling.exporter`  | `exporter`| Present for structural parity with other KubeDB databases only.        |
+
+> **Important:** KubeDB does **not** deploy a metrics exporter sidecar for etcd — etcd serves its own
+> Prometheus metrics natively on the metrics listener (port `2381`), so there is nothing extra to
+> resize. `spec.verticalScaling.exporter` exists in the `EtcdOpsRequest` API for structural parity
+> with the other KubeDB databases, and setting it has **no effect** unless you have added a container
+> literally named `exporter` yourself through `spec.podTemplate`. Do not rely on it.
+
+In the [next](/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md) doc, we are going to
+show a step-by-step guide on updating the resources of an Etcd cluster using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md
@@ -1,0 +1,407 @@
+---
+title: Vertical Scaling Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-vertical-scaling-ops
+    name: Scale Vertically
+    parent: etcd-vertical-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Vertical Scale Etcd
+
+This guide will show you how to use the `KubeDB` Ops-manager operator to update the compute
+resources of an `Etcd` cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster. If you do not already have a cluster, you can create
+  one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Vertical Scaling Overview](/docs/guides/etcd/scaling/vertical-scaling/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/scaling/vertical-scaling](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/scaling/vertical-scaling)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Apply Vertical Scaling
+
+Here, we are going to deploy an `Etcd` cluster using a version supported by the `KubeDB` operator,
+and then apply vertical scaling on it.
+
+### Deploy Etcd
+
+Below is the YAML of the `Etcd` CR that we are going to create,
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/scaling/vertical-scaling/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Now, wait until `etcd-cluster` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    4m
+```
+
+Let's check the resources of the `etcd` container:
+
+```bash
+$ kubectl get pod -n demo etcd-cluster-0 -o json | jq '.spec.containers[] | select(.name=="etcd") | .resources'
+{
+  "limits": {
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "500m",
+    "memory": "1Gi"
+  }
+}
+```
+
+These are the default resources assigned by the KubeDB operator (etcd is latency sensitive but its
+working set is bounded by the backend quota rather than by the dataset size, so the default footprint
+is deliberately modest).
+
+We are now ready to apply an `EtcdOpsRequest` to update these resources.
+
+### Vertical Scaling
+
+#### Create EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-vscale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: etcd-cluster
+  verticalScaling:
+    mode: Restart
+    etcd:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+  timeout: 10m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing the vertical scaling operation on the
+  `etcd-cluster` database.
+- `spec.type` specifies that we are performing `VerticalScaling` on our database.
+- `spec.verticalScaling.etcd.resources` specifies the desired resources of the `etcd` container after
+  scaling.
+- `spec.verticalScaling.mode` specifies how the scaling is actuated — `Restart` (the default; the
+  member pods are restarted one at a time, leader last) or `InPlace` (the running pods are resized
+  through the `pods/resize` subresource with no restart at all). See
+  [Vertical Scaling Modes](/docs/guides/etcd/scaling/vertical-scaling/overview.md#vertical-scaling-modes).
+- Have a look [here](/docs/guides/etcd/concepts/etcdopsrequest.md) to understand the `timeout` and
+  `apply` fields.
+
+> `spec.verticalScaling.etcd` and `spec.verticalScaling.exporter` are the only two containers the API
+> accepts, and at least one of them must be set — the validating webhook rejects an empty
+> `verticalScaling`. In practice you always want `etcd`: KubeDB does not run an exporter sidecar for
+> etcd (see the [note in the overview](/docs/guides/etcd/scaling/vertical-scaling/overview.md#scalable-containers)).
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/scaling/vertical-scaling/etcdops-vscale.yaml
+etcdopsrequest.ops.kubedb.com/etcd-vscale created
+```
+
+#### Verify the Etcd resources are updated successfully
+
+Let's wait for the `EtcdOpsRequest` to become `Successful`. Run the following command to watch the
+`EtcdOpsRequest` CR,
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME          TYPE              STATUS       AGE
+etcd-vscale   VerticalScaling   Successful   3m12s
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-vscale
+Name:         etcd-vscale
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T09:41:02Z
+  Generation:          1
+  Resource Version:    120451
+  UID:                 3ca1e0c4-7a0f-4f1d-9b3a-6f2a4c1c9f01
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:   etcd-cluster
+  Timeout:  10m
+  Type:     VerticalScaling
+  Vertical Scaling:
+    Etcd:
+      Resources:
+        Limits:
+          Cpu:     1
+          Memory:  2Gi
+        Requests:
+          Cpu:     1
+          Memory:  2Gi
+    Mode:          Restart
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T09:41:02Z
+    Message:               Vertical Scaling is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T09:41:12Z
+    Message:               Successfully updated the petset resources
+    Observed Generation:   1
+    Reason:                UpdateEtcdPetSet
+    Status:                True
+    Type:                  UpdateEtcdPetSet
+    Last Transition Time:  2026-08-15T09:41:12Z
+    Message:               Successfully updated the Etcd resources
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-08-15T09:41:47Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-cluster-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-cluster-1
+    Last Transition Time:  2026-08-15T09:41:52Z
+    Message:               etcd cluster healthy; ConditionStatus:True; PodName:etcd-cluster-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdClusterHealthy--etcd-cluster-1
+    Last Transition Time:  2026-08-15T09:42:27Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-cluster-2
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-cluster-2
+    Last Transition Time:  2026-08-15T09:42:32Z
+    Message:               etcd cluster healthy; ConditionStatus:True; PodName:etcd-cluster-2
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdClusterHealthy--etcd-cluster-2
+    Last Transition Time:  2026-08-15T09:43:07Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-cluster-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-cluster-0
+    Last Transition Time:  2026-08-15T09:43:12Z
+    Message:               Successfully restarted the etcd members with the new resources
+    Observed Generation:   1
+    Reason:                VerticalScale
+    Status:                True
+    Type:                  VerticalScale
+    Last Transition Time:  2026-08-15T09:43:14Z
+    Message:               Successfully vertically scaled the etcd cluster
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason            Age    From                         Message
+  ----    ------            ----   ----                         -------
+  Normal  PauseDatabase     3m12s  KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
+  Normal  UpdateEtcdPetSet  3m2s   KubeDB Ops-manager Operator  Successfully updated the petset resources
+  Normal  UpdateDatabase    3m2s   KubeDB Ops-manager Operator  Successfully updated the Etcd resources
+  Normal  VerticalScale     12s    KubeDB Ops-manager Operator  Successfully restarted the etcd members with the new resources
+  Normal  ResumeDatabase    10s    KubeDB Ops-manager Operator  Successfully resumed Etcd demo/etcd-cluster
+  Normal  Successful        10s    KubeDB Ops-manager Operator  Successfully vertically scaled the etcd cluster
+```
+
+A few things worth pointing out in that condition list:
+
+- The per-pod `CheckPodReady--<pod>` / `EtcdClusterHealthy--<pod>` conditions only show up for the
+  steps that actually had to wait. They are the sequencing gate: the operator does not evict the next
+  member until the previous one is `Ready` **and** the cluster reports a healthy quorum
+  (`healthy members >= N/2+1`) again.
+- The followers (`etcd-cluster-1`, `etcd-cluster-2` in this run) are restarted before the Raft leader
+  (`etcd-cluster-0` here). Which pod is the leader is discovered at runtime, so the order you observe
+  depends on where leadership happens to sit when the ops request starts.
+- Before the leader is evicted, the operator issues a `MoveLeader` RPC to hand leadership to another
+  voting member; if that step has to wait you will also see a `MoveLeader--<pod>` condition.
+
+Now let's verify from the `PetSet` and the pods that the resources have been updated:
+
+```bash
+$ kubectl get petset -n demo etcd-cluster \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="etcd")].resources}' | jq
+{
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "1",
+    "memory": "2Gi"
+  }
+}
+
+$ kubectl get pod -n demo etcd-cluster-0 -o json | jq '.spec.containers[] | select(.name=="etcd") | .resources'
+{
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "1",
+    "memory": "2Gi"
+  }
+}
+```
+
+The new resources are also persisted onto the `Etcd` object itself, so the Provisioner operator
+re-renders the same template after the database is resumed:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster \
+  -o jsonpath='{.spec.podTemplate.spec.containers[?(@.name=="etcd")].resources}' | jq
+{
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "requests": {
+    "cpu": "1",
+    "memory": "2Gi"
+  }
+}
+```
+
+### In-Place Vertical Scaling
+
+To resize the member pods **without restarting them**, set `spec.verticalScaling.mode` to `InPlace`.
+The operator resizes the running containers through the Kubernetes `pods/resize` subresource; no pod
+is evicted, no Raft leadership is moved, and there is no election risk at all.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-vscale-inplace
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: etcd-cluster
+  verticalScaling:
+    mode: InPlace
+    etcd:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "3Gi"
+        limits:
+          cpu: "1"
+          memory: "3Gi"
+  timeout: 10m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/scaling/vertical-scaling/etcdops-vscale-inplace.yaml
+etcdopsrequest.ops.kubedb.com/etcd-vscale-inplace created
+```
+
+The condition list looks the same up to `UpdateDatabase`; the actuation step is then reported through
+`RequestInPlaceResize--<pod>` / `CheckInPlaceResizeSettled--<pod>` conditions and finishes with:
+
+```yaml
+    Message:               Successfully resized the etcd members in place
+    Reason:                VerticalScale
+    Status:                True
+    Type:                  VerticalScale
+```
+
+If the kubelet reports the resize as `Infeasible` for a pod (its Node cannot fit the new request
+without a reschedule), the operator logs that and falls back to the `Restart` behavior **for that pod
+only**, using the same leader-last ordering. So a partially infeasible `InPlace` request still
+converges — some pods are resized live, the rest are rolled.
+
+> **Note:** `InPlace` requires the Kubernetes `InPlacePodVerticalScaling` feature gate (on by default
+> from Kubernetes v1.33). On older clusters use `Restart`.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-vscale etcd-vscale-inplace
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Scale the cluster [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md).
+- [Expand the volume](/docs/guides/etcd/volume-expansion/volume-expansion.md) of an Etcd cluster.
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md
@@ -280,15 +280,18 @@ Events:
 
 A few things worth pointing out in that condition list:
 
-- The per-pod `CheckPodReady--<pod>` / `EtcdClusterHealthy--<pod>` conditions only show up for the
-  steps that actually had to wait. They are the sequencing gate: the operator does not evict the next
-  member until the previous one is `Ready` **and** the cluster reports a healthy quorum
-  (`healthy members >= N/2+1`) again.
+- The per-pod `CheckPodReady--<pod>` / `EtcdClusterHealthy--<pod>` conditions are written for every
+  member the operation touched, not only for the steps that had to wait — they are both the
+  sequencing gate and the operator's own record of what is already done, so they survive a restart of
+  the operator. The gate itself is: the operator does not evict the next member until the previous
+  one is `Ready` **and** the cluster reports a healthy quorum (`healthy members >= N/2+1`) again. The
+  matching `GetLeader--<pod>` and `EvictPod--<pod>` conditions are elided from the output above.
 - The followers (`etcd-cluster-1`, `etcd-cluster-2` in this run) are restarted before the Raft leader
   (`etcd-cluster-0` here). Which pod is the leader is discovered at runtime, so the order you observe
   depends on where leadership happens to sit when the ops request starts.
 - Before the leader is evicted, the operator issues a `MoveLeader` RPC to hand leadership to another
-  voting member; if that step has to wait you will also see a `MoveLeader--<pod>` condition.
+  voting member, and always records a `MoveLeader--<pod>` condition naming the pod it moved
+  leadership away from.
 
 Now let's verify from the `PetSet` and the pods that the resources have been updated:
 

--- a/docs/guides/etcd/storage-migration/_index.md
+++ b/docs/guides/etcd/storage-migration/_index.md
@@ -1,0 +1,12 @@
+---
+title: Storage Migration
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-storage-migration
+    name: Storage Migration
+    parent: etcd-etcd-guides
+    weight: 75
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/storage-migration/overview.md
+++ b/docs/guides/etcd/storage-migration/overview.md
@@ -1,0 +1,86 @@
+---
+title: Etcd Storage Migration Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-storage-migration-overview
+    name: Overview
+    parent: etcd-storage-migration
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Storage Migration
+
+This guide gives an overview of how the KubeDB Ops-manager operator moves the data volumes of an
+`Etcd` cluster from one `StorageClass` to another.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## Why It Is Not Just an Edit
+
+`spec.storageClassName` on a PVC is immutable, and so is `spec.volumeClaimTemplates` on a `PetSet`.
+Moving an etcd member onto a different `StorageClass` therefore means provisioning a **new** volume,
+copying the data across, and giving the new volume the old claim's name so the member picks it up
+again. `StorageMigration` is the `EtcdOpsRequest` type that does all of that for you.
+
+## How the Storage Migration Process Works
+
+The mechanics are the shared KubeDB migration machinery, identical to every other KubeDB database.
+The only etcd-specific part is the **ordering**: members are migrated one at a time, **followers
+first and the Raft leader last**, so the cluster keeps a quorum throughout.
+
+1. The user creates an `EtcdOpsRequest` of type `StorageMigration` with
+   `spec.migration.storageClassName` (the target `StorageClass`) and a `spec.timeout`.
+
+2. The Ops-manager operator pauses the `Etcd` object, so the Provisioner operator does not fight the
+   migration.
+
+3. It deletes the `PetSet` **with an orphan propagation policy**. The `PetSet` has to go first —
+   otherwise it would immediately recreate every pod the migration deletes — but the pods are
+   orphaned, not deleted, so every member keeps serving until its own turn comes.
+
+4. It resolves the current Raft leader and splits the members into followers and the leader, so the
+   leader's volume is migrated last.
+
+5. For each member, in that order:
+   - create a new PVC on the target `StorageClass`, sized from the old one;
+   - if the target `StorageClass` uses `WaitForFirstConsumer`, run a short-lived mounter pod pinned to
+     the member's node, so the new volume is provisioned in the right topology;
+   - stash the member pod's manifest as an annotation on the ops request and delete the pod;
+   - run a migrator `Job` that `rsync`s the data directory from the old volume to the new one;
+   - swap the names: delete the original PVC (with its PV temporarily set to `Retain`, so no data is
+     lost) and re-create the claim under the original name bound to the new volume;
+   - recreate the member pod from the stashed manifest and wait for it to become `Ready`;
+   - **wait for a healthy quorum before moving to the next member.**
+
+6. Once every member has been migrated, the operator patches
+   `spec.storage.storageClassName` on the `Etcd` object, resumes it, and marks the request
+   `Successful`.
+
+## Preconditions
+
+- `spec.migration.storageClassName` is required, and the target `StorageClass` must exist.
+- **`spec.timeout` is required.** The webhook rejects a `StorageMigration` without it. Every step of
+  the migration is bounded by that timeout, and the data-copy `Job` has no other deadline at all — so
+  size it against how much data you have, not against how long a pod takes to restart.
+- `spec.storageType` must be `Durable`; there is nothing to migrate on an `Ephemeral` etcd.
+- If the **source** `StorageClass` uses `volumeBindingMode: WaitForFirstConsumer`, the target must use
+  it too. The webhook rejects the mismatch.
+
+> **Keeping the source volumes.** While the claims are being swapped, each PV's reclaim policy is
+> temporarily forced to `Retain` so nothing is lost mid-flight, and the original policy is restored
+> once the member is back — which means a source PV provisioned by a `Delete`-reclaiming
+> `StorageClass` is eventually reclaimed. Set `spec.migration.oldPVReclaimPolicy: Retain` if you want
+> the previous volumes to survive the migration.
+
+In the [next](/docs/guides/etcd/storage-migration/storage-migration.md) doc, we are going to show a
+step-by-step guide on migrating the storage of an Etcd cluster using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/storage-migration/storage-migration.md
+++ b/docs/guides/etcd/storage-migration/storage-migration.md
@@ -1,0 +1,334 @@
+---
+title: Etcd Storage Migration
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-storage-migration-ops
+    name: Migrate StorageClass
+    parent: etcd-storage-migration
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Storage Migration of an Etcd Cluster
+
+This guide shows how to move an `Etcd` cluster's data volumes to a different `StorageClass` using an
+`EtcdOpsRequest` of type `StorageMigration`. KubeDB provisions new PVCs on the target `StorageClass`,
+copies the data across with a migrator `Job`, swaps the volumes in and recreates each member pod —
+**followers first, the Raft leader last**, waiting for a healthy quorum between members.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster.
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Storage Migration Overview](/docs/guides/etcd/storage-migration/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/storage-migration](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/storage-migration)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Prepare Source and Target StorageClasses
+
+You need a **source** and a **target** `StorageClass`. This guide migrates between two
+[Longhorn](https://longhorn.io/) StorageClasses, `longhorn-single` and `longhorn-single-migrated`:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single-migrated
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fsType: ext4
+  dataLocality: disabled
+  dataEngine: v1
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/storage-migration/longhorn-single.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/storage-migration/longhorn-single-migrated.yaml
+```
+
+> If the **source** `StorageClass` uses `volumeBindingMode: WaitForFirstConsumer`, the target must use
+> it too — the validating webhook rejects the mismatch, because a migration that changes the binding
+> mode cannot guarantee the new volume lands in the right topology.
+
+## Deploy an Etcd Cluster on the Source StorageClass
+
+Below is the YAML of the `Etcd` CR that we are going to create,
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "longhorn-single"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/storage-migration/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Wait until `etcd-cluster` is `Ready`, then note the source `StorageClass` of the PVCs:
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    5m
+
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=etcd-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                  SC                SIZE
+data-etcd-cluster-0   longhorn-single   2Gi
+data-etcd-cluster-1   longhorn-single   2Gi
+data-etcd-cluster-2   longhorn-single   2Gi
+```
+
+## Create a StorageMigration EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: etcd-cluster
+  migration:
+    storageClassName: longhorn-single-migrated
+  timeout: 30m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.migration.storageClassName` is the **target** `StorageClass`.
+- `spec.timeout` is **required** for `StorageMigration`. Every step is bounded by it, and the
+  data-copy `Job` has no other deadline — so size it against how much data each member holds, not
+  against how long a pod takes to restart.
+- `spec.migration.oldPVReclaimPolicy` (optional) controls what happens to the source PVs once their
+  claims have been renamed away. Set it to `Retain` if you want to keep the old volumes.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/storage-migration/etcdops-storage-migration.yaml
+etcdopsrequest.ops.kubedb.com/etcd-storage-migration created
+```
+
+## Verify the Migration
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME                     TYPE               STATUS       AGE
+etcd-storage-migration   StorageMigration   Successful   14m
+```
+
+While it runs you can watch the members being migrated one at a time. The `PetSet` is deleted up
+front (with orphaned pods, so the members keep serving), and then each member's pod goes away and
+comes back on the new volume:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME                            READY   STATUS      RESTARTS   AGE
+etcd-cluster-0                  1/1     Running     0          21m
+etcd-cluster-2                  1/1     Running     0          20m
+migrator-etcd-cluster-1-xxxxx   0/1     Completed   0          38s
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-storage-migration
+Name:         etcd-storage-migration
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T12:15:07Z
+  Generation:          1
+  Resource Version:    158773
+  UID:                 c40b7c19-6d33-4f2e-b9b7-8f8f2b8a4d10
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:  etcd-cluster
+  Migration:
+    Storage Class Name:  longhorn-single-migrated
+  Timeout:               30m
+  Type:                  StorageMigration
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T12:15:07Z
+    Message:               StorageClass migration is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T12:15:22Z
+    Message:               pet set deleted; ConditionStatus:True; PodName:etcd-cluster
+    Observed Generation:   1
+    Status:                True
+    Type:                  PetSetDeleted--etcd-cluster
+    Last Transition Time:  2026-08-15T12:19:47Z
+    Message:               PVC migration completed for etcd-cluster-1
+    Observed Generation:   1
+    Reason:                PodMigrationCompleted-etcd-cluster-1
+    Status:                True
+    Type:                  PodMigrationCompleted-etcd-cluster-1
+    Last Transition Time:  2026-08-15T12:24:12Z
+    Message:               PVC migration completed for etcd-cluster-2
+    Observed Generation:   1
+    Reason:                PodMigrationCompleted-etcd-cluster-2
+    Status:                True
+    Type:                  PodMigrationCompleted-etcd-cluster-2
+    Last Transition Time:  2026-08-15T12:28:31Z
+    Message:               PVC migration completed for etcd-cluster-0
+    Observed Generation:   1
+    Reason:                PodMigrationCompleted-etcd-cluster-0
+    Status:                True
+    Type:                  PodMigrationCompleted-etcd-cluster-0
+    Last Transition Time:  2026-08-15T12:28:36Z
+    Message:               Successfully migrated the StorageClass of every etcd member
+    Observed Generation:   1
+    Reason:                MigrateEtcdStorage
+    Status:                True
+    Type:                  MigrateEtcdStorage
+    Last Transition Time:  2026-08-15T12:28:41Z
+    Message:               Successfully updated the Etcd storage class
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-08-15T12:28:44Z
+    Message:               Successfully migrated the etcd StorageClass
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason              Age  From                         Message
+  ----    ------              ---- ----                         -------
+  Normal  PauseDatabase       14m  KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
+  Normal  MigrateEtcdStorage  20s  KubeDB Ops-manager Operator  Successfully migrated the StorageClass of every etcd member
+  Normal  UpdateDatabase      15s  KubeDB Ops-manager Operator  Successfully updated the Etcd storage class
+  Normal  ResumeDatabase      12s  KubeDB Ops-manager Operator  Successfully resumed Etcd demo/etcd-cluster
+  Normal  Successful          12s  KubeDB Ops-manager Operator  Successfully migrated the etcd StorageClass
+```
+
+Note the order of the `PodMigrationCompleted-*` conditions: the followers (`etcd-cluster-1`,
+`etcd-cluster-2` in this run) complete before the Raft leader (`etcd-cluster-0` here). Which pod is
+the leader is discovered at runtime, so the order you observe depends on where leadership sits when
+the migration starts. Between two members, the operator waits for the restarted one to be `Ready` and
+for the cluster to report a healthy quorum — that gate is what keeps a 3-member cluster from ever
+having two members down at once.
+
+The per-resource progress conditions (`PVCCreated--…`, `PodDeleted--…`, `JobCreated--…`,
+`PVCDeleted--…`, `PodReady--…`, and so on) are elided above; they appear for every step that had to
+wait and are useful when a migration stalls.
+
+Confirm the data PVCs are now bound to the target `StorageClass` and the cluster is `Ready`:
+
+```bash
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=etcd-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                  SC                         SIZE
+data-etcd-cluster-0   longhorn-single-migrated   2Gi
+data-etcd-cluster-1   longhorn-single-migrated   2Gi
+data-etcd-cluster-2   longhorn-single-migrated   2Gi
+
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.storage.storageClassName}'
+longhorn-single-migrated
+
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    43m
+```
+
+And that etcd itself still has all three voting members with a healthy quorum:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 endpoint health --cluster -w table
++---------------------------------------------------------------------+--------+-------------+-------+
+|                              ENDPOINT                               | HEALTH |    TOOK     | ERROR |
++---------------------------------------------------------------------+--------+-------------+-------+
+| http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 |   true | 4.512103ms  |       |
+| http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 |   true | 5.284917ms  |       |
+| http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 |   true | 5.901442ms  |       |
++---------------------------------------------------------------------+--------+-------------+-------+
+```
+
+## Troubleshooting
+
+- **`spec.timeout is required for a storage migration`** — add `spec.timeout`. It is not optional for
+  this ops type.
+- **`storage class <name> not found`** — the target `StorageClass` must exist before the request is
+  created.
+- **`volume binding mode should be WaitForFirstConsumer for <name> storageClass`** — the source class
+  binds late and the target does not. Pick a target with a matching `volumeBindingMode`.
+- **`storage migration is not applicable to an ephemeral etcd`** — `spec.storageType` is `Ephemeral`;
+  there are no PVCs to migrate.
+- **The migration stalls on one member** — look at the migrator `Job`
+  (`kubectl logs -n demo job/migrator-<pod-name>`); it is the `rsync` doing the copying. Bear in mind
+  the whole request, including that copy, is bounded by `spec.timeout`.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-storage-migration
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Expand the volume](/docs/guides/etcd/volume-expansion/volume-expansion.md) of an Etcd cluster.
+- Scale the cluster [vertically](/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md) or
+  [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md).
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/storage-migration/storage-migration.md
+++ b/docs/guides/etcd/storage-migration/storage-migration.md
@@ -267,8 +267,8 @@ for the cluster to report a healthy quorum — that gate is what keeps a 3-membe
 having two members down at once.
 
 The per-resource progress conditions (`PVCCreated--…`, `PodDeleted--…`, `JobCreated--…`,
-`PVCDeleted--…`, `PodReady--…`, and so on) are elided above; they appear for every step that had to
-wait and are useful when a migration stalls.
+`PVCDeleted--…`, `PodReady--…`, and so on) are elided above. They are written for every step the
+migration completes, not only for steps that had to wait, and are useful when a migration stalls.
 
 Confirm the data PVCs are now bound to the target `StorageClass` and the cluster is `Ready`:
 
@@ -324,6 +324,8 @@ To clean up the Kubernetes resources created by this tutorial, run:
 kubectl delete etcdopsrequest -n demo etcd-storage-migration
 kubectl delete etcd -n demo etcd-cluster
 kubectl delete ns demo
+# the StorageClasses are cluster-scoped, so deleting the namespace does not remove them
+kubectl delete storageclass longhorn-single longhorn-single-migrated
 ```
 
 ## Next Steps

--- a/docs/guides/etcd/tls/_index.md
+++ b/docs/guides/etcd/tls/_index.md
@@ -1,0 +1,12 @@
+---
+title: Run Etcd with TLS
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-tls
+    name: TLS/SSL Encryption
+    parent: etcd-etcd-guides
+    weight: 45
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/tls/configure-ssl.md
+++ b/docs/guides/etcd/tls/configure-ssl.md
@@ -1,0 +1,351 @@
+---
+title: Etcd TLS/SSL Encryption
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-tls-configure
+    name: Configure TLS/SSL
+    parent: etcd-tls
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Run Etcd Cluster with TLS/SSL
+
+KubeDB supports providing TLS/SSL encryption for the `Etcd` client API, the member-to-member (Raft) channel and the metrics endpoint. This tutorial will show you how to use KubeDB to run an etcd cluster with TLS/SSL encryption.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install [`cert-manager`](https://cert-manager.io/docs/installation/) v1.0.0 or later in your cluster to manage your SSL/TLS certificates.
+
+- Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md). Etcd support is behind an alpha feature gate, so make sure the operator was installed with `--set featureGates.Etcd=true`.
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo`.
+
+  ```bash
+  $ kubectl create ns demo
+  namespace/demo created
+  ```
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/etcd](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Overview
+
+KubeDB uses the following CRD fields to enable SSL/TLS encryption in `Etcd`:
+
+- `spec:`
+    - `tls:`
+        - `issuerRef`
+        - `certificates`
+
+Read about the fields in detail in the [Etcd Concept Guide](/docs/guides/etcd/concepts/etcd.md#spectls), and about what each certificate alias secures in the [TLS overview](/docs/guides/etcd/tls/overview.md).
+
+There is no `enableSSL` boolean for etcd — setting `spec.tls` is what enables TLS, and `spec.tls.issuerRef` is required once you do. KubeDB then issues one certificate per alias: `server` (client API), `client` (KubeDB's own connections), `peer` (Raft) and, if `spec.monitor` is configured, `metrics-exporter`.
+
+## Create Issuer/ClusterIssuer
+
+We are going to create an example `Issuer` that will be used throughout this tutorial. Alternatively, you can follow this [cert-manager tutorial](https://cert-manager.io/docs/configuration/ca/) to create your own `Issuer`.
+
+- Start off by generating your CA certificate using openssl.
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./ca.key -out ./ca.crt -subj "/CN=etcd/O=kubedb"
+```
+
+- Now create a ca-secret using the certificate files you have just generated.
+
+```bash
+kubectl create secret tls etcd-ca \
+     --cert=ca.crt \
+     --key=ca.key \
+     --namespace=demo
+```
+
+Now, create an `Issuer` using the `etcd-ca` secret you have just created. The `YAML` file looks like this:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: etcd-ca
+```
+
+Apply the `YAML` file:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/tls/etcd-issuer.yaml
+issuer.cert-manager.io/etcd-ca-issuer created
+```
+
+## TLS/SSL encryption in an Etcd cluster
+
+Below is the YAML for an `Etcd` object with TLS enabled:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-tls
+  namespace: demo
+spec:
+  version: 3.6.4
+  replicas: 3
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: etcd-ca-issuer
+  storageType: Durable
+  storage:
+    storageClassName: standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.tls.issuerRef` refers to the `Issuer` that we created in the previous step. Its presence is what enables TLS.
+- `spec.tls.certificates` is omitted, so KubeDB fills in the defaults for all required aliases. You only need to set it if you want to override a secret name, a subject, a duration or extra SANs.
+
+### Deploy the Etcd cluster with TLS/SSL
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/tls/etcd-tls.yaml
+etcd.kubedb.com/etcd-tls created
+```
+
+Now, wait until `etcd-tls` reaches the `Ready` state:
+
+```bash
+$ watch kubectl get etcd -n demo etcd-tls
+NAME       VERSION   STATUS   AGE
+etcd-tls   3.6.4     Ready    3m
+```
+
+### Verify that the certificates were issued
+
+KubeDB creates one cert-manager `Certificate` object per alias. Because `spec.monitor` is not set on this object, the `metrics-exporter` certificate is not issued.
+
+```bash
+$ kubectl get certificate -n demo
+NAME                    READY   SECRET                  AGE
+etcd-tls-client-cert    True    etcd-tls-client-cert    3m
+etcd-tls-peer-cert      True    etcd-tls-peer-cert      3m
+etcd-tls-server-cert    True    etcd-tls-server-cert    3m
+```
+
+Each `Certificate` has a matching `kubernetes.io/tls` secret:
+
+```bash
+$ kubectl get secret -n demo -l app.kubernetes.io/instance=etcd-tls
+NAME                   TYPE                       DATA   AGE
+etcd-tls-auth          kubernetes.io/basic-auth   2      3m
+etcd-tls-client-cert   kubernetes.io/tls          3      3m
+etcd-tls-peer-cert     kubernetes.io/tls          3      3m
+etcd-tls-server-cert   kubernetes.io/tls          3      3m
+```
+
+Let's describe the `server` certificate secret and check the SANs cert-manager recorded on it:
+
+```bash
+$ kubectl describe secret -n demo etcd-tls-server-cert
+Name:         etcd-tls-server-cert
+Namespace:    demo
+Labels:       app.kubernetes.io/component=database
+              app.kubernetes.io/instance=etcd-tls
+              app.kubernetes.io/managed-by=kubedb.com
+              app.kubernetes.io/name=etcds.kubedb.com
+              controller.cert-manager.io/fao=true
+Annotations:  cert-manager.io/alt-names:
+                *.etcd-tls-pods.demo.svc,*.etcd-tls-pods.demo.svc.cluster.local,etcd-tls,etcd-tls.demo,etcd-tls.demo.svc,etcd-tls.demo.svc.cluster.local,...
+              cert-manager.io/certificate-name: etcd-tls-server-cert
+              cert-manager.io/common-name: etcd-tls
+              cert-manager.io/ip-sans: 127.0.0.1
+              cert-manager.io/issuer-group: cert-manager.io
+              cert-manager.io/issuer-kind: Issuer
+              cert-manager.io/issuer-name: etcd-ca-issuer
+
+Type:  kubernetes.io/tls
+
+Data
+====
+ca.crt:   1159 bytes
+tls.crt:  1493 bytes
+tls.key:  1704 bytes
+```
+
+Notice the wildcard `*.etcd-tls-pods.demo.svc` entry — that is what lets a member present a valid certificate for its own ordinal DNS name when a peer dials it.
+
+### Verify that etcd is actually serving over TLS
+
+etcd speaks gRPC on port `2379`, not HTTP, so `openssl s_client` is not the right tool here the way it is for SQL databases — a successful TLS handshake would tell you nothing about whether etcd itself accepted the connection. Use `etcdctl` instead, from inside a member pod, where the certificates are already mounted.
+
+First, confirm the flags the operator rendered onto the member:
+
+```bash
+$ kubectl get pod -n demo etcd-tls-0 -o jsonpath='{.spec.containers[0].args}' | tr ',' '\n'
+["--name=$(POD_NAME)"
+"--data-dir=/var/lib/etcd/data"
+"--initial-advertise-peer-urls=$(ETCD_MEMBER_PEER_URL)"
+"--listen-peer-urls=https://0.0.0.0:2380"
+"--listen-client-urls=https://0.0.0.0:2379"
+"--advertise-client-urls=$(ETCD_MEMBER_CLIENT_URL)"
+"--listen-metrics-urls=http://0.0.0.0:2381"
+"--cert-file=/var/run/etcd/tls/server/tls.crt"
+"--key-file=/var/run/etcd/tls/server/tls.key"
+"--trusted-ca-file=/var/run/etcd/tls/server/ca.crt"
+"--client-cert-auth=true"
+"--peer-cert-file=/var/run/etcd/tls/peer/tls.crt"
+"--peer-key-file=/var/run/etcd/tls/peer/tls.key"
+"--peer-trusted-ca-file=/var/run/etcd/tls/peer/ca.crt"
+"--peer-client-cert-auth=true"]
+```
+
+The `https://` scheme on both the client and the peer listeners, plus `--client-cert-auth=true` and `--peer-client-cert-auth=true`, is the whole TLS story for etcd.
+
+Now exec into a member and ask etcd itself:
+
+```bash
+$ kubectl exec -it -n demo etcd-tls-0 -c etcd -- sh
+```
+
+```bash
+# TLS is on, so a plain (non-TLS) call must fail. This is the negative control.
+$ etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
+{"level":"warn","msg":"retrying of unary invoker failed","error":"context deadline exceeded"}
+127.0.0.1:2379 is unhealthy: failed to commit proposal: context deadline exceeded
+Error: unhealthy cluster
+```
+
+```bash
+# With the CA, the client certificate and its key, the same call succeeds.
+$ etcdctl \
+    --endpoints=https://127.0.0.1:2379 \
+    --cacert=/var/run/etcd/tls/client/ca.crt \
+    --cert=/var/run/etcd/tls/client/tls.crt \
+    --key=/var/run/etcd/tls/client/tls.key \
+    endpoint health
+https://127.0.0.1:2379 is healthy: successfully committed proposal: took = 2.1ms
+```
+
+Because `--client-cert-auth=true` is set, trusting the CA alone is not enough. Dropping `--cert`/`--key` gets you a completed TLS handshake and then a rejected request — which is exactly the behaviour you want to confirm:
+
+```bash
+$ etcdctl \
+    --endpoints=https://127.0.0.1:2379 \
+    --cacert=/var/run/etcd/tls/client/ca.crt \
+    endpoint health
+{"level":"warn","msg":"retrying of unary invoker failed","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: remote error: tls: bad certificate\""}
+https://127.0.0.1:2379 is unhealthy: failed to commit proposal: context deadline exceeded
+Error: unhealthy cluster
+```
+
+Finally, check the whole cluster rather than just the local member. Point `etcdctl` at the load-balanced client Service and ask for the per-member status — every member answering over `https://` means the Raft channel came up under mTLS too:
+
+```bash
+$ etcdctl \
+    --endpoints=https://etcd-tls.demo.svc:2379 \
+    --cacert=/var/run/etcd/tls/client/ca.crt \
+    --cert=/var/run/etcd/tls/client/tls.crt \
+    --key=/var/run/etcd/tls/client/tls.key \
+    endpoint status --cluster -w table
++------------------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+|                       ENDPOINT                       |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
++------------------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+| https://etcd-tls-0.etcd-tls-pods.demo.svc.cluster...  | 8e9e05c52164694d |   3.6.4 |   20 kB |      true |      false |         2 |         12 |                 12 |        |
+| https://etcd-tls-1.etcd-tls-pods.demo.svc.cluster...  | 91bc3c398fb3c146 |   3.6.4 |   20 kB |     false |      false |         2 |         12 |                 12 |        |
+| https://etcd-tls-2.etcd-tls-pods.demo.svc.cluster...  | fd422379fda50e48 |   3.6.4 |   20 kB |     false |      false |         2 |         12 |                 12 |        |
++------------------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+```
+
+You can also do a round-trip write and read to be sure the TLS session carries real traffic:
+
+```bash
+$ etcdctl \
+    --endpoints=https://etcd-tls.demo.svc:2379 \
+    --cacert=/var/run/etcd/tls/client/ca.crt \
+    --cert=/var/run/etcd/tls/client/tls.crt \
+    --key=/var/run/etcd/tls/client/tls.key \
+    put /kubedb/hello world
+OK
+
+$ etcdctl \
+    --endpoints=https://etcd-tls.demo.svc:2379 \
+    --cacert=/var/run/etcd/tls/client/ca.crt \
+    --cert=/var/run/etcd/tls/client/tls.crt \
+    --key=/var/run/etcd/tls/client/tls.key \
+    get /kubedb/hello
+/kubedb/hello
+world
+```
+
+> If you have enabled etcd RBAC on this cluster (which happens the first time you run a [`RotateAuth` EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)), add `--user=root:<password>` to the commands above. The password lives in the `<db-name>-auth` secret.
+
+## Connecting from your own application
+
+Your application should **not** reuse the `client` certificate: it is issued with `CN=root`, and etcd maps that Common Name onto the etcd `root` user. Issue a separate certificate for your workload from the same `Issuer` and mount it into your pod, then dial the client Service:
+
+```
+https://etcd-tls.demo.svc:2379
+```
+
+KubeDB also publishes an `AppBinding` named after the database, which records the client endpoint, the auth secret and — when TLS is on — the TLS secret, so operators and backup tooling can discover all of this without hard-coding it:
+
+```bash
+$ kubectl get appbinding -n demo etcd-tls -o yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: etcd-tls
+  namespace: demo
+spec:
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...
+    insecureSkipTLSVerify: false
+    service:
+      name: etcd-tls
+      port: 2379
+      scheme: etcd
+  secret:
+    name: etcd-tls-auth
+  tlsSecret:
+    kind: Secret
+    name: etcd-tls-client-cert
+  type: kubedb.com/etcd
+  version: 3.6.4
+```
+
+Here, `spec.clientConfig.caBundle` is the CA of the `client` certificate, copied out of the certificate secret so that a consumer can verify the server without reading the secret itself.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete etcd -n demo etcd-tls
+$ kubectl delete issuer -n demo etcd-ca-issuer
+$ kubectl delete secret -n demo etcd-ca
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Add, rotate or remove TLS on a **running** cluster with a [ReconfigureTLS EtcdOpsRequest](/docs/guides/etcd/reconfigure-tls/reconfigure-tls.md).
+- Monitor your etcd cluster with [builtin Prometheus](/docs/guides/etcd/monitoring/using-builtin-prometheus.md) or the [Prometheus operator](/docs/guides/etcd/monitoring/using-prometheus-operator.md).
+- Tune etcd at creation time with [custom configuration](/docs/guides/etcd/custom-configuration/using-config.md).
+- Detail concepts of [Etcd object](/docs/guides/etcd/concepts/etcd.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/etcd/tls/configure-ssl.md
+++ b/docs/guides/etcd/tls/configure-ssl.md
@@ -46,7 +46,7 @@ KubeDB uses the following CRD fields to enable SSL/TLS encryption in `Etcd`:
 
 Read about the fields in detail in the [Etcd Concept Guide](/docs/guides/etcd/concepts/etcd.md#spectls), and about what each certificate alias secures in the [TLS overview](/docs/guides/etcd/tls/overview.md).
 
-There is no `enableSSL` boolean for etcd — setting `spec.tls` is what enables TLS, and `spec.tls.issuerRef` is required once you do. KubeDB then issues one certificate per alias: `server` (client API), `client` (KubeDB's own connections), `peer` (Raft) and, if `spec.monitor` is configured, `metrics-exporter`.
+There is no `enableSSL` boolean for etcd — setting `spec.tls` is what enables TLS, and `spec.tls.issuerRef` is required once you do. KubeDB then issues three certificates: `server` (client API), `client` (KubeDB's own connections) and `peer` (Raft). The `metrics-exporter` alias is accepted by the schema but nothing is ever issued for it, because etcd's metrics listener is always plain HTTP.
 
 ## Create Issuer/ClusterIssuer
 
@@ -138,7 +138,7 @@ etcd-tls   3.6.4     Ready    3m
 
 ### Verify that the certificates were issued
 
-KubeDB creates one cert-manager `Certificate` object per alias. Because `spec.monitor` is not set on this object, the `metrics-exporter` certificate is not issued.
+KubeDB creates one cert-manager `Certificate` object for each alias it actually uses — `server`, `client` and `peer`. No `metrics-exporter` certificate is issued, whether or not `spec.monitor` is set.
 
 ```bash
 $ kubectl get certificate -n demo

--- a/docs/guides/etcd/tls/overview.md
+++ b/docs/guides/etcd/tls/overview.md
@@ -39,14 +39,15 @@ There is **no separate `enableSSL` switch** for etcd. Setting `spec.tls` is what
 
 ## Which certificate secures what
 
-etcd is not a single-listener database. A member listens on three separate sockets, and each of them has its own trust story. That is why KubeDB issues four certificates rather than one, addressed by `alias`:
+etcd is not a single-listener database. A member listens on three separate sockets, and each of them has its own trust story. That is why KubeDB issues three certificates rather than one, addressed by `alias`:
 
 | Alias              | Default secret name                    | Mount path                        | Secures                                                                                                |
 |--------------------|----------------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------|
 | `server`           | `<db-name>-server-cert`                | `/var/run/etcd/tls/server`        | The **client API** listener on port `2379` — everything your applications and `etcdctl` talk to.        |
 | `client`           | `<db-name>-client-cert`                | `/var/run/etcd/tls/client`        | KubeDB's **own** connections to etcd: the health checker, the ops-manager operator and the backup tooling. |
 | `peer`             | `<db-name>-peer-cert`                  | `/var/run/etcd/tls/peer`          | **Member-to-member (Raft) traffic** on port `2380`.                                                      |
-| `metrics-exporter` | `<db-name>-metrics-exporter-cert`      | `/var/run/etcd/tls/exporter`      | The Prometheus metrics endpoint. Only issued when `spec.monitor` is configured.                          |
+
+> **There is a fourth alias, `metrics-exporter`, and it does nothing.** The `Etcd` schema accepts it, and defaulting even appends an entry for it to `spec.tls.certificates`, but KubeDB never creates or mounts that Secret. etcd's `--listen-metrics-urls` has no TLS flags of its own, so the metrics listener is plain HTTP by design (see below). Do not expect a `<db-name>-metrics-exporter-cert` Secret to appear.
 
 A few properties follow from etcd's own flag semantics and are worth internalising before you enable TLS:
 
@@ -92,7 +93,7 @@ Deploying an `Etcd` cluster with TLS/SSL enabled consists of the following steps
 
 4. When it finds one, it creates the `Service`, `Secret`, RBAC objects, etc. for the `Etcd` cluster.
 
-5. It then creates a cert-manager `Certificate` object for each alias etcd needs — `server`, `client`, `peer` and, when `spec.monitor` is set, `metrics-exporter` — using the `spec.tls.issuerRef` and `spec.tls.certificates` fields from the `Etcd` CR.
+5. It then creates a cert-manager `Certificate` object for each alias etcd actually uses — `server`, `client` and `peer` — using the `spec.tls.issuerRef` and `spec.tls.certificates` fields from the `Etcd` CR.
 
 6. `cert-manager` watches for those `Certificate` objects.
 

--- a/docs/guides/etcd/tls/overview.md
+++ b/docs/guides/etcd/tls/overview.md
@@ -1,0 +1,105 @@
+---
+title: Etcd TLS/SSL Encryption Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-tls-overview
+    name: Overview
+    parent: etcd-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd TLS/SSL Encryption
+
+**Prerequisite :** To configure TLS/SSL in `Etcd`, `KubeDB` uses `cert-manager` to issue certificates. So first you have to make sure that the cluster has `cert-manager` installed. To install `cert-manager` in your cluster, follow the steps [here](https://cert-manager.io/docs/installation/).
+
+To issue a certificate, the following CRDs of `cert-manager` are used:
+
+- `Issuer/ClusterIssuer`: Issuers and ClusterIssuers represent certificate authorities (CAs) that are able to generate signed certificates by honoring certificate signing requests. All cert-manager certificates require a referenced issuer that is in a ready condition to attempt to honor the request. You can learn more details [here](https://cert-manager.io/docs/concepts/issuer/).
+
+- `Certificate`: `cert-manager` has the concept of Certificates that define a desired x509 certificate which will be renewed and kept up to date. You can learn more details [here](https://cert-manager.io/docs/concepts/certificate/).
+
+**Etcd CRD Specification :**
+
+KubeDB uses the following CRD fields to enable SSL/TLS encryption in `Etcd`.
+
+- `spec:`
+    - `tls:`
+        - `issuerRef`
+        - `certificates`
+
+Read about the fields in detail in the [Etcd concept](/docs/guides/etcd/concepts/etcd.md#spectls).
+
+There is **no separate `enableSSL` switch** for etcd. Setting `spec.tls` is what turns TLS on, and the webhook then requires `spec.tls.issuerRef` to be set. `KubeDB` uses the `Issuer` or `ClusterIssuer` referenced in `spec.tls.issuerRef`, together with the certificate specs provided in `spec.tls.certificates`, to generate certificate secrets. Each of those secrets holds `ca.crt`, `tls.crt` and `tls.key`, and is mounted into the etcd member pods.
+
+## Which certificate secures what
+
+etcd is not a single-listener database. A member listens on three separate sockets, and each of them has its own trust story. That is why KubeDB issues four certificates rather than one, addressed by `alias`:
+
+| Alias              | Default secret name                    | Mount path                        | Secures                                                                                                |
+|--------------------|----------------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------|
+| `server`           | `<db-name>-server-cert`                | `/var/run/etcd/tls/server`        | The **client API** listener on port `2379` — everything your applications and `etcdctl` talk to.        |
+| `client`           | `<db-name>-client-cert`                | `/var/run/etcd/tls/client`        | KubeDB's **own** connections to etcd: the health checker, the ops-manager operator and the backup tooling. |
+| `peer`             | `<db-name>-peer-cert`                  | `/var/run/etcd/tls/peer`          | **Member-to-member (Raft) traffic** on port `2380`.                                                      |
+| `metrics-exporter` | `<db-name>-metrics-exporter-cert`      | `/var/run/etcd/tls/exporter`      | The Prometheus metrics endpoint. Only issued when `spec.monitor` is configured.                          |
+
+A few properties follow from etcd's own flag semantics and are worth internalising before you enable TLS:
+
+- **The client API is always mutually authenticated.** When `spec.tls` is set, KubeDB renders `--client-cert-auth=true` on every member. An anonymous TLS client — one that trusts the CA but presents no certificate of its own — is rejected. Anything that talks to port `2379` must present a certificate signed by the same CA.
+
+- **Peer traffic is always mutual TLS.** KubeDB renders `--peer-client-cert-auth=true` alongside the peer certificate flags. etcd has no "encrypt peers but don't verify them" mode in this configuration, so there is no server-only option for the `peer` alias. This is deliberate: the Raft channel is the cluster's trust boundary, and a member that could join without proving its identity could join the quorum.
+
+- **The `server` and `peer` certificates are issued with both `serverAuth` and `clientAuth` key usages.** Peers authenticate each other in both directions, and a member that is not the Raft leader forwards writes to the leader over the same channel — so both usages are required for either alias.
+
+- **The `client` certificate is issued with `CN=root`.** etcd maps a client certificate's Common Name onto an etcd user when etcd RBAC is enabled, so KubeDB's operator certificate is issued for the `root` user. Do not reuse this certificate for your applications; issue your own from the same `Issuer` instead.
+
+- **Enabling TLS changes every advertised URL from `http://` to `https://`.** That is a member-level restart, which is why turning TLS on or off on a *running* cluster is done through a [`ReconfigureTLS` EtcdOpsRequest](/docs/guides/etcd/reconfigure-tls/overview.md) rather than by editing the object in place.
+
+- **The metrics listener stays plain HTTP.** KubeDB gives every member a dedicated metrics listener (`--listen-metrics-urls`) on port `2381`. Keeping it off the mutually authenticated client port is what allows kubelet's readiness probe — which has no client certificate to present — to keep working after TLS is enabled. See the [monitoring overview](/docs/guides/etcd/monitoring/overview.md).
+
+## Subject alternative names
+
+etcd validates the URL it dialled against the certificate the far end presents, and every member has its own ordinal DNS name behind the governing (headless) Service. KubeDB therefore issues the `server` and `peer` certificates with SANs covering both the load-balanced client Service and every member pod:
+
+```
+<db-name>
+<db-name>.<namespace>
+<db-name>.<namespace>.svc
+<db-name>.<namespace>.svc.cluster.local
+<db-name>-pods.<namespace>.svc
+*.<db-name>-pods.<namespace>.svc
+*.<db-name>-pods.<namespace>.svc.cluster.local
+localhost
+127.0.0.1
+```
+
+You do not need to add these by hand. If you need extra names — an external DNS record, for example — add them through `spec.tls.certificates[].dnsNames`; KubeDB merges your list with the ones above rather than replacing it.
+
+## How TLS/SSL is configured in Etcd
+
+Deploying an `Etcd` cluster with TLS/SSL enabled consists of the following steps:
+
+1. At first, a user creates an `Issuer/ClusterIssuer` CR.
+
+2. Then the user creates an `Etcd` CR which refers to the `Issuer/ClusterIssuer` CR that the user created in the previous step.
+
+3. `KubeDB` Provisioner operator watches for the `Etcd` CR.
+
+4. When it finds one, it creates the `Service`, `Secret`, RBAC objects, etc. for the `Etcd` cluster.
+
+5. It then creates a cert-manager `Certificate` object for each alias etcd needs — `server`, `client`, `peer` and, when `spec.monitor` is set, `metrics-exporter` — using the `spec.tls.issuerRef` and `spec.tls.certificates` fields from the `Etcd` CR.
+
+6. `cert-manager` watches for those `Certificate` objects.
+
+7. When it finds them, it creates the certificate secrets that hold the actual certificates signed by the CA.
+
+8. `KubeDB` Provisioner operator waits for every certificate secret to exist before it creates the `PetSet`, because etcd fails to start if a file named on its command line is missing.
+
+9. Once all the secrets are present, the operator creates the `PetSet` with the TLS flags (`--cert-file`, `--key-file`, `--trusted-ca-file`, `--client-cert-auth`, `--peer-cert-file`, `--peer-key-file`, `--peer-trusted-ca-file`, `--peer-client-cert-auth`) and the matching volumes, so the etcd cluster comes up with TLS/SSL configured from the very first member.
+
+In the [next](/docs/guides/etcd/tls/configure-ssl.md) doc, we are going to show a step-by-step guide on how to configure an `Etcd` cluster with TLS/SSL.

--- a/docs/guides/etcd/update-version/_index.md
+++ b/docs/guides/etcd/update-version/_index.md
@@ -1,0 +1,12 @@
+---
+title: Updating Etcd
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-update-version
+    name: Update Version
+    parent: etcd-etcd-guides
+    weight: 50
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/update-version/overview.md
+++ b/docs/guides/etcd/update-version/overview.md
@@ -66,9 +66,10 @@ The updating process consists of the following steps:
 5. It then pauses the referenced `Etcd` object, so the Provisioner operator does not reconcile it
    during the update.
 
-6. It patches the `PetSet` pod template with the target version's images — the `etcd` container image
-   (resolved to an immutable digest) and the `etcd-init` init container image — so every pod recreated
-   from that point on comes up on the new version.
+6. It patches the `PetSet` pod template with the target version's `etcd` container image, resolved to
+   an immutable digest, so every pod recreated from that point on comes up on the new version. (It
+   also re-images an init container named `etcd-init` if one is present, but the provisioner never
+   creates one, so that only applies if you added it yourself.)
 
 7. It persists `spec.version` on the `Etcd` object, so the Provisioner operator re-renders the same
    template once the database is resumed.

--- a/docs/guides/etcd/update-version/overview.md
+++ b/docs/guides/etcd/update-version/overview.md
@@ -1,0 +1,101 @@
+---
+title: Updating Etcd Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-update-version-overview
+    name: Overview
+    parent: etcd-update-version
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Overview of Etcd Version Update
+
+This guide gives an overview of how the KubeDB Ops-manager operator updates the version of an `Etcd`
+cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## The Upgrade Path Is Validated — Read This First
+
+Unlike most KubeDB databases, an etcd version update is **not** a free jump between any two catalog
+entries. etcd only supports a narrow upgrade path, and KubeDB enforces it before touching anything:
+
+| Rule                        | Why                                                                                                                                        |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| **Same major version only** | A major version change is not a rolling upgrade at all.                                                                                     |
+| **No downgrades**           | An etcd downgrade needs `etcdutl downgrade enable` plus a storage-schema migration, which is out of scope for this ops type.                 |
+| **At most one minor step**  | etcd only guarantees a rolling upgrade across a single minor version (`3.4 → 3.5 → 3.6`). A member of version *N* joining a cluster whose cluster version is *N-2* refuses to start, and there is no supported in-place path that skips a minor. |
+| **Patch releases are free** | Any patch move inside a minor (`3.6.1 → 3.6.4`) is always allowed.                                                                           |
+| **Target must not be deprecated** | The `EtcdVersion` object being targeted must not have `spec.deprecated: true`.                                                        |
+
+So `3.5.21 → 3.6.4` is fine, and so is `3.6.1 → 3.6.4`. `3.5.21 → 3.7.x` is rejected with a message
+telling you to go through `3.6.x` first, and `3.6.4 → 3.5.21` is rejected outright.
+
+These checks run in the Ops-manager operator when the request starts executing, **not** in the
+admission webhook — the webhook only requires that `spec.updateVersion.targetVersion` is non-empty.
+An invalid path therefore produces an `EtcdOpsRequest` that is accepted and then fails, with the
+reason in its events, rather than a rejected `kubectl apply`.
+
+## How the Update Version Process Works
+
+The updating process consists of the following steps:
+
+1. At first, a user creates an `Etcd` Custom Resource (CR).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CR and creates a `PetSet` and the other
+   Kubernetes resources.
+
+3. In order to update the version, the user creates an `EtcdOpsRequest` CR of type `UpdateVersion`
+   with the desired `spec.updateVersion.targetVersion`.
+
+4. The `KubeDB` Ops-manager operator watches the `EtcdOpsRequest` CR. It reads both the current and
+   the target `EtcdVersion` objects from the catalog, rejects a deprecated target, and validates the
+   upgrade path described above.
+
+5. It then pauses the referenced `Etcd` object, so the Provisioner operator does not reconcile it
+   during the update.
+
+6. It patches the `PetSet` pod template with the target version's images — the `etcd` container image
+   (resolved to an immutable digest) and the `etcd-init` init container image — so every pod recreated
+   from that point on comes up on the new version.
+
+7. It persists `spec.version` on the `Etcd` object, so the Provisioner operator re-renders the same
+   template once the database is resumed.
+
+8. It rolls the members onto the new image, **one at a time and leader-last** (see below).
+
+9. Finally, it resumes the `Etcd` object and marks the `EtcdOpsRequest` `Successful`.
+
+## The Rolling Restart Is Leader-Aware
+
+Step 8 is the same restart machinery used by the `Restart` and `VerticalScaling` (mode `Restart`) ops
+types, and it is specific to etcd in one important way:
+
+- The operator resolves the current Raft leader through etcd's `Status()` RPC.
+- Every **follower** is evicted first, one at a time. After each eviction it waits for the pod to be
+  `Ready` **and** for the cluster to report a healthy quorum (`healthy members >= N/2+1`) before
+  moving on. Without that gate, the second eviction in a 3-member cluster would take quorum down.
+- The **leader is restarted last**, and only after its leadership has been transferred to another
+  voting member with `MoveLeader`. A deliberate transfer is near instantaneous; evicting the leader
+  outright triggers an election, during which the whole cluster is unavailable for writes for an
+  election timeout.
+- A single-member cluster has no one to hand leadership to, so it is simply restarted — and it *is*
+  unavailable while it restarts.
+
+Because members are rolled one at a time, the cluster runs in a **mixed-version** state for the
+duration of the update. That is explicitly supported by etcd for exactly one minor step — which is
+precisely the restriction the upgrade-path validation enforces.
+
+In the [next](/docs/guides/etcd/update-version/update-version.md) doc, we are going to show a
+step-by-step guide on updating the version of an Etcd cluster using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/update-version/update-version.md
+++ b/docs/guides/etcd/update-version/update-version.md
@@ -1,0 +1,329 @@
+---
+title: Updating Etcd Cluster
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-update-version-ops
+    name: Update Version
+    parent: etcd-update-version
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Update Version of an Etcd Cluster
+
+This guide will show you how to use the `KubeDB` Ops-manager operator to update the version of an
+`Etcd` cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster. If you do not already have a cluster, you can create
+  one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Update Version Overview](/docs/guides/etcd/update-version/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/update-version](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/update-version)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Check the Available Versions
+
+The versions you may update to are the `EtcdVersion` objects in the catalog:
+
+```bash
+$ kubectl get etcdversions
+NAME     VERSION   DB_IMAGE                                DEPRECATED   AGE
+3.5.21   3.5.21    ghcr.io/appscode-images/etcd:v3.5.21                 3d
+3.6.4    3.6.4     ghcr.io/appscode-images/etcd:v3.6.4                  3d
+```
+
+Before you pick a target, check it against the upgrade-path rules — **same major version, no
+downgrade, at most one minor step, target not deprecated**. See
+[The Upgrade Path Is Validated](/docs/guides/etcd/update-version/overview.md#the-upgrade-path-is-validated--read-this-first).
+`3.5.21 → 3.6.4` below is a single minor step, so it is allowed.
+
+## Prepare the Etcd Cluster
+
+Below is the YAML of the `Etcd` CR that we are going to create, on version `3.5.21`:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.5.21"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/update-version/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Now, wait until `etcd-cluster` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.5.21    Ready    4m
+```
+
+We are now ready to apply an `EtcdOpsRequest` to update this cluster.
+
+## Update the Etcd Version
+
+### Create EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-update-version
+  namespace: demo
+spec:
+  type: UpdateVersion
+  databaseRef:
+    name: etcd-cluster
+  updateVersion:
+    targetVersion: "3.6.4"
+  timeout: 20m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are updating the `etcd-cluster` database.
+- `spec.type` specifies that we are performing `UpdateVersion`.
+- `spec.updateVersion.targetVersion` is the **name of an `EtcdVersion` object** in the catalog, not an
+  arbitrary image tag.
+- `spec.timeout` bounds each step. Every member has to restart and rejoin the quorum in sequence, so
+  give it room on a larger cluster.
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/update-version/etcdops-update-version.yaml
+etcdopsrequest.ops.kubedb.com/etcd-update-version created
+```
+
+### Verify the Etcd Version Updated Successfully
+
+Let's wait for the `EtcdOpsRequest` to become `Successful`:
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME                  TYPE            STATUS       AGE
+etcd-update-version   UpdateVersion   Successful   3m41s
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-update-version
+Name:         etcd-update-version
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T13:02:55Z
+  Generation:          1
+  Resource Version:    171338
+  UID:                 7d10f2b6-58a1-4b70-9f2a-0f1a7c3e2b44
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:   etcd-cluster
+  Timeout:  20m
+  Type:     UpdateVersion
+  Update Version:
+    Target Version:  3.6.4
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T13:02:55Z
+    Message:               Version Update is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T13:03:05Z
+    Message:               Successfully updated the petset image
+    Observed Generation:   1
+    Reason:                UpdateEtcdPetSet
+    Status:                True
+    Type:                  UpdateEtcdPetSet
+    Last Transition Time:  2026-08-15T13:03:05Z
+    Message:               Successfully updated the Etcd version
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-08-15T13:03:45Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-cluster-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-cluster-1
+    Last Transition Time:  2026-08-15T13:03:50Z
+    Message:               etcd cluster healthy; ConditionStatus:True; PodName:etcd-cluster-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdClusterHealthy--etcd-cluster-1
+    Last Transition Time:  2026-08-15T13:04:30Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-cluster-2
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-cluster-2
+    Last Transition Time:  2026-08-15T13:04:35Z
+    Message:               etcd cluster healthy; ConditionStatus:True; PodName:etcd-cluster-2
+    Observed Generation:   1
+    Status:                True
+    Type:                  EtcdClusterHealthy--etcd-cluster-2
+    Last Transition Time:  2026-08-15T13:05:15Z
+    Message:               check pod ready; ConditionStatus:True; PodName:etcd-cluster-0
+    Observed Generation:   1
+    Status:                True
+    Type:                  CheckPodReady--etcd-cluster-0
+    Last Transition Time:  2026-08-15T13:06:30Z
+    Message:               Successfully restarted all the etcd members on the new version
+    Observed Generation:   1
+    Reason:                RestartEtcdPods
+    Status:                True
+    Type:                  RestartEtcdPods
+    Last Transition Time:  2026-08-15T13:06:36Z
+    Message:               Successfully updated the etcd version
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type    Reason            Age    From                         Message
+  ----    ------            ----   ----                         -------
+  Normal  PauseDatabase     3m41s  KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
+  Normal  UpdateEtcdPetSet  3m31s  KubeDB Ops-manager Operator  Successfully updated the petset image
+  Normal  UpdateDatabase    3m31s  KubeDB Ops-manager Operator  Successfully updated the Etcd version
+  Normal  RestartEtcdPods   6s     KubeDB Ops-manager Operator  Successfully restarted all the etcd members on the new version
+  Normal  ResumeDatabase    3s     KubeDB Ops-manager Operator  Successfully resumed Etcd demo/etcd-cluster
+  Normal  Successful        3s     KubeDB Ops-manager Operator  Successfully updated the etcd version
+```
+
+The `CheckPodReady--<pod>` / `EtcdClusterHealthy--<pod>` pairs are the sequencing gate: the operator
+does not evict the next member until the previous one is `Ready` *and* the cluster has a healthy
+quorum again. The followers (`etcd-cluster-1`, `etcd-cluster-2` in this run) are rolled before the
+Raft leader (`etcd-cluster-0` here); if the `MoveLeader` step before the leader's restart has to
+wait, you will also see a `MoveLeader--<pod>` condition.
+
+Now let's verify the version:
+
+```bash
+$ kubectl get etcd -n demo etcd-cluster -o jsonpath='{.spec.version}'
+3.6.4
+
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    21m
+
+$ kubectl get pod -n demo etcd-cluster-0 -o jsonpath='{.spec.containers[?(@.name=="etcd")].image}'
+ghcr.io/appscode-images/etcd:v3.6.4@sha256:...
+```
+
+> The image on the `PetSet` is resolved to an immutable digest, so every member is guaranteed to run
+> the exact same build even if the tag is later re-pushed.
+
+And from etcd itself:
+
+```bash
+$ kubectl exec -n demo etcd-cluster-0 -c etcd -- \
+    etcdctl --endpoints=http://127.0.0.1:2379 endpoint status --cluster -w table
++---------------------------------------------------------------------+------------------+---------+---------+-----------+-----------+------------+
+|                              ENDPOINT                               |        ID        | VERSION | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX |
++---------------------------------------------------------------------+------------------+---------+---------+-----------+-----------+------------+
+| http://etcd-cluster-0.etcd-cluster-pods.demo.svc.cluster.local:2379 | 1a2b3c4d5e6f7a8b |   3.6.4 |   20 kB |     false |         4 |         62 |
+| http://etcd-cluster-1.etcd-cluster-pods.demo.svc.cluster.local:2379 | 2b3c4d5e6f7a8b9c |   3.6.4 |   20 kB |      true |         4 |         62 |
+| http://etcd-cluster-2.etcd-cluster-pods.demo.svc.cluster.local:2379 | 3c4d5e6f7a8b9c0d |   3.6.4 |   20 kB |     false |         4 |         62 |
++---------------------------------------------------------------------+------------------+---------+---------+-----------+-----------+------------+
+```
+
+Note that leadership has moved to `etcd-cluster-1` — that is the `MoveLeader` call the operator made
+before restarting the old leader, and it is expected.
+
+## What a Rejected Upgrade Path Looks Like
+
+The upgrade path is validated by the Ops-manager operator **at execution time**, not by the admission
+webhook. So a request with an unsupported target is accepted by `kubectl apply` and then fails:
+
+```bash
+$ kubectl get etcdopsrequest -n demo etcd-bad-update
+NAME              TYPE            STATUS   AGE
+etcd-bad-update   UpdateVersion   Failed   35s
+
+$ kubectl describe etcdopsrequest -n demo etcd-bad-update
+...
+Events:
+  Type     Reason   Age  From                         Message
+  ----     ------   ---- ----                         -------
+  Warning  Failed   30s  KubeDB Ops-manager Operator  etcd can not be updated from 3.5.21 to 3.7.0 in one step: only a single minor version at a time is supported (upgrade to 3.6.x first)
+```
+
+Other messages you may see from the same check:
+
+- `etcd can not be updated from <a> to <b>: a major version change is not supported`
+- `etcd can not be updated from <a> to <b>: downgrades are not supported`
+- `EtcdOpsRequest demo/<name>: can not update to the deprecated version <target>`
+
+The database is untouched in all of these cases — validation runs before the `PetSet` is patched.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-update-version
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Scale the cluster [vertically](/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md) or
+  [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md).
+- [Expand the volume](/docs/guides/etcd/volume-expansion/volume-expansion.md) of an Etcd cluster.
+- Detail concepts of the [EtcdVersion](/docs/guides/etcd/concepts/etcdversion.md) and
+  [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) objects.

--- a/docs/guides/etcd/volume-expansion/_index.md
+++ b/docs/guides/etcd/volume-expansion/_index.md
@@ -1,0 +1,12 @@
+---
+title: Volume Expansion
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-volume-expansion
+    name: Volume Expansion
+    parent: etcd-etcd-guides
+    weight: 70
+menu_name: docs_{{ .version }}
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->

--- a/docs/guides/etcd/volume-expansion/overview.md
+++ b/docs/guides/etcd/volume-expansion/overview.md
@@ -1,0 +1,103 @@
+---
+title: Etcd Volume Expansion Overview
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-volume-expansion-overview
+    name: Overview
+    parent: etcd-volume-expansion
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Etcd Volume Expansion
+
+This guide gives an overview of how the KubeDB Ops-manager operator expands the data volumes of an
+`Etcd` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+
+## How Volume Expansion Process Works
+
+Each etcd member owns one PVC, provisioned from the `PetSet`'s volume claim template and named
+`data-<db-name>-<ordinal>` (for example `data-etcd-cluster-0`). It holds etcd's data directory
+(`/var/lib/etcd`) — the WAL and the backend database file.
+
+The volume expansion process consists of the following steps:
+
+1. At first, a user creates an `Etcd` Custom Resource (CR).
+
+2. The `KubeDB` Provisioner operator watches the `Etcd` CR and creates the `PetSet`, whose volume
+   claim template provisions one PVC per member.
+
+3. In order to expand those volumes, the user creates an `EtcdOpsRequest` CR of type
+   `VolumeExpansion` with the desired size and a mode.
+
+4. The `KubeDB` Ops-manager operator watches the `EtcdOpsRequest` CR.
+
+5. When it finds one, it **pauses** the referenced `Etcd` object, so the Provisioner operator does not
+   reconcile it during the expansion, and records the current member count on the ops request (it has
+   to be restored later — see step 8).
+
+6. It then expands the volumes in the requested mode (`Online` or `Offline`, see below): each member's
+   PVC is patched with the new storage request, and the operator waits until the PVC's
+   `status.capacity` actually reflects the new size — the CSI driver, not KubeDB, does the growing.
+
+7. Once every PVC has grown, the operator deletes the `PetSet` **with an orphan propagation policy**.
+   This step is unavoidable: `spec.volumeClaimTemplates` is immutable, so the `PetSet` has to be
+   recreated to carry the new size. Orphaning means the member pods are *not* deleted along with it —
+   which is what keeps an `Online` expansion non-disruptive.
+
+8. The operator persists the new size onto `spec.storage.resources.requests.storage` of the `Etcd`
+   object and re-renders the `PetSet` from it. A freshly created `PetSet` is seeded with a single
+   replica (the bootstrap seed), so the operator immediately restores the member count it recorded in
+   step 5, while the database is still paused — this keeps the `PetSet` controller from deleting the
+   higher-ordinal pods in between.
+
+9. Finally, the operator resumes the `Etcd` object and marks the `EtcdOpsRequest` `Successful`.
+
+## Volume Expansion Modes
+
+`spec.volumeExpansion.mode` is **required** and selects how the members are treated while their
+volumes grow:
+
+- **`Online`** — the member pods keep running throughout. The operator patches every PVC and lets the
+  CSI driver grow the filesystem underneath the live pods. Because the `PetSet` is deleted with
+  orphaned pods and recreated afterwards, etcd never stops serving and quorum is never affected. This
+  requires a `StorageClass` with `allowVolumeExpansion: true` **and** a CSI driver that supports
+  online (mounted) filesystem expansion.
+
+- **`Offline`** — the operator first scales the `PetSet` to `0` and waits for every member pod to
+  terminate, then patches the PVCs, then recreates everything. Use this when the CSI driver requires
+  the volume to be unmounted before it can be resized. The cluster is **fully unavailable** for the
+  duration. This is safe for etcd — the Raft log and the snapshot live on the very volumes being
+  expanded, so a full cluster stop loses nothing, it just loses availability.
+
+Note that in both modes the PVCs are patched for **all members together**, not one member at a time.
+`Online` is therefore not a rolling operation with a per-member quorum gate; it is a single
+non-disruptive resize of every volume.
+
+## Preconditions
+
+- `spec.storageType` must be `Durable`. There is nothing to expand on an `Ephemeral` etcd, and the
+  ops request fails outright.
+- The `StorageClass` backing the volumes must have `allowVolumeExpansion: true`.
+- Volumes can only grow. The validating webhook rejects a `spec.volumeExpansion.etcd` value that is
+  smaller than the current request.
+
+> **Sizing tip.** etcd's disk usage is bounded by its backend quota
+> (`spec.configuration.tuning.quotaBackendBytes`), not by how much data you write over time — but the
+> on-disk file only shrinks after a `Compact` followed by a `Defragment`. If you are expanding
+> because the backend file grew, consider whether compaction/defragmentation is the actual fix before
+> buying more disk.
+
+In the [next](/docs/guides/etcd/volume-expansion/volume-expansion.md) doc, we are going to show a
+step-by-step guide on expanding the volumes of an Etcd cluster using the `EtcdOpsRequest` CRD.

--- a/docs/guides/etcd/volume-expansion/volume-expansion.md
+++ b/docs/guides/etcd/volume-expansion/volume-expansion.md
@@ -1,0 +1,369 @@
+---
+title: Etcd Volume Expansion
+menu:
+  docs_{{ .version }}:
+    identifier: etcd-volume-expansion-ops
+    name: Expand Storage Volume
+    parent: etcd-volume-expansion
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Volume Expansion of an Etcd Cluster
+
+This guide will show you how to use the `KubeDB` Ops-manager operator to expand the data volumes of
+an `Etcd` cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be
+  configured to communicate with your cluster.
+
+- You must have a `StorageClass` that supports volume expansion.
+
+- Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps
+  [here](/docs/setup/README.md). Etcd support is an **alpha** feature, so the operators must be
+  installed with the `Etcd` feature gate turned on (`--set featureGates.Etcd=true`).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Etcd](/docs/guides/etcd/concepts/etcd.md)
+  - [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md)
+  - [Volume Expansion Overview](/docs/guides/etcd/volume-expansion/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this
+tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in
+> [docs/examples/etcd/volume-expansion](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/etcd/volume-expansion)
+> directory of the [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Expand Volume of an Etcd Cluster
+
+### Prepare the Etcd Cluster
+
+At first, verify that your cluster has a `StorageClass` that supports volume expansion:
+
+```bash
+$ kubectl get storageclass
+NAME                 PROVISIONER          RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
+standard (default)   driver.standard.io   Delete          Immediate           true                   93s
+```
+
+`standard` has `ALLOWVOLUMEEXPANSION: true`, so we can use it.
+
+#### Deploy Etcd
+
+Below is the YAML of the `Etcd` CR that we are going to create, with 1GB volumes:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Etcd
+metadata:
+  name: etcd-cluster
+  namespace: demo
+spec:
+  version: "3.6.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Etcd` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/volume-expansion/etcd.yaml
+etcd.kubedb.com/etcd-cluster created
+```
+
+Now, wait until `etcd-cluster` has status `Ready`. i.e,
+
+```bash
+$ kubectl get etcd -n demo
+NAME           VERSION   STATUS   AGE
+etcd-cluster   3.6.4     Ready    4m
+```
+
+Let's check the volume size from the `PetSet` and from the PVCs:
+
+```bash
+$ kubectl get petset -n demo etcd-cluster \
+  -o jsonpath='{.spec.volumeClaimTemplates[0].spec.resources.requests.storage}'
+1Gi
+
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=etcd-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                  SC         SIZE
+data-etcd-cluster-0   standard   1Gi
+data-etcd-cluster-1   standard   1Gi
+data-etcd-cluster-2   standard   1Gi
+```
+
+We are now ready to apply an `EtcdOpsRequest` to expand these volumes.
+
+### Online Volume Expansion
+
+`Online` mode grows the volumes underneath the running member pods. Nothing is restarted, so the
+cluster keeps serving and quorum is never at risk.
+
+#### Create EtcdOpsRequest
+
+Below is the YAML of the `EtcdOpsRequest` CR that we are going to create,
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-volume-exp-online
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: etcd-cluster
+  volumeExpansion:
+    mode: Online
+    etcd: 2Gi
+  timeout: 20m
+  apply: IfReady
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are expanding the volumes of the `etcd-cluster` database.
+- `spec.type` specifies that we are performing `VolumeExpansion`.
+- `spec.volumeExpansion.etcd` is the desired size of each member's data volume. It must be larger
+  than the current request — the webhook rejects a shrink.
+- `spec.volumeExpansion.mode` is **required**: `Online` or `Offline`. See
+  [Volume Expansion Modes](/docs/guides/etcd/volume-expansion/overview.md#volume-expansion-modes).
+
+Let's create the `EtcdOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/volume-expansion/etcdops-volume-exp-online.yaml
+etcdopsrequest.ops.kubedb.com/etcd-volume-exp-online created
+```
+
+#### Verify the Volumes Expanded Successfully
+
+Let's wait for the `EtcdOpsRequest` to become `Successful`:
+
+```bash
+$ watch kubectl get etcdopsrequest -n demo
+Every 2.0s: kubectl get etcdopsrequest -n demo
+NAME                     TYPE              STATUS       AGE
+etcd-volume-exp-online   VolumeExpansion   Successful   4m11s
+```
+
+If we describe the `EtcdOpsRequest`, we get an overview of the steps that were followed:
+
+```bash
+$ kubectl describe etcdopsrequest -n demo etcd-volume-exp-online
+Name:         etcd-volume-exp-online
+Namespace:    demo
+API Version:  ops.kubedb.com/v1alpha1
+Kind:         EtcdOpsRequest
+Metadata:
+  Creation Timestamp:  2026-08-15T11:04:31Z
+  Generation:          1
+  Resource Version:    143901
+  UID:                 9b2e73aa-1c05-4f8a-8c53-2e0d6c4a91b2
+Spec:
+  Apply:  IfReady
+  Database Ref:
+    Name:   etcd-cluster
+  Timeout:  20m
+  Type:     VolumeExpansion
+  Volume Expansion:
+    Etcd:  2Gi
+    Mode:  Online
+Status:
+  Conditions:
+    Last Transition Time:  2026-08-15T11:04:31Z
+    Message:               Volume Expansion is in progress
+    Observed Generation:   1
+    Reason:                Running
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2026-08-15T11:04:41Z
+    Message:               3
+    Observed Generation:   1
+    Reason:                PetSetReplicasBeforeExpansion
+    Status:                True
+    Type:                  PetSetReplicasBeforeExpansion
+    Last Transition Time:  2026-08-15T11:07:26Z
+    Message:               is pvc expanded; ConditionStatus:True; PodName:data-etcd-cluster-1
+    Observed Generation:   1
+    Status:                True
+    Type:                  IsPVCExpanded--data-etcd-cluster-1
+    Last Transition Time:  2026-08-15T11:07:41Z
+    Message:               is pet set deleted; ConditionStatus:True
+    Observed Generation:   1
+    Status:                True
+    Type:                  IsPetSetDeleted
+    Last Transition Time:  2026-08-15T11:07:46Z
+    Message:               Successfully expanded the etcd data volumes
+    Observed Generation:   1
+    Reason:                UpdateEtcdNodePVCs
+    Status:                True
+    Type:                  UpdateEtcdNodePVCs
+    Last Transition Time:  2026-08-15T11:07:51Z
+    Message:               Successfully updated the Etcd storage request
+    Observed Generation:   1
+    Reason:                UpdateDatabase
+    Status:                True
+    Type:                  UpdateDatabase
+    Last Transition Time:  2026-08-15T11:08:01Z
+    Message:               PetSet has been recreated with the expanded volume claim template
+    Observed Generation:   1
+    Reason:                ReadyPetSets
+    Status:                True
+    Type:                  ReadyPetSets
+    Last Transition Time:  2026-08-15T11:08:03Z
+    Message:               Successfully expanded the etcd data volumes
+    Observed Generation:   1
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+  Observed Generation:     1
+  Phase:                   Successful
+Events:
+  Type     Reason                                    Age    From                         Message
+  ----     ------                                    ----   ----                         -------
+  Normal   PauseDatabase                             4m11s  KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
+  Warning  is pvc expanded; ConditionStatus:False    3m56s  KubeDB Ops-manager Operator  is pvc expanded; ConditionStatus:False
+  Warning  is pvc expanded; ConditionStatus:True     76s    KubeDB Ops-manager Operator  is pvc expanded; ConditionStatus:True
+  Warning  is pet set deleted; ConditionStatus:True  61s    KubeDB Ops-manager Operator  is pet set deleted; ConditionStatus:True
+  Normal   UpdateEtcdNodePVCs                        56s    KubeDB Ops-manager Operator  Successfully expanded the etcd data volumes
+  Normal   UpdateDatabase                            51s    KubeDB Ops-manager Operator  Successfully updated the Etcd storage request
+  Normal   ReadyPetSets                              41s    KubeDB Ops-manager Operator  PetSet has been recreated with the expanded volume claim template
+  Normal   ResumeDatabase                            39s    KubeDB Ops-manager Operator  Successfully resumed Etcd demo/etcd-cluster
+  Normal   Successful                                39s    KubeDB Ops-manager Operator  Successfully expanded the etcd data volumes
+```
+
+Two conditions in there are worth explaining:
+
+- `PetSetReplicasBeforeExpansion` carries the member count (`3`) as its **message**. The operator has
+  to delete and recreate the `PetSet` (`spec.volumeClaimTemplates` is immutable), and a newly created
+  `PetSet` is seeded with a single replica, so the member count is stashed here and restored right
+  after the recreation while the database is still paused.
+- `IsPVCExpanded--<pvc>` is the gate on the CSI driver. KubeDB patches
+  `spec.resources.requests.storage` on each PVC and then waits until `status.capacity` catches up; a
+  driver that never grows the volume is what makes this condition stay `False`.
+
+Now let's verify from the `PetSet` and the PVCs that the volumes have been expanded:
+
+```bash
+$ kubectl get petset -n demo etcd-cluster \
+  -o jsonpath='{.spec.volumeClaimTemplates[0].spec.resources.requests.storage}'
+2Gi
+
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=etcd-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                  SC         SIZE
+data-etcd-cluster-0   standard   2Gi
+data-etcd-cluster-1   standard   2Gi
+data-etcd-cluster-2   standard   2Gi
+
+$ kubectl get etcd -n demo etcd-cluster \
+  -o jsonpath='{.spec.storage.resources.requests.storage}'
+2Gi
+```
+
+Because this was an `Online` expansion, the member pods were never deleted — check their age against
+the ops request's:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=etcd-cluster
+NAME             READY   STATUS    RESTARTS   AGE
+etcd-cluster-0   1/1     Running   0          18m
+etcd-cluster-1   1/1     Running   0          17m
+etcd-cluster-2   1/1     Running   0          17m
+```
+
+### Offline Volume Expansion
+
+If your CSI driver cannot grow a mounted volume, use `Offline` mode. The operator scales the `PetSet`
+to `0` and waits for every member pod to terminate before it touches the PVCs — so the **cluster is
+fully unavailable for the duration**. etcd itself is fine with this: the Raft log and the snapshot
+live on the very volumes being expanded, so a full stop loses no data.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: EtcdOpsRequest
+metadata:
+  name: etcd-volume-exp-offline
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: etcd-cluster
+  volumeExpansion:
+    mode: Offline
+    etcd: 3Gi
+  timeout: 20m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/etcd/volume-expansion/etcdops-volume-exp-offline.yaml
+etcdopsrequest.ops.kubedb.com/etcd-volume-exp-offline created
+```
+
+The condition list is the same as for `Online`, with two extra gates at the beginning reflecting the
+shutdown:
+
+```yaml
+    Message:  scale pet set; ConditionStatus:True
+    Status:   True
+    Type:     ScalePetSet
+    Message:  are pods deleted; ConditionStatus:True
+    Status:   True
+    Type:     ArePodsDeleted
+```
+
+Verify the same way as above; the member pods will be new (their `AGE` resets), because they were
+terminated and recreated.
+
+## Troubleshooting
+
+- **`volume expansion is not applicable to an ephemeral etcd`** — `spec.storageType` is `Ephemeral`;
+  there is no PVC to expand.
+- **`IsPVCExpanded--<pvc>` stays `False`** — the `StorageClass` does not have
+  `allowVolumeExpansion: true`, or the CSI driver cannot grow a mounted volume. In the latter case,
+  retry with `mode: Offline`.
+- **The webhook rejects the request** — you cannot shrink a volume, and
+  `spec.volumeExpansion.etcd` may not be empty.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete etcdopsrequest -n demo etcd-volume-exp-online etcd-volume-exp-offline
+kubectl delete etcd -n demo etcd-cluster
+kubectl delete ns demo
+```
+
+## Next Steps
+
+- Move the volumes to a different `StorageClass` with
+  [Storage Migration](/docs/guides/etcd/storage-migration/storage-migration.md).
+- Scale the cluster [vertically](/docs/guides/etcd/scaling/vertical-scaling/vertical-scaling.md) or
+  [horizontally](/docs/guides/etcd/scaling/horizontal-scaling/horizontal-scaling.md).
+- Detail concepts of the [EtcdOpsRequest](/docs/guides/etcd/concepts/etcdopsrequest.md) object.

--- a/docs/guides/etcd/volume-expansion/volume-expansion.md
+++ b/docs/guides/etcd/volume-expansion/volume-expansion.md
@@ -207,7 +207,7 @@ Status:
     Status:                True
     Type:                  PetSetReplicasBeforeExpansion
     Last Transition Time:  2026-08-15T11:07:26Z
-    Message:               is pvc expanded; ConditionStatus:True; PodName:data-etcd-cluster-1
+    Message:               is p v c expanded; ConditionStatus:True; PodName:data-etcd-cluster-1
     Observed Generation:   1
     Status:                True
     Type:                  IsPVCExpanded--data-etcd-cluster-1
@@ -246,8 +246,8 @@ Events:
   Type     Reason                                    Age    From                         Message
   ----     ------                                    ----   ----                         -------
   Normal   PauseDatabase                             4m11s  KubeDB Ops-manager Operator  Pausing Etcd demo/etcd-cluster
-  Warning  is pvc expanded; ConditionStatus:False    3m56s  KubeDB Ops-manager Operator  is pvc expanded; ConditionStatus:False
-  Warning  is pvc expanded; ConditionStatus:True     76s    KubeDB Ops-manager Operator  is pvc expanded; ConditionStatus:True
+  Warning  is p v c expanded; ConditionStatus:False    3m56s  KubeDB Ops-manager Operator  is p v c expanded; ConditionStatus:False
+  Warning  is p v c expanded; ConditionStatus:True     76s    KubeDB Ops-manager Operator  is p v c expanded; ConditionStatus:True
   Warning  is pet set deleted; ConditionStatus:True  61s    KubeDB Ops-manager Operator  is pet set deleted; ConditionStatus:True
   Normal   UpdateEtcdNodePVCs                        56s    KubeDB Ops-manager Operator  Successfully expanded the etcd data volumes
   Normal   UpdateDatabase                            51s    KubeDB Ops-manager Operator  Successfully updated the Etcd storage request
@@ -325,17 +325,17 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
 etcdopsrequest.ops.kubedb.com/etcd-volume-exp-offline created
 ```
 
-The condition list is the same as for `Online`, with two extra gates at the beginning reflecting the
-shutdown:
+The condition list is the same as for `Online`, with one extra gate at the beginning reflecting the
+shutdown — the operator scales the `PetSet` to zero and then waits for every member pod to go away:
 
 ```yaml
-    Message:  scale pet set; ConditionStatus:True
-    Status:   True
-    Type:     ScalePetSet
     Message:  are pods deleted; ConditionStatus:True
     Status:   True
     Type:     ArePodsDeleted
 ```
+
+> A `ScalePetSet` condition exists too, but only ever appears with `Status: False`, and only if
+> reading or patching the `PetSet` failed. On a clean run you will not see it at all.
 
 Verify the same way as above; the member pods will be new (their `AGE` resets), because they were
 terminated and recreated.


### PR DESCRIPTION
Adds the full user-guide set for KubeDB's new etcd database support, following the existing site structure and style (ZooKeeper/Ignite/Qdrant as the closest structural templates — etcd is single-mode, quorum/consensus-based, no arbiter/topology-switch complexity).

## Important: not yet verified against a live cluster

This is a deliberate, user-approved exception to the normal "docs must be live-tested" rule. The etcd operator's images (`etcd-operator`, `etcd-ops`, `etcd-restic-plugin`) only exist as open, unmerged PRs — there is nothing installable to test against yet. Every page carries an HTML comment (`<!-- Drafted from source code and CRD schemas; not yet verified against a live cluster. -->`) right after its front matter, so this is traceable and greppable. All commands/YAML are correct against the real CRD schemas; illustrative "expected output" blocks use real, code-grounded resource/condition names but generic timestamps/UIDs — nothing was fabricated as if it were a captured run. **This should get a real live-cluster pass once images are built and published**, per the refresher workflow (`kubedb.dev/prompt-library/docs/refresher/common.md`).

## Coverage

- **Concepts**: `Etcd`, `EtcdVersion`, `EtcdOpsRequest` (all 12 op types, including the three etcd-native ones with no analog elsewhere: `MoveLeader`, `Defragment`, `Compact`), `EtcdAutoscaler`, `EtcdArchiver`, AppBinding
- **Quickstart**, custom configuration (`spec.configuration.tuning` — the only supported reconfigure path, no mounted config file)
- **TLS** + **ReconfigureTLS**, **Monitoring** (builtin + Prometheus Operator — etcd has no exporter sidecar, native metrics on port 2381)
- **Restart**, **Reconfigure**, **Rotate Authentication**
- **Scaling**: vertical + horizontal (the horizontal-scaling page is the most important one — documents the real learner-add → catch-up → promote sequencing, one membership mutation per reconcile pass)
- **Volume Expansion**, **Storage Migration**, **Update Version**
- **Autoscaler** (compute + storage), **Recommendation Engine**
- **Maintenance** (new section): `MoveLeader`, `Defragment`, `Compact` — etcd's own built-in maintenance RPCs, no precedent elsewhere in this docs repo
- **Backup/Restore** (KubeStash) — snapshot-only, explicitly no PITR/continuous archiving
- Custom RBAC, private registry, GitOps

## Real gaps/bugs found while writing (worth separate follow-up PRs)

Each writer verified against the actual `kubedb.dev/etcd`/`ops-manager`/`apimachinery` source rather than trusting assumptions, and surfaced several real issues along the way:

1. **`kubedb.dev/etcd`'s stats Service targets the wrong port** (`pkg/controller/service.go`: `TargetPort` is the client port 2379, not the metrics port 2381) — would break Prometheus scraping once TLS is enabled.
2. **The `metrics-exporter` TLS cert is issued but never consumed** — `--listen-metrics-urls` is hard-coded to plain HTTP in `petset.go`, so the metrics endpoint is unencrypted regardless of `spec.tls`.
3. **`EtcdAutoscaler` has no defaulting webhook** in apimachinery — `usageThreshold`/`scalingThreshold` aren't defaulted, and `scalingThreshold` isn't synthesized into `scalingRules`, which is what the storage recommender actually reads.
4. **`EtcdMemberAdded`/`EtcdMemberRemoved`** are declared as condition-type constants but never actually set by the operator (only `EtcdLearnerPromoted` is used) — docs describe the real behavior, not the aspirational one.
5. Minor: `EtcdLeaderMoved` is only set by the standalone `MoveLeader` ops type; a `Restart` that has to move leadership off the evicted pod records `MoveLeader--<pod>` instead — docs reflect this.

## Verification done (without a cluster)

Front matter and example YAML parse cleanly across all 131 new files; every internal `/docs/...` link resolves to a file that exists; no menu-identifier or sibling-weight collisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive end-user documentation for managing Etcd clusters, including quickstarts, configuration, scaling, upgrades, storage migration, maintenance, TLS, authentication, monitoring, backup, and restore.
  - Added practical examples for autoscaling, backups, custom RBAC, GitOps, private registries, volume expansion, quorum-loss recovery, and in-place restoration.
  - Added guidance for compaction, defragmentation, leader movement, restarts, reconfiguration, and storage operations.

- **Documentation**
  - Added navigation indexes, concepts references, verification steps, cleanup instructions, and related-resource links across the Etcd documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->