### PR TITLE
Update Storage Autoscalling DOCs

### DIFF
--- a/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Cassa
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Cassa
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Cassa
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Click
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Click
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Click
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/documentdb/autoscaler/storage/index.md
+++ b/docs/guides/documentdb/autoscaler/storage/index.md
@@ -22,7 +22,13 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a `Docu
 
 - Install `KubeDB` Provisioner, Ops-Manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation), and the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API — `metrics-server` alone is **not** enough.
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
 
 - You must have a `StorageClass` that supports volume expansion (`allowVolumeExpansion: true`).
 

--- a/docs/guides/druid/autoscaler/storage/guide.md
+++ b/docs/guides/druid/autoscaler/storage/guide.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Druid
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/druid/autoscaler/storage/guide.md
+++ b/docs/guides/druid/autoscaler/storage/guide.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Druid
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/druid/autoscaler/storage/guide.md
+++ b/docs/guides/druid/autoscaler/storage/guide.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Druid
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/elasticsearch/autoscaler/storage/combined/index.md
+++ b/docs/guides/elasticsearch/autoscaler/storage/combined/index.md
@@ -22,8 +22,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of an Elas
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
   
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/elasticsearch/autoscaler/storage/combined/index.md
+++ b/docs/guides/elasticsearch/autoscaler/storage/combined/index.md
@@ -22,6 +22,14 @@ This guide will show you how to use `KubeDB` to autoscale the storage of an Elas
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
   
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/elasticsearch/autoscaler/storage/topology/index.md
+++ b/docs/guides/elasticsearch/autoscaler/storage/topology/index.md
@@ -22,6 +22,14 @@ This guide will show you how to use `KubeDB` to autoscale the storage of an Elas
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/elasticsearch/autoscaler/storage/topology/index.md
+++ b/docs/guides/elasticsearch/autoscaler/storage/topology/index.md
@@ -22,8 +22,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of an Elas
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/etcd/autoscaler/storage/overview.md
+++ b/docs/guides/etcd/autoscaler/storage/overview.md
@@ -44,7 +44,8 @@ The autoscaling process consists of the following steps:
 5. The `KubeDB` Autoscaler operator watches the `EtcdAutoscaler` CRO.
 
 6. The `KubeDB` Autoscaler operator continuously reads the PVC usage of the database's pods from
-   Prometheus and compares it against `spec.storage.etcd.usageThreshold`.
+   the `custom.metrics.k8s.io` API backed by the KubeDB storage-metrics apiserver and compares it
+   against `spec.storage.etcd.usageThreshold`.
    - If the usage exceeds the threshold, the operator computes a new size and creates an
      `EtcdOpsRequest` of type `VolumeExpansion` to expand the storage.
 

--- a/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
@@ -35,10 +35,6 @@ This guide shows you how to use `KubeDB` to autoscale the storage of an etcd clu
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
-  The Autoscaler operator reads PVC usage through the custom metrics API, which is backed by
-  Prometheus.
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
@@ -35,6 +35,8 @@ This guide shows you how to use `KubeDB` to autoscale the storage of an etcd clu
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/etcd/autoscaler/storage/storage-autoscale.md
@@ -29,7 +29,11 @@ This guide shows you how to use `KubeDB` to autoscale the storage of an etcd clu
 - etcd support is behind an alpha feature gate. Make sure the operators are installed with
   `Etcd=true` enabled (Helm value `featureGates.Etcd=true`).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation).
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
   The Autoscaler operator reads PVC usage through the custom metrics API, which is backed by

--- a/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
+++ b/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Hazel
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
+++ b/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Hazel
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
+++ b/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Hazel
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Ignit
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Ignit
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Ignit
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/kafka/autoscaler/storage/kafka-combined.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-combined.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Kafka
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/kafka/autoscaler/storage/kafka-combined.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-combined.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Kafka
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/kafka/autoscaler/storage/kafka-combined.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-combined.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Kafka
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/kafka/autoscaler/storage/kafka-topology.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-topology.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Kafka
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/kafka/autoscaler/storage/kafka-topology.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-topology.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Kafka
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/kafka/autoscaler/storage/kafka-topology.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-topology.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Kafka
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mariadb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/index.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Maria
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mariadb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/index.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Maria
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mariadb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/index.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Maria
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
@@ -31,6 +31,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a distr
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion in each spoke cluster.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
@@ -25,7 +25,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a distr
   --set petset.features.ocm.enabled=true
   ```
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus in each spoke cluster. The autoscaler queries the per-cluster Prometheus endpoint (configured in the `PlacementPolicy`) to collect storage usage metrics. You can install it from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
@@ -31,8 +31,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a distr
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus in each spoke cluster. The autoscaler queries the per-cluster Prometheus endpoint (configured in the `PlacementPolicy`) to collect storage usage metrics. You can install it from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion in each spoke cluster.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/milvus/autoscaler/storage/guide.md
+++ b/docs/guides/milvus/autoscaler/storage/guide.md
@@ -25,6 +25,14 @@ This guide will show you how to use the `KubeDB` Autoscaler operator to autoscal
 
 - Install the **KubeDB Autoscaler** operator.
 
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - The PVC's `StorageClass` must support volume expansion (`allowVolumeExpansion: true`) — e.g. `longhorn-custom`.
 
 - Complete the dependency setup from [Prepare Dependencies](/docs/guides/milvus/quickstart/prerequisites.md). It installs MinIO, creates the `milvus-storage-config` secret, and installs the etcd operator required by Milvus.

--- a/docs/guides/milvus/autoscaler/storage/guide.md
+++ b/docs/guides/milvus/autoscaler/storage/guide.md
@@ -23,7 +23,7 @@ This guide will show you how to use the `KubeDB` Autoscaler operator to autoscal
   - [MilvusAutoscaler](/docs/guides/milvus/concepts/milvusautoscaler.md)
   - [Storage Autoscaling Overview](/docs/guides/milvus/autoscaler/storage/overview.md)
 
-- Install the **KubeDB Autoscaler** operator and **Prometheus** (storage autoscaling reads PVC usage from Prometheus).
+- Install the **KubeDB Autoscaler** operator.
 
 - The PVC's `StorageClass` must support volume expansion (`allowVolumeExpansion: true`) — e.g. `longhorn-custom`.
 

--- a/docs/guides/milvus/autoscaler/storage/guide.md
+++ b/docs/guides/milvus/autoscaler/storage/guide.md
@@ -81,7 +81,7 @@ milvus-standalone-compute-autoscaler   94s
 milvus-storage-autoscaler              93s
 ```
 
-The storage autoscaler watches the `streamingnode`/`node` PVC usage (read from Prometheus). When usage crosses `usageThreshold`, it creates a `VolumeExpansion` `MilvusOpsRequest`. In this walkthrough the volume stayed well below the threshold (a freshly-created, near-empty `1Gi` volume), so no expansion was triggered:
+The storage autoscaler watches the `streamingnode`/`node` PVC usage through the `custom.metrics.k8s.io` API backed by the KubeDB storage-metrics apiserver. When usage crosses `usageThreshold`, it creates a `VolumeExpansion` `MilvusOpsRequest`. In this walkthrough the volume stayed well below the threshold (a freshly-created, near-empty `1Gi` volume), so no expansion was triggered:
 
 ```bash
 $ kubectl get pvc -n demo -l app.kubernetes.io/instance=milvus-standalone -o custom-columns=NAME:.metadata.name,SIZE:.status.capacity.storage

--- a/docs/guides/milvus/autoscaler/storage/overview.md
+++ b/docs/guides/milvus/autoscaler/storage/overview.md
@@ -52,10 +52,10 @@ spec:
 The flow is:
 
 1. A user creates a `MilvusAutoscaler` with `spec.storage`.
-2. The autoscaler reads PVC usage from Prometheus.
+2. The autoscaler reads PVC usage from the `custom.metrics.k8s.io` API backed by the KubeDB storage-metrics apiserver.
 3. When usage exceeds `usageThreshold`, the autoscaler creates a `VolumeExpansion` `MilvusOpsRequest` sized per `scalingRules`.
 4. The Ops-manager operator performs the volume expansion as usual.
 
-> **Prerequisites:** Prometheus must be collecting volume metrics, and the PVC's `StorageClass` must have `allowVolumeExpansion: true`.
+> **Prerequisites:** The KubeDB storage metrics server must be enabled and serving the `custom.metrics.k8s.io` API, and the PVC's `StorageClass` must have `allowVolumeExpansion: true`.
 
 In the next doc, we will see a step-by-step guide on storage autoscaling of a Milvus database.

--- a/docs/guides/mongodb/autoscaler/storage/replicaset.md
+++ b/docs/guides/mongodb/autoscaler/storage/replicaset.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mongodb/autoscaler/storage/replicaset.md
+++ b/docs/guides/mongodb/autoscaler/storage/replicaset.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mongodb/autoscaler/storage/replicaset.md
+++ b/docs/guides/mongodb/autoscaler/storage/replicaset.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mongodb/autoscaler/storage/sharding.md
+++ b/docs/guides/mongodb/autoscaler/storage/sharding.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mongodb/autoscaler/storage/sharding.md
+++ b/docs/guides/mongodb/autoscaler/storage/sharding.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mongodb/autoscaler/storage/sharding.md
+++ b/docs/guides/mongodb/autoscaler/storage/sharding.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mongodb/autoscaler/storage/standalone.md
+++ b/docs/guides/mongodb/autoscaler/storage/standalone.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mongodb/autoscaler/storage/standalone.md
+++ b/docs/guides/mongodb/autoscaler/storage/standalone.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
   
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mongodb/autoscaler/storage/standalone.md
+++ b/docs/guides/mongodb/autoscaler/storage/standalone.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Mongo
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
   
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mssqlserver/autoscaler/storage/cluster.md
+++ b/docs/guides/mssqlserver/autoscaler/storage/cluster.md
@@ -24,7 +24,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a MSSQL
 
 - To configure TLS/SSL in `MSSQLServer`, `KubeDB` uses `cert-manager` to issue certificates. So first you have to make sure that the cluster has `cert-manager` installed. To install `cert-manager` in your cluster following steps [here](https://cert-manager.io/docs/installation/kubernetes/).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/mssqlserver/autoscaler/storage/cluster.md
+++ b/docs/guides/mssqlserver/autoscaler/storage/cluster.md
@@ -30,8 +30,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a MSSQL
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mssqlserver/autoscaler/storage/cluster.md
+++ b/docs/guides/mssqlserver/autoscaler/storage/cluster.md
@@ -30,6 +30,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a MSSQL
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mysql/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/storage/cluster/index.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a MySQL
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mysql/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/storage/cluster/index.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a MySQL
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/mysql/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/storage/cluster/index.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a MySQL
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Perco
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Perco
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Perco
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/postgres/autoscaler/storage/cluster.md
+++ b/docs/guides/postgres/autoscaler/storage/cluster.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Postg
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/postgres/autoscaler/storage/cluster.md
+++ b/docs/guides/postgres/autoscaler/storage/cluster.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Postg
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/postgres/autoscaler/storage/cluster.md
+++ b/docs/guides/postgres/autoscaler/storage/cluster.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Postg
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/qdrant/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/qdrant/autoscaler/storage/storage-autoscale.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Qdran
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/qdrant/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/qdrant/autoscaler/storage/storage-autoscale.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Qdran
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation).
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
 

--- a/docs/guides/qdrant/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/qdrant/autoscaler/storage/storage-autoscale.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Qdran
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Rabbi
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Rabbi
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Rabbi
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/redis/autoscaler/storage/redis.md
+++ b/docs/guides/redis/autoscaler/storage/redis.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Redis
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/redis/autoscaler/storage/redis.md
+++ b/docs/guides/redis/autoscaler/storage/redis.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Redis
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
   
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/redis/autoscaler/storage/redis.md
+++ b/docs/guides/redis/autoscaler/storage/redis.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Redis
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
   
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/singlestore/autoscaler/storage/cluster.md
+++ b/docs/guides/singlestore/autoscaler/storage/cluster.md
@@ -28,8 +28,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Singl
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/singlestore/autoscaler/storage/cluster.md
+++ b/docs/guides/singlestore/autoscaler/storage/cluster.md
@@ -28,6 +28,8 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Singl
   --set kubedb-autoscaler.storage-metrics-server.enabled=true
   ```
 
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/singlestore/autoscaler/storage/cluster.md
+++ b/docs/guides/singlestore/autoscaler/storage/cluster.md
@@ -22,7 +22,11 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a Singl
 
 - Install `KubeDB` Provisioner, Ops-manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation)
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
 
 - Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 

--- a/docs/guides/solr/autoscaler/storage/combined.md
+++ b/docs/guides/solr/autoscaler/storage/combined.md
@@ -22,8 +22,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of an Solr
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/solr/autoscaler/storage/combined.md
+++ b/docs/guides/solr/autoscaler/storage/combined.md
@@ -22,6 +22,14 @@ This guide will show you how to use `KubeDB` to autoscale the storage of an Solr
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/solr/autoscaler/storage/topology.md
+++ b/docs/guides/solr/autoscaler/storage/topology.md
@@ -22,6 +22,14 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a solr 
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
+
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/solr/autoscaler/storage/topology.md
+++ b/docs/guides/solr/autoscaler/storage/topology.md
@@ -22,8 +22,6 @@ This guide will show you how to use `KubeDB` to autoscale the storage of a solr 
 
 - Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
 
-- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-
 - You must have a `StorageClass` that supports volume expansion.
 
 - You should be familiar with the following `KubeDB` concepts:

--- a/docs/guides/weaviate/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/weaviate/autoscaler/storage/storage-autoscale.md
@@ -22,9 +22,15 @@ This guide will show you how to use `KubeDB` to auto-scale the storage of a Weav
 
 - Install `KubeDB` Provisioner, Ops-Manager, and Autoscaler operators in your cluster following the steps [here](/docs/setup/README.md).
 
-- You must have a `StorageClass` that supports **volume expansion** (`allowVolumeExpansion: true`). Storage autoscaling expands the existing PVCs in place.
+- During KubeDB installation, enable the KubeDB storage metrics server by passing the following Helm flag:
 
-- Storage autoscaling reacts to the volume-usage metric (`volume_used_percentage`) exposed through KubeDB's metrics API. Make sure the KubeDB metrics stack is installed and serving this metric in your cluster.
+  ```bash
+  --set kubedb-autoscaler.storage-metrics-server.enabled=true
+  ```
+
+  It provides the **custom metrics API** (`custom.metrics.k8s.io`) backed by the KubeDB storage-metrics apiserver. The storage autoscaler reads PVC usage from this API.
+
+- You must have a `StorageClass` that supports **volume expansion** (`allowVolumeExpansion: true`). Storage autoscaling expands the existing PVCs in place.
 
 - You should be familiar with the following `KubeDB` concepts:
   - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated storage autoscaling prerequisites across supported database guides.
  * Added instructions to enable KubeDB’s storage metrics server during installation using the provided Helm setting.
  * Clarified that the server exposes the `custom.metrics.k8s.io` API for reading PVC usage.
  * Removed separate Kubernetes Metrics Server and Prometheus installation requirements where no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->