### PR TITLE
Prepare for release v2026.8.14-rc.0

### DIFF
--- a/docs/CHANGELOG-v2026.8.14-rc.0.md
+++ b/docs/CHANGELOG-v2026.8.14-rc.0.md
@@ -1,0 +1,770 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2026.8.14-rc.0
+    name: Changelog-v2026.8.14-rc.0
+    parent: welcome
+    weight: 20260814
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.8.14-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.8.14-rc.0/
+---
+
+# KubeDB v2026.8.14-rc.0 (2026-08-15)
+
+
+## [kubedb/aerospike](https://github.com/kubedb/aerospike)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/aerospike/releases/tag/v0.3.0-rc.0)
+
+- [bd299458](https://github.com/kubedb/aerospike/commit/bd299458) Prepare for release v0.3.0-rc.0 (#13)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.67.0-rc.0](https://github.com/kubedb/apimachinery/releases/tag/v0.67.0-rc.0)
+
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.52.0-rc.0](https://github.com/kubedb/autoscaler/releases/tag/v0.52.0-rc.0)
+
+- [0848d0fa](https://github.com/kubedb/autoscaler/commit/0848d0fa) Prepare for release v0.52.0-rc.0 (#315)
+- [8982a5eb](https://github.com/kubedb/autoscaler/commit/8982a5eb) Fix Build (#313)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.20.0-rc.0](https://github.com/kubedb/cassandra/releases/tag/v0.20.0-rc.0)
+
+- [7638b232](https://github.com/kubedb/cassandra/commit/7638b232) Prepare for release v0.20.0-rc.0 (#104)
+
+
+
+## [kubedb/cassandra-medusa-plugin](https://github.com/kubedb/cassandra-medusa-plugin)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/cassandra-medusa-plugin/releases/tag/v0.14.0-rc.0)
+
+- [3caac86c](https://github.com/kubedb/cassandra-medusa-plugin/commit/3caac86c) Prepare for release v0.14.0-rc.0 (#45)
+- [56fdcb76](https://github.com/kubedb/cassandra-medusa-plugin/commit/56fdcb76) Prepare for release v0.13.0-rc.0 (#44)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.67.0-rc.0](https://github.com/kubedb/cli/releases/tag/v0.67.0-rc.0)
+
+- [ef5de5ad](https://github.com/kubedb/cli/commit/ef5de5ad6) Prepare for release v0.67.0-rc.0 (#840)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/clickhouse/releases/tag/v0.22.0-rc.0)
+
+- [c75721ce](https://github.com/kubedb/clickhouse/commit/c75721ce) Prepare for release v0.22.0-rc.0 (#134)
+- [40fc5e4e](https://github.com/kubedb/clickhouse/commit/40fc5e4e) Add ClickHouseKeeper Ops Support (#128)
+
+
+
+## [kubedb/clickhouse-backup-plugin](https://github.com/kubedb/clickhouse-backup-plugin)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/clickhouse-backup-plugin/releases/tag/v0.4.0-rc.0)
+
+- [0d81b0b9](https://github.com/kubedb/clickhouse-backup-plugin/commit/0d81b0b9) Prepare for release v0.4.0-rc.0 (#33)
+- [bf9e0a97](https://github.com/kubedb/clickhouse-backup-plugin/commit/bf9e0a97) Prepare for release v0.3.0-rc.0 (#32)
+- [3d30c64a](https://github.com/kubedb/clickhouse-backup-plugin/commit/3d30c64a) Update Cleanup for Snapshot Manifest (#31)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/crd-manager/releases/tag/v0.22.0-rc.0)
+
+- [0c07ded1](https://github.com/kubedb/crd-manager/commit/0c07ded1) Prepare for release v0.22.0-rc.0 (#151)
+- [4934fa38](https://github.com/kubedb/crd-manager/commit/4934fa38) Tolerate missing CRD when deleting unused db CRDs
+- [e1df5a00](https://github.com/kubedb/crd-manager/commit/e1df5a00) Auto-enable dependency feature gates before CRD setup (#150)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.25.0-rc.0)
+
+- [b8448033](https://github.com/kubedb/dashboard-restic-plugin/commit/b8448033) Prepare for release v0.25.0-rc.0 (#85)
+- [c20ab2b9](https://github.com/kubedb/dashboard-restic-plugin/commit/c20ab2b9) Prepare for release v0.24.0-rc.0 (#84)
+- [e0e49517](https://github.com/kubedb/dashboard-restic-plugin/commit/e0e49517) Add Virtual Secret Support (#81)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/db-client-go/releases/tag/v0.22.0-rc.0)
+
+- [784f6a68](https://github.com/kubedb/db-client-go/commit/784f6a68) Prepare for release v0.22.0-rc.0 (#260)
+
+
+
+## [kubedb/db2](https://github.com/kubedb/db2)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/db2/releases/tag/v0.8.0-rc.0)
+
+- [b58a8323](https://github.com/kubedb/db2/commit/b58a8323) Prepare for release v0.8.0-rc.0 (#39)
+
+
+
+## [kubedb/db2-coordinator](https://github.com/kubedb/db2-coordinator)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/db2-coordinator/releases/tag/v0.8.0-rc.0)
+
+- [938389f](https://github.com/kubedb/db2-coordinator/commit/938389f) Prepare for release v0.8.0-rc.0 (#18)
+
+
+
+## [kubedb/documentdb](https://github.com/kubedb/documentdb)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/documentdb/releases/tag/v0.4.0-rc.0)
+
+- [79b3cee7](https://github.com/kubedb/documentdb/commit/79b3cee7) Prepare for release v0.4.0-rc.0 (#47)
+
+
+
+## [kubedb/documentdb-coordinator](https://github.com/kubedb/documentdb-coordinator)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/documentdb-coordinator/releases/tag/v0.3.0-rc.0)
+
+- [93d895f](https://github.com/kubedb/documentdb-coordinator/commit/93d895f) Prepare for release v0.3.0-rc.0 (#12)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/druid/releases/tag/v0.22.0-rc.0)
+
+- [b9ad65ca](https://github.com/kubedb/druid/commit/b9ad65ca) Prepare for release v0.22.0-rc.0 (#153)
+- [14081e59](https://github.com/kubedb/druid/commit/14081e59) Prepare for release v0.21.0-rc.0 (#152)
+- [91905bb4](https://github.com/kubedb/druid/commit/91905bb4) Migrate to shared auth-secret package (#151)
+- [3d9469d6](https://github.com/kubedb/druid/commit/3d9469d6) Adopt shared monitor/appbinding packages from apimachinery (#150)
+- [247bfac0](https://github.com/kubedb/druid/commit/247bfac0) Add virtual secret support (#133)
+- [7abb51db](https://github.com/kubedb/druid/commit/7abb51db) Set default resource limits before patching petset in vertical scaling (#148)
+- [0a1e5aac](https://github.com/kubedb/druid/commit/0a1e5aac) Move deletion logic to apimachinery (#149)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.67.0-rc.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.67.0-rc.0)
+
+- [566ae07c](https://github.com/kubedb/elasticsearch/commit/566ae07c7) Prepare for release v0.67.0-rc.0 (#833)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.30.0-rc.0)
+
+- [a7ea7a14](https://github.com/kubedb/elasticsearch-restic-plugin/commit/a7ea7a14) Prepare for release v0.30.0-rc.0 (#108)
+- [d3eaaafd](https://github.com/kubedb/elasticsearch-restic-plugin/commit/d3eaaafd) Prepare for release v0.29.0-rc.0 (#107)
+- [542bd21b](https://github.com/kubedb/elasticsearch-restic-plugin/commit/542bd21b) Add Virtual Secret Support (#104)
+
+
+
+## [kubedb/gitops](https://github.com/kubedb/gitops)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/gitops/releases/tag/v0.15.0-rc.0)
+
+- [a77ddade](https://github.com/kubedb/gitops/commit/a77ddade) Prepare for release v0.15.0-rc.0 (#90)
+
+
+
+## [kubedb/hanadb](https://github.com/kubedb/hanadb)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/hanadb/releases/tag/v0.8.0-rc.0)
+
+- [b678cf7a](https://github.com/kubedb/hanadb/commit/b678cf7a) Prepare for release v0.8.0-rc.0 (#59)
+
+
+
+## [kubedb/hanadb-coordinator](https://github.com/kubedb/hanadb-coordinator)
+
+### [v0.7.0-rc.0](https://github.com/kubedb/hanadb-coordinator/releases/tag/v0.7.0-rc.0)
+
+- [008bb749](https://github.com/kubedb/hanadb-coordinator/commit/008bb749) Prepare for release v0.7.0-rc.0 (#22)
+
+
+
+## [kubedb/hazelcast](https://github.com/kubedb/hazelcast)
+
+### [v0.13.0-rc.0](https://github.com/kubedb/hazelcast/releases/tag/v0.13.0-rc.0)
+
+- [654af89f](https://github.com/kubedb/hazelcast/commit/654af89f) Prepare for release v0.13.0-rc.0 (#66)
+
+
+
+## [kubedb/ignite](https://github.com/kubedb/ignite)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/ignite/releases/tag/v0.14.0-rc.0)
+
+- [053b6b4c](https://github.com/kubedb/ignite/commit/053b6b4c) Prepare for release v0.14.0-rc.0 (#72)
+- [9c019938](https://github.com/kubedb/ignite/commit/9c019938) Prepare for release v0.13.0-rc.0 (#71)
+- [bf57aef8](https://github.com/kubedb/ignite/commit/bf57aef8) Migrate auth/keystore secret management to shared apimachinery pkg (#70)
+- [5e7d5e13](https://github.com/kubedb/ignite/commit/5e7d5e13) Add virtual secret support (#55)
+- [ea1d0e17](https://github.com/kubedb/ignite/commit/ea1d0e17) Use shared monitor and appbinding packages (#69)
+- [140b6332](https://github.com/kubedb/ignite/commit/140b6332) Set default resource limits before patching petset in vertical scaling
+- [d8aee1f0](https://github.com/kubedb/ignite/commit/d8aee1f0) Honor user-provided renewBefore in TLS certificate ops (#56)
+- [8d071a7a](https://github.com/kubedb/ignite/commit/8d071a7a) Move deletion logic to apimachinery (#68)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2026.8.14-rc.0](https://github.com/kubedb/installer/releases/tag/v2026.8.14-rc.0)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.38.0-rc.0](https://github.com/kubedb/kafka/releases/tag/v0.38.0-rc.0)
+
+- [84c08626](https://github.com/kubedb/kafka/commit/84c08626) Prepare for release v0.38.0-rc.0 (#218)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/kibana/releases/tag/v0.43.0-rc.0)
+
+- [8f0ed22c](https://github.com/kubedb/kibana/commit/8f0ed22c) Prepare for release v0.43.0-rc.0 (#190)
+- [79f4dbb6](https://github.com/kubedb/kibana/commit/79f4dbb6) Lint fix (#189)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.30.0-rc.0)
+
+- [130ac489](https://github.com/kubedb/kubedb-manifest-plugin/commit/130ac489) Prepare for release v0.30.0-rc.0 (#142)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.18.0-rc.0](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.18.0-rc.0)
+
+- [0ee34ed3](https://github.com/kubedb/kubedb-verifier/commit/0ee34ed3) Prepare for release v0.18.0-rc.0 (#59)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.51.0-rc.0](https://github.com/kubedb/mariadb/releases/tag/v0.51.0-rc.0)
+
+- [4b7cbf3d](https://github.com/kubedb/mariadb/commit/4b7cbf3dc) Prepare for release v0.51.0-rc.0 (#427)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.27.0-rc.0)
+
+- [2065feca](https://github.com/kubedb/mariadb-archiver/commit/2065feca) Prepare for release v0.27.0-rc.0 (#101)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.27.0-rc.0)
+
+- [085bf2f2](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/085bf2f2) Prepare for release v0.27.0-rc.0 (#85)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.25.0-rc.0)
+
+- [de4e7af5](https://github.com/kubedb/mariadb-restic-plugin/commit/de4e7af5) Prepare for release v0.25.0-rc.0 (#102)
+- [69621d76](https://github.com/kubedb/mariadb-restic-plugin/commit/69621d76) Prepare for release v0.24.0-rc.0 (#101)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.61.0-rc.0](https://github.com/kubedb/memcached/releases/tag/v0.61.0-rc.0)
+
+- [9b7f7b39](https://github.com/kubedb/memcached/commit/9b7f7b39d) Prepare for release v0.61.0-rc.0 (#554)
+- [9e229413](https://github.com/kubedb/memcached/commit/9e2294132) Prepare for release v0.59.0-rc.0 (#553)
+- [c187ceef](https://github.com/kubedb/memcached/commit/c187ceef4) Add virtual secret support (#540)
+- [cca8107f](https://github.com/kubedb/memcached/commit/cca8107f0) Use shared monitor and appbinding packages (#552)
+- [5737e69b](https://github.com/kubedb/memcached/commit/5737e69b5) Set default resource limits before patching petset in vertical scaling
+- [e64d9c6f](https://github.com/kubedb/memcached/commit/e64d9c6f8) Move deletion logic to apimachinery (#551)
+
+
+
+## [kubedb/migrator](https://github.com/kubedb/migrator)
+
+### [v0.7.0-rc.0](https://github.com/kubedb/migrator/releases/tag/v0.7.0-rc.0)
+
+- [72b69108](https://github.com/kubedb/migrator/commit/72b69108) Prepare for release v0.7.0-rc.0 (#49)
+
+
+
+## [kubedb/milvus](https://github.com/kubedb/milvus)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/milvus/releases/tag/v0.8.0-rc.0)
+
+- [4edc3864](https://github.com/kubedb/milvus/commit/4edc3864) Prepare for release v0.8.0-rc.0 (#63)
+- [1b216221](https://github.com/kubedb/milvus/commit/1b216221) Prepare for release v0.7.0-rc.0 (#62)
+- [4fe1caf8](https://github.com/kubedb/milvus/commit/4fe1caf8) Fix Milvus Minio Secret Bug (#61)
+- [fb200646](https://github.com/kubedb/milvus/commit/fb200646) Migrate to shared apimachinery secret package (#60)
+- [f57a329e](https://github.com/kubedb/milvus/commit/f57a329e) Use shared monitor and appbinding packages (#59)
+- [c0190f3e](https://github.com/kubedb/milvus/commit/c0190f3e) Add virtual secret support (#38)
+- [c7794778](https://github.com/kubedb/milvus/commit/c7794778) Set default resource limits before patching petset in vertical scaling
+- [db076099](https://github.com/kubedb/milvus/commit/db076099) Move deletion logic to apimachinery (#57)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.60.0-rc.0](https://github.com/kubedb/mongodb/releases/tag/v0.60.0-rc.0)
+
+- [1a23d8c2](https://github.com/kubedb/mongodb/commit/1a23d8c2a) Prepare for release v0.60.0-rc.0 (#783)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.30.0-rc.0)
+
+- [0a863335](https://github.com/kubedb/mongodb-restic-plugin/commit/0a863335) Prepare for release v0.30.0-rc.0 (#137)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.22.0-rc.0)
+
+- [11832898](https://github.com/kubedb/mssql-coordinator/commit/11832898) Prepare for release v0.22.0-rc.0 (#81)
+- [ccd2c520](https://github.com/kubedb/mssql-coordinator/commit/ccd2c520) Prepare for release v0.21.0-rc.0 (#80)
+- [872322d9](https://github.com/kubedb/mssql-coordinator/commit/872322d9) Add Virtual Secret (#77)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.21.0-rc.0)
+
+- [d48e439](https://github.com/kubedb/mssqlserver-archiver/commit/d48e439) Prepare for release v0.21.0-rc.0 (#35)
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.21.0-rc.0)
+
+- [795d6e08](https://github.com/kubedb/mssqlserver-walg-plugin/commit/795d6e08) Prepare for release v0.21.0-rc.0 (#68)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.60.0-rc.0](https://github.com/kubedb/mysql/releases/tag/v0.60.0-rc.0)
+
+- [db444927](https://github.com/kubedb/mysql/commit/db4449279) Prepare for release v0.60.0-rc.0 (#778)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.28.0-rc.0)
+
+- [e0da0940](https://github.com/kubedb/mysql-archiver/commit/e0da0940) Prepare for release v0.28.0-rc.0 (#115)
+- [8d7d93e7](https://github.com/kubedb/mysql-archiver/commit/8d7d93e7) Prepare for release v0.27.0-rc.0 (#113)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.45.0-rc.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.45.0-rc.0)
+
+- [cdf83626](https://github.com/kubedb/mysql-coordinator/commit/cdf83626) Prepare for release v0.45.0-rc.0 (#191)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.28.0-rc.0)
+
+- [4f2b4470](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/4f2b4470) Prepare for release v0.28.0-rc.0 (#87)
+- [72e86946](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/72e86946) Prepare for release v0.27.0-rc.0 (#85)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.30.0-rc.0)
+
+- [72b83af2](https://github.com/kubedb/mysql-restic-plugin/commit/72b83af2) Prepare for release v0.30.0-rc.0 (#123)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.45.0-rc.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.45.0-rc.0)
+
+- [f335f57](https://github.com/kubedb/mysql-router-init/commit/f335f57) Prepare for release v0.45.0-rc.0 (#69)
+
+
+
+## [kubedb/neo4j](https://github.com/kubedb/neo4j)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/neo4j/releases/tag/v0.8.0-rc.0)
+
+
+
+
+## [kubedb/neo4j-backup-plugin](https://github.com/kubedb/neo4j-backup-plugin)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/neo4j-backup-plugin/releases/tag/v0.3.0-rc.0)
+
+- [334ac63](https://github.com/kubedb/neo4j-backup-plugin/commit/334ac63) Prepare for release v0.3.0-rc.0 (#13)
+- [c6a9b6a](https://github.com/kubedb/neo4j-backup-plugin/commit/c6a9b6a) Merge pull request #12 from kubedb/fix-restore-script-path
+- [85fee4d](https://github.com/kubedb/neo4j-backup-plugin/commit/85fee4d) Fix restore script path file permission issue.
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.54.0-rc.0](https://github.com/kubedb/ops-manager/releases/tag/v0.54.0-rc.0)
+
+
+
+
+## [kubedb/oracle](https://github.com/kubedb/oracle)
+
+### [v0.13.0-rc.0](https://github.com/kubedb/oracle/releases/tag/v0.13.0-rc.0)
+
+- [aa0ac08b](https://github.com/kubedb/oracle/commit/aa0ac08b) Prepare for release v0.13.0-rc.0 (#82)
+
+
+
+## [kubedb/oracle-coordinator](https://github.com/kubedb/oracle-coordinator)
+
+### [v0.13.0-rc.0](https://github.com/kubedb/oracle-coordinator/releases/tag/v0.13.0-rc.0)
+
+- [6121bc9](https://github.com/kubedb/oracle-coordinator/commit/6121bc9) Prepare for release v0.13.0-rc.0 (#45)
+- [1cdbe95](https://github.com/kubedb/oracle-coordinator/commit/1cdbe95) Prepare for release v0.12.0-rc.0 (#44)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.54.0-rc.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.54.0-rc.0)
+
+- [be7d3974](https://github.com/kubedb/percona-xtradb/commit/be7d39743) Prepare for release v0.54.0-rc.0 (#473)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.40.0-rc.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.40.0-rc.0)
+
+- [1fbe6adf](https://github.com/kubedb/percona-xtradb-coordinator/commit/1fbe6adf) Prepare for release v0.40.0-rc.0 (#135)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.51.0-rc.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.51.0-rc.0)
+
+- [4943ae65](https://github.com/kubedb/pg-coordinator/commit/4943ae65) Prepare for release v0.51.0-rc.0 (#272)
+- [dae2e9a7](https://github.com/kubedb/pg-coordinator/commit/dae2e9a7) Prepare for release v0.50.0-rc.0 (#269)
+- [a83e4182](https://github.com/kubedb/pg-coordinator/commit/a83e4182) Serve remote replica DR metrics on the raft-metrics port (#268)
+- [409a0f41](https://github.com/kubedb/pg-coordinator/commit/409a0f41) Add remote replica mode with pg_rewind and reinitialization support (#257)
+- [9e889075](https://github.com/kubedb/pg-coordinator/commit/9e889075) Use pg_tde_rewind and pg_tde_basebackup when TDE is enabled (#264)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.54.0-rc.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.54.0-rc.0)
+
+- [e08ff26b](https://github.com/kubedb/pgbouncer/commit/e08ff26b0) Prepare for release v0.54.0-rc.0 (#430)
+- [2e658fc4](https://github.com/kubedb/pgbouncer/commit/2e658fc47) Init Script volume override problem fix (#421)
+- [7c17e108](https://github.com/kubedb/pgbouncer/commit/7c17e1088) Migrate auth-secret handling to shared apimachinery secret package (#429)
+- [eead948c](https://github.com/kubedb/pgbouncer/commit/eead948cf) Use shared monitor and appbinding packages (#428)
+- [61fc4725](https://github.com/kubedb/pgbouncer/commit/61fc47254) Virtual Secret Ops Support (#426)
+- [68a2f276](https://github.com/kubedb/pgbouncer/commit/68a2f2767) Honor user-provided renewBefore in TLS certificate ops (#414)
+- [adf24115](https://github.com/kubedb/pgbouncer/commit/adf241151) Move deletion logic to apimachinery (#427)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/pgpool/releases/tag/v0.22.0-rc.0)
+
+- [6bf78777](https://github.com/kubedb/pgpool/commit/6bf78777) Prepare for release v0.22.0-rc.0 (#144)
+- [9f165e26](https://github.com/kubedb/pgpool/commit/9f165e26) Prepare for release v0.21.0-rc.0 (#143)
+- [ea823306](https://github.com/kubedb/pgpool/commit/ea823306) Dont validate pool config until the pg appbinding found (#142)
+- [c5071c52](https://github.com/kubedb/pgpool/commit/c5071c52) Fix max_pool validation to check absolute minimum, not per-replica (#141)
+- [70094e98](https://github.com/kubedb/pgpool/commit/70094e98) Reduce default max_pool from 15 to 4 (#140)
+- [4aff494d](https://github.com/kubedb/pgpool/commit/4aff494d) Requeue if underlying postgres appbinding not found (#139)
+- [955ad569](https://github.com/kubedb/pgpool/commit/955ad569) Use shared pkg/controller/secret for auth secret (#138)
+- [009328ff](https://github.com/kubedb/pgpool/commit/009328ff) Use shared monitor and appbinding packages (#137)
+- [a601d9d6](https://github.com/kubedb/pgpool/commit/a601d9d6) Virtual Secret Ops Support (#136)
+- [0b8ea40b](https://github.com/kubedb/pgpool/commit/0b8ea40b) Honor user-provided renewBefore in TLS certificate ops (#121)
+- [f9c951b8](https://github.com/kubedb/pgpool/commit/f9c951b8) Move deletion logic to apimachinery (#135)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.67.0-rc.0](https://github.com/kubedb/postgres/releases/tag/v0.67.0-rc.0)
+
+- [42d19328](https://github.com/kubedb/postgres/commit/42d193289) Prepare for release v0.67.0-rc.0 (#927)
+- [32b03ab1](https://github.com/kubedb/postgres/commit/32b03ab18) Generate auth-secret passwords with a symbol class (#925)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.28.0-rc.0)
+
+- [760aa637](https://github.com/kubedb/postgres-archiver/commit/760aa637) Prepare for release v0.28.0-rc.0 (#117)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.28.0-rc.0)
+
+- [a1b4e158](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/a1b4e158) Prepare for release v0.28.0-rc.0 (#96)
+- [9c132102](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/9c132102) Prepare for release v0.27.0-rc.0 (#95)
+- [683eca1a](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/683eca1a) Merge pull request #94 from kubedb/v2026.7.10-master
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.30.0-rc.0)
+
+- [b546216f](https://github.com/kubedb/postgres-restic-plugin/commit/b546216f) Prepare for release v0.30.0-rc.0 (#123)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/provider-aws/releases/tag/v0.28.0-rc.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/provider-azure/releases/tag/v0.28.0-rc.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.28.0-rc.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.67.0-rc.0](https://github.com/kubedb/provisioner/releases/tag/v0.67.0-rc.0)
+
+- [6c9aa6c3](https://github.com/kubedb/provisioner/commit/6c9aa6c3a) Prepare for release v0.67.0-rc.0 (#223)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.54.0-rc.0](https://github.com/kubedb/proxysql/releases/tag/v0.54.0-rc.0)
+
+- [1eb7bca9](https://github.com/kubedb/proxysql/commit/1eb7bca96) Prepare for release v0.54.0-rc.0 (#450)
+- [0607fcd5](https://github.com/kubedb/proxysql/commit/0607fcd53) Migrate ProxySQL admin auth secret to shared secret package (#449)
+- [a8def901](https://github.com/kubedb/proxysql/commit/a8def901e) Use shared monitor package (#448)
+- [1ea1ae93](https://github.com/kubedb/proxysql/commit/1ea1ae93d) Add virtual secret support (#435)
+- [06aa72fb](https://github.com/kubedb/proxysql/commit/06aa72fbb) Set default resource limits before patching petset in vertical scaling (#446)
+- [0c98223d](https://github.com/kubedb/proxysql/commit/0c98223da) Move deletion logic to apimachinery (#447)
+
+
+
+## [kubedb/qdrant](https://github.com/kubedb/qdrant)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/qdrant/releases/tag/v0.8.0-rc.0)
+
+- [e1c81c10](https://github.com/kubedb/qdrant/commit/e1c81c10) Prepare for release v0.8.0-rc.0 (#60)
+
+
+
+## [kubedb/qdrant-restic-plugin](https://github.com/kubedb/qdrant-restic-plugin)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/qdrant-restic-plugin/releases/tag/v0.3.0-rc.0)
+
+- [815a4cd](https://github.com/kubedb/qdrant-restic-plugin/commit/815a4cd) Replace hub command with gh command in script
+- [7a4c0de](https://github.com/kubedb/qdrant-restic-plugin/commit/7a4c0de) Prepare for release v0.3.0-rc.0 (#10)
+- [fb288cc](https://github.com/kubedb/qdrant-restic-plugin/commit/fb288cc) Prepare for release v0.2.0-rc.0 (#8)
+- [34a99ba](https://github.com/kubedb/qdrant-restic-plugin/commit/34a99ba) Merge pull request #7 from kubedb/v2026.7.10-master
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/rabbitmq/releases/tag/v0.22.0-rc.0)
+
+- [69b2974c](https://github.com/kubedb/rabbitmq/commit/69b2974c) Prepare for release v0.22.0-rc.0 (#154)
+- [8d7aa943](https://github.com/kubedb/rabbitmq/commit/8d7aa943) Add Management AppBinding (#152)
+- [68f62a51](https://github.com/kubedb/rabbitmq/commit/68f62a51) Prepare for release v0.21.0-rc.0 (#153)
+- [e4fe45ba](https://github.com/kubedb/rabbitmq/commit/e4fe45ba) log fixed (#151)
+- [39ce0108](https://github.com/kubedb/rabbitmq/commit/39ce0108) Use shared pkg/controller/secret for auth secret (#150)
+- [f83d3abd](https://github.com/kubedb/rabbitmq/commit/f83d3abd) Use shared monitor and appbinding packages (#149)
+- [ed7a49d4](https://github.com/kubedb/rabbitmq/commit/ed7a49d4) Add virtual secret support (#134)
+- [7a7d559a](https://github.com/kubedb/rabbitmq/commit/7a7d559a) Set default resource limits before patching petset in vertical scaling
+- [91a1006f](https://github.com/kubedb/rabbitmq/commit/91a1006f) Honor user-provided renewBefore in TLS certificate ops (#135)
+- [a9bc44a5](https://github.com/kubedb/rabbitmq/commit/a9bc44a5) Move deletion logic to apimachinery (#148)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.60.0-rc.0](https://github.com/kubedb/redis/releases/tag/v0.60.0-rc.0)
+
+- [b505761f](https://github.com/kubedb/redis/commit/b505761f9) Prepare for release v0.60.0-rc.0 (#676)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.46.0-rc.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.46.0-rc.0)
+
+- [c175fe00](https://github.com/kubedb/redis-coordinator/commit/c175fe00) Prepare for release v0.46.0-rc.0 (#168)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.30.0-rc.0)
+
+- [1c069125](https://github.com/kubedb/redis-restic-plugin/commit/1c069125) Prepare for release v0.30.0-rc.0 (#115)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.54.0-rc.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.54.0-rc.0)
+
+- [637dd051](https://github.com/kubedb/replication-mode-detector/commit/637dd051) Prepare for release v0.54.0-rc.0 (#330)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/schema-manager/releases/tag/v0.43.0-rc.0)
+
+- [a98434c0](https://github.com/kubedb/schema-manager/commit/a98434c0) Prepare for release v0.43.0-rc.0 (#177)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/singlestore/releases/tag/v0.22.0-rc.0)
+
+- [6f9da672](https://github.com/kubedb/singlestore/commit/6f9da672) Prepare for release v0.22.0-rc.0 (#144)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.22.0-rc.0)
+
+- [e2d7a2e2](https://github.com/kubedb/singlestore-coordinator/commit/e2d7a2e2) Prepare for release v0.22.0-rc.0 (#80)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.25.0-rc.0)
+
+- [914e097c](https://github.com/kubedb/singlestore-restic-plugin/commit/914e097c) Prepare for release v0.25.0-rc.0 (#95)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/solr/releases/tag/v0.22.0-rc.0)
+
+- [df17e445](https://github.com/kubedb/solr/commit/df17e445) Prepare for release v0.22.0-rc.0 (#156)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.52.0-rc.0](https://github.com/kubedb/tests/releases/tag/v0.52.0-rc.0)
+
+- [f457453e](https://github.com/kubedb/tests/commit/f457453e8) Prepare for release v0.52.0-rc.0 (#552)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/ui-server/releases/tag/v0.43.0-rc.0)
+
+- [6f430b06](https://github.com/kubedb/ui-server/commit/6f430b062) Prepare for release v0.43.0-rc.0 (#223)
+
+
+
+## [kubedb/weaviate](https://github.com/kubedb/weaviate)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/weaviate/releases/tag/v0.8.0-rc.0)
+
+- [d3cf3289](https://github.com/kubedb/weaviate/commit/d3cf3289) Prepare for release v0.8.0-rc.0 (#60)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/webhook-server/releases/tag/v0.43.0-rc.0)
+
+
+
+
+## [kubedb/xtrabackup-restic-plugin](https://github.com/kubedb/xtrabackup-restic-plugin)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/xtrabackup-restic-plugin/releases/tag/v0.15.0-rc.0)
+
+- [c8d5e992](https://github.com/kubedb/xtrabackup-restic-plugin/commit/c8d5e992) Prepare for release v0.15.0-rc.0 (#63)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/zookeeper/releases/tag/v0.22.0-rc.0)
+
+- [b6b631e9](https://github.com/kubedb/zookeeper/commit/b6b631e9) Prepare for release v0.22.0-rc.0 (#140)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.22.0-rc.0)
+
+- [a0e15552](https://github.com/kubedb/zookeeper-restic-plugin/commit/a0e15552) Prepare for release v0.22.0-rc.0 (#79)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.8.14-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/142
Signed-off-by: 1gtm <1gtm@appscode.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the KubeDB v2026.8.14-rc.0 changelog.
  * Included release metadata, date, component versions, and links to related release commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->