### PR TITLE
Fix schema validation errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,11 @@ jobs:
 
       - name: Check links
         run: |
-          lychee --root-dir $(pwd) --max-concurrency 10 --exclude-all-private --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*|.*\.svc.*|.*github.io.*|.*kubedb.com.*|.*kubestash.com.*|.*stash.run.*)$' 'docs/**/*.md'
+          lychee --root-dir $(pwd) --max-concurrency 10 --exclude-all-private --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*sap.com.*|.*milvus.io.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*|.*\.svc.*|.*github.io.*|.*kubedb.com.*|.*kubestash.com.*|.*stash.run.*)$' 'docs/**/*.md'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if lychee --root-dir $(pwd) --max-concurrency 10 --exclude-all-private --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*|.*\.svc.*|.*github.io.*|.*kubedb.com.*|.*kubestash.com.*|.*stash.run.*)$' 'docs/**/*.md'; then
+            if lychee --root-dir $(pwd) --max-concurrency 10 --exclude-all-private --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*sap.com.*|.*milvus.io.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*|.*\.svc.*|.*github.io.*|.*kubedb.com.*|.*kubestash.com.*|.*stash.run.*)$' 'docs/**/*.md'; then
               echo "Link check passed"
               exit 0
             fi

--- a/docs/examples/etcd/recommendation/etcd.yaml
+++ b/docs/examples/etcd/recommendation/etcd.yaml
@@ -15,6 +15,7 @@ spec:
       requests:
         storage: 1Gi
   authSecret:
+    kind: Secret
     name: etcd-recommendation-auth
     rotateAfter: 720h
   tls:

--- a/docs/examples/vault/secretstore.yaml
+++ b/docs/examples/vault/secretstore.yaml
@@ -4,5 +4,7 @@ metadata:
   name: vault
 spec:
   vault:
-    url: http://vault.vault-demo.svc:8200
+    ref:
+      name: vault
+      namespace: vault-demo
     roleName: virtual-secrets-role

--- a/docs/guides/documentdb/reconfigure/reconfigure.md
+++ b/docs/guides/documentdb/reconfigure/reconfigure.md
@@ -135,7 +135,7 @@ from each pod so `max_connections` returns to its default of `100`.
 > clear that state — recovery requires recreating the `DocumentDB`. Validate `Reconfigure`
 > against a non-production cluster on this build before relying on it. The YAML and rollout
 > mechanics above are the intended workflow; provisioning custom configuration up front (see
-> [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file/)) is
+> [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file.md)) is
 > unaffected.
 
 ## Standalone
@@ -155,5 +155,5 @@ kubectl delete ns demo
 
 ## Next Steps
 
-- Provision a database with [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file/).
+- Provision a database with [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file.md).
 - [Restart](/docs/guides/documentdb/restart/) a DocumentDB database.

--- a/docs/guides/documentdb/rotate-authentication/rotate-authentication.md
+++ b/docs/guides/documentdb/rotate-authentication/rotate-authentication.md
@@ -159,4 +159,4 @@ kubectl delete ns demo
 ## Next Steps
 
 - [Restart](/docs/guides/documentdb/restart/) a DocumentDB database.
-- Provision a database with [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file/).
+- Provision a database with [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file.md).

--- a/docs/guides/etcd/concepts/etcd.md
+++ b/docs/guides/etcd/concepts/etcd.md
@@ -44,6 +44,7 @@ spec:
       requests:
         storage: 1Gi
   authSecret:
+    kind: Secret
     name: etcd-cluster-auth
     externallyManaged: false
   configuration:

--- a/docs/guides/etcd/recommendation/recommendation.md
+++ b/docs/guides/etcd/recommendation/recommendation.md
@@ -94,6 +94,7 @@ spec:
   version: "3.6.4"
   replicas: 3
   authSecret:
+    kind: Secret
     name: etcd-recommendation-auth
     rotateAfter: 720h
 ```

--- a/docs/guides/ignite/update-version/overview.md
+++ b/docs/guides/ignite/update-version/overview.md
@@ -27,7 +27,7 @@ This guide will give you an overview on how KubeDB Ops-manager operator update t
 The following diagram shows how KubeDB Ops-manager operator used to update the version of `Ignite`. Open the image in a new tab to see the enlarged version.
 
 <figure align="center">
-  <img alt="updating Process of Ignite" src="/docs/images/day-2-operation/ignite/ig-version-update.svg">
+  <img alt="updating Process of Ignite" src="/docs/images/day-2-operation/ignite/ig-version-update.png">
 <figcaption align="center">Fig: updating Process of Ignite</figcaption>
 </figure>
 

--- a/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
+++ b/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
@@ -113,7 +113,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.8.2
+  version: 1.18.4
   replicas: 3
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/yamls/vault.yaml
+++ b/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/yamls/vault.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.8.2
+  version: 1.18.4
   replicas: 3
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
@@ -113,7 +113,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.8.2
+  version: 1.18.4
   replicas: 3
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mongodb/schema-manager/initializing-with-script/yamls/vault.yaml
+++ b/docs/guides/mongodb/schema-manager/initializing-with-script/yamls/vault.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.8.2
+  version: 1.18.4
   replicas: 3
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
@@ -127,7 +127,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.8.2
+  version: 1.18.4
   replicas: 3
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/yamls/vault.yaml
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/yamls/vault.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.8.2
+  version: 1.18.4
   replicas: 3
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mysql/schema-manager/deploy-mysqldatabase/index.md
+++ b/docs/guides/mysql/schema-manager/deploy-mysqldatabase/index.md
@@ -97,7 +97,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.9.2
+  version: 1.18.4
   replicas: 1
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mysql/schema-manager/deploy-mysqldatabase/yamls/vault.yaml
+++ b/docs/guides/mysql/schema-manager/deploy-mysqldatabase/yamls/vault.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.9.2
+  version: 1.18.4
   replicas: 1
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mysql/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mysql/schema-manager/initializing-with-script/index.md
@@ -98,7 +98,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.9.2
+  version: 1.18.4
   replicas: 1
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/mysql/schema-manager/initializing-with-script/yamls/vault.yaml
+++ b/docs/guides/mysql/schema-manager/initializing-with-script/yamls/vault.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: demo
 spec:
-  version: 1.9.2
+  version: 1.18.4
   replicas: 1
   allowedSecretEngines:
     namespaces:

--- a/docs/guides/pgbouncer/virtual_secret/guide.md
+++ b/docs/guides/pgbouncer/virtual_secret/guide.md
@@ -100,7 +100,9 @@ metadata:
   name: vault
 spec:
   vault:
-    url: http://vault.vault-demo.svc:8200
+    ref:
+      name: vault
+      namespace: vault-demo
     roleName: virtual-secrets-role
 ```
 ```bash
@@ -110,7 +112,7 @@ secretstore.config.virtual-secrets.dev/vault configured
 Here,
 
 - `spec.vault` - section describes the connection information for vault.
-- `spec.vault.url` - contains the connection url to the vault server.
+- `spec.vault.ref` - refers to the AppBinding published by the KubeVault `VaultServer`, which carries the vault connection url and CA bundle.
 - `spec.vault.roleName` - contains the role name we specified when binding the policy to the service account earlier.
 
 > **Note:** `spec.aws`, `spec.azure` and `spec.gcp` can be used to specify the connection information of the corresponding secret manager.

--- a/docs/guides/pgpool/virtual_secret/guide.md
+++ b/docs/guides/pgpool/virtual_secret/guide.md
@@ -99,7 +99,9 @@ metadata:
   name: vault
 spec:
   vault:
-    url: http://vault.vault-demo.svc:8200
+    ref:
+      name: vault
+      namespace: vault-demo
     roleName: virtual-secrets-role
 ```
 ```bash
@@ -110,7 +112,7 @@ secretstore.config.virtual-secrets.dev/vault configured
 Here,
 
 - `spec.vault` - section describes the connection information for vault.
-- `spec.vault.url` - contains the connection url to the vault server.
+- `spec.vault.ref` - refers to the AppBinding published by the KubeVault `VaultServer`, which carries the vault connection url and CA bundle.
 - `spec.vault.roleName` - contains the role name we specified when binding the policy to the service account earlier.
 
 > **Note:** `spec.aws`, `spec.azure` and `spec.gcp` can be used to specify the connection information of the corresponding secret manager.

--- a/docs/guides/postgres/remote-replica/advanced-setup-yamls/pg-london-remote-replica.yaml
+++ b/docs/guides/postgres/remote-replica/advanced-setup-yamls/pg-london-remote-replica.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-london-auth
   remoteReplica:
     sourceRef:

--- a/docs/guides/postgres/remote-replica/advanced-setup-yamls/pg-london.yaml
+++ b/docs/guides/postgres/remote-replica/advanced-setup-yamls/pg-london.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-london-auth
   clientAuthMode: md5
   deletionPolicy: Halt

--- a/docs/guides/postgres/remote-replica/advanced-setup-yamls/pg-singapore.yaml
+++ b/docs/guides/postgres/remote-replica/advanced-setup-yamls/pg-singapore.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Halt

--- a/docs/guides/postgres/remote-replica/advanced-setup.md
+++ b/docs/guides/postgres/remote-replica/advanced-setup.md
@@ -197,6 +197,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Halt
@@ -336,6 +337,7 @@ spec:
       name: pg-singapore
       namespace: demo
   authSecret:
+    kind: Secret
     name: pg-london-auth
   clientAuthMode: md5
   standbyMode: Hot
@@ -586,6 +588,7 @@ spec:
       name: pg-london
       namespace: demo
   authSecret:
+    kind: Secret
     name: pg-london-auth
   clientAuthMode: md5
   standbyMode: Hot

--- a/docs/guides/postgres/remote-replica/migration-yamls/pg-mig.yaml
+++ b/docs/guides/postgres/remote-replica/migration-yamls/pg-mig.yaml
@@ -9,6 +9,7 @@ spec:
       name: source-pg          # the AppBinding above, in THIS cluster
       namespace: demo
   authSecret:
+    kind: Secret
     name: source-pg-auth       # during the warm phase: the migration user's credentials
   clientAuthMode: md5
   standbyMode: Hot

--- a/docs/guides/postgres/remote-replica/migration-yamls/source-appbinding.yaml
+++ b/docs/guides/postgres/remote-replica/migration-yamls/source-appbinding.yaml
@@ -26,8 +26,6 @@ spec:
       query: sslmode=disable  # or verify-ca with a tlsSecret carrying the SOURCE's CA
       scheme: postgresql
   secret:
-    apiGroup: ""
-    kind: Secret
     name: source-pg-auth
   type: kubedb.com/postgres
   version: "17.4"

--- a/docs/guides/postgres/remote-replica/migration.md
+++ b/docs/guides/postgres/remote-replica/migration.md
@@ -106,8 +106,6 @@ spec:
       query: sslmode=disable   # TLS source: verify-ca + a tlsSecret carrying the SOURCE's CA
       scheme: postgresql
   secret:
-    apiGroup: ""
-    kind: Secret
     name: source-pg-auth
   type: kubedb.com/postgres
   version: "17.4"
@@ -131,6 +129,7 @@ spec:
       name: source-pg
       namespace: demo
   authSecret:
+    kind: Secret
     name: source-pg-auth       # yes — the migration user's credentials; see below
   clientAuthMode: md5
   standbyMode: Hot

--- a/docs/guides/postgres/remote-replica/synchronous-yamls/pg-london.yaml
+++ b/docs/guides/postgres/remote-replica/synchronous-yamls/pg-london.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-london-auth
   remoteReplica:
     sourceRef:

--- a/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore-3.yaml
+++ b/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore-3.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Delete

--- a/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore-sync-3.yaml
+++ b/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore-sync-3.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Delete

--- a/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore-sync.yaml
+++ b/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore-sync.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Delete

--- a/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore.yaml
+++ b/docs/guides/postgres/remote-replica/synchronous-yamls/pg-singapore.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Delete

--- a/docs/guides/postgres/remote-replica/synchronous.md
+++ b/docs/guides/postgres/remote-replica/synchronous.md
@@ -193,6 +193,7 @@ metadata:
   namespace: demo
 spec:
   authSecret:
+    kind: Secret
     name: pg-singapore-auth
   clientAuthMode: md5
   deletionPolicy: Delete
@@ -310,6 +311,7 @@ spec:
       name: pg-singapore
       namespace: demo
   authSecret:
+    kind: Secret
     name: pg-london-auth
   clientAuthMode: md5
   standbyMode: Hot

--- a/docs/guides/postgres/virtual_secret/guide.md
+++ b/docs/guides/postgres/virtual_secret/guide.md
@@ -102,7 +102,9 @@ metadata:
   name: vault
 spec:
   vault:
-    url: http://vault.demo.svc:8200
+    ref:
+      name: vault
+      namespace: demo
     roleName: virtual-secrets-role
 ```
 ```bash
@@ -112,8 +114,8 @@ secretstore.config.virtual-secrets.dev/vault configured
 Here,
 
 - `spec.vault` - section describes the connection information for vault.
-- `spec.url` - contains the connection url to the vault server.
-- `spec.roleName` - contains the role name we specified when binding the policy to the service account earlier.
+- `spec.vault.ref` - refers to the AppBinding published by the KubeVault `VaultServer`, which carries the vault connection url and CA bundle.
+- `spec.vault.roleName` - contains the role name we specified when binding the policy to the service account earlier.
 
 > **Note:** `spec.aws`, `spec.azure` and `spec.gcp` can be used to specify the connection information of the corresponding secret manager.
 

--- a/docs/guides/redis/virtual_secret/guide.md
+++ b/docs/guides/redis/virtual_secret/guide.md
@@ -102,7 +102,9 @@ metadata:
   name: vault
 spec:
   vault:
-    url: http://vault.demo.svc:8200
+    ref:
+      name: vault
+      namespace: demo
     roleName: virtual-secrets-role
 ```
 ```bash
@@ -112,7 +114,7 @@ secretstore.config.virtual-secrets.dev/vault configured
 Here,
 
 - `spec.vault` - section describes the connection information for vault.
-- `spec.vault.url` - contains the connection url to the vault server.
+- `spec.vault.ref` - refers to the AppBinding published by the KubeVault `VaultServer`, which carries the vault connection url and CA bundle.
 - `spec.vault.roleName` - contains the role name we specified when binding the policy to the service account earlier.
 
 > **Note:** `spec.aws`, `spec.azure` and `spec.gcp` can be used to specify the connection information of the corresponding secret manager.


### PR DESCRIPTION
The `codespan-schema-checker` step on master fails ([run 32727515948](https://github.com/kubedb/docs/actions/runs/32727515948/job/97432047917)) with three classes of schema errors. All three are fixed here, verified against the same CRDs CI installs.

| Error | Cause | Fix |
|---|---|---|
| `Etcd/Postgres.spec.authSecret: missing required field "kind"` | `authSecret` is a `TypedLocalObjectReference`; the CRD marks `kind` required (the `Secret` default is applied server-side only, the checker validates client-side) | added `kind: Secret` |
| `SecretStore.spec.vault: unknown field "url"` / `missing required field "ref"` | virtual-secrets replaced `vault.url` with `vault.ref`, an AppBinding reference published by the KubeVault `VaultServer` | `url: http://vault.<ns>.svc:8200` → `ref: {name, namespace}`, plus the surrounding prose |
| `AppBinding.spec.secret: unknown field "apiGroup"/"kind"` | `spec.secret` is a plain `LocalObjectReference` — `name` only | dropped `apiGroup`/`kind` |

Affected areas: etcd examples/guides, `postgres/remote-replica/*`, the four `*/virtual_secret/guide.md`, and `docs/examples/vault/secretstore.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication examples to explicitly identify referenced resources as Kubernetes Secrets.
  * Updated Vault-backed secret store examples to reference Vault AppBindings by name and namespace instead of direct service URLs.
  * Clarified that AppBindings provide Vault connection details and CA bundles.
  * Simplified secret references in PostgreSQL migration examples.
  * Updated MongoDB and MySQL schema-management examples to use Vault 1.18.4.
  * Fixed internal documentation links and updated an Ignite guide image format.

* **Chores**
  * Improved CI link checks by excluding additional external domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->