### PR TITLE
Document Postgres spec.license and the AppsCode distribution

### DIFF
--- a/docs/guides/postgres/concepts/catalog.md
+++ b/docs/guides/postgres/concepts/catalog.md
@@ -65,6 +65,29 @@ We modify original PostgreSQL docker image to support additional features like W
 
 `spec.version` is a required field that specifies the original version of PostgreSQL database that has been used to build the docker image specified in `spec.db.image` field.
 
+### spec.distribution
+
+`spec.distribution` is an optional field that names the PostgreSQL distribution the image in `spec.db.image` was built from. Supported values are `Official`, `TimescaleDB`, `PostGIS`, `KubeDB`, `DocumentDB`, `PostgreSQL`, `Percona`, and `AppsCode`.
+
+The `AppsCode` distribution is "Postgres Enterprise by AppsCode", a custom-branded, license-enforced PostgreSQL build whose postmaster refuses to start without a valid license certificate. A `PostgresVersion` for this distribution should also set `spec.license.required: true` (below); every `Postgres` object using it must then set [`spec.license`](/docs/guides/postgres/concepts/postgres.md#speclicense).
+
+### spec.license.required
+
+`spec.license.required` is an optional field, only meaningful for the `AppsCode` distribution, that is `true` when the image in `spec.db.image` refuses to start without a valid license file. When it is `true`, every `Postgres` object referencing this `PostgresVersion` must set `spec.license`; the KubeDB admission webhook rejects a `Postgres` object that gets this wrong in either direction. Leave it unset (or `false`) for every other distribution.
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.9-appscode"
+spec:
+  ...
+  distribution: AppsCode
+  license:
+    required: true
+  version: "16.9"
+```
+
 ### spec.deprecated
 
 `spec.deprecated` is an optional field that specifies whether the docker images specified here is supported by the current KubeDB operator. For example, we have modified `kubedb/postgres:10.2` docker image to support custom configuration and re-tagged as `kubedb/postgres:10.2-v2`. Now, KubeDB `0.9.0-rc.0` supports providing custom configuration which required `kubedb/postgres:10.2-v2` docker image. So, we have marked `kubedb/postgres:10.2` as deprecated in KubeDB `0.9.0-rc.0`.

--- a/docs/guides/postgres/concepts/postgres.md
+++ b/docs/guides/postgres/concepts/postgres.md
@@ -454,6 +454,36 @@ If you don't specify `spec.deletionPolicy` KubeDB uses `Halt` termination policy
 
 > For more details you can visit [here](https://appscode.com/blog/post/deletion-policy/)
 
+### spec.license
+
+`spec.license` is an optional field that names the Secret holding the license certificate a "Postgres Enterprise by AppsCode" build needs to start. This is unrelated to the KubeDB platform license you pass via `global.license` when installing the KubeDB operator ([see PostgresVersion](/docs/guides/postgres/concepts/catalog.md)); that license activates KubeDB Enterprise features, while `spec.license` activates the database binary itself, and only applies when `spec.version` points at a [PostgresVersion](/docs/guides/postgres/concepts/catalog.md) whose `spec.distribution` is `AppsCode` and `spec.license.required` is `true`. For any other distribution, `spec.license` must be left unset.
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Postgres
+metadata:
+  name: p1
+  namespace: demo
+spec:
+  version: "16.9-appscode"
+  license:
+    secretRef:
+      name: p1-license
+      key: license.pem
+  ...
+```
+
+- `spec.license.secretRef.name` is a required field that names a Secret in the same namespace as the Postgres object.
+- `spec.license.secretRef.key` is an optional field naming the key inside that Secret under which the license certificate (an X.509 PEM file) is stored. It defaults to `license.pem` when left unset.
+
+```bash
+$ kubectl create secret generic p1-license -n demo \
+--from-file=license.pem=/path/to/license.pem
+secret "p1-license" created
+```
+
+KubeDB mounts the referenced certificate outside the database's data volume and points the database process at it; the certificate itself, how it is issued, and its validity window are managed entirely outside KubeDB. If `spec.version` requires a license and `spec.license` is not set, or `spec.license` is set against a version that does not require one, the KubeDB admission webhook rejects the Postgres object.
+
 ## Next Steps
 
 - Learn how to use KubeDB to run a PostgreSQL database [here](/docs/guides/postgres/README.md).


### PR DESCRIPTION
## Summary

Documents the new `spec.license` field being added in kubedb/apimachinery#1880 and wired up in kubedb/postgres#930 (both open, not yet merged).

- `docs/guides/postgres/concepts/postgres.md`: adds a `spec.license` section — what it's for, how it differs from the KubeDB platform license (`global.license` at operator install time, already mentioned in `catalog.md`), the `secretRef.name`/`secretRef.key` fields (key defaults to `license.pem`), and the admission-webhook rule that ties it to the referenced `PostgresVersion`.
- `docs/guides/postgres/concepts/catalog.md`: adds `spec.distribution` (previously used in the example YAML but never documented) and `spec.license.required`, explaining the new `AppsCode` distribution value ("Postgres Enterprise by AppsCode").

Scoped to exactly what's shipping in the two linked PRs; did not attempt to backfill documentation for other undocumented `Postgres`/`PostgresVersion` fields (e.g. TDE) that predate this change.

## Test plan
- [x] Read through both edited files end to end for consistency with the surrounding style and existing anchor-link conventions
- [ ] Re-check cross-reference anchors (`postgres.md#speclicense`, `catalog.md`) once the site renders, since this repo has no local markdown/link linter to run
- [ ] Merge only after kubedb/apimachinery#1880 and kubedb/postgres#930 land, so the documented behavior matches shipped code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring PostgreSQL distributions and license requirements.
  * Documented how to provide enterprise license certificates through Secrets.
  * Added validation rules, supported scenarios, and YAML examples.
  * Clarified admission behavior when licenses are missing or configured incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->