### PR TITLE
Prepare for release v2026.8.26-rc.2

### DIFF
--- a/docs/CHANGELOG-v2026.8.26-rc.2.md
+++ b/docs/CHANGELOG-v2026.8.26-rc.2.md
@@ -1,0 +1,804 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2026.8.26-rc.2
+    name: Changelog-v2026.8.26-rc.2
+    parent: welcome
+    weight: 20260826
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.8.26-rc.2/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.8.26-rc.2/
+---
+
+# KubeDB v2026.8.26-rc.2 (2026-08-26)
+
+
+## [kubedb/aerospike](https://github.com/kubedb/aerospike)
+
+### [v0.3.0-rc.2](https://github.com/kubedb/aerospike/releases/tag/v0.3.0-rc.2)
+
+- [442d7867](https://github.com/kubedb/aerospike/commit/442d7867) Prepare for release v0.3.0-rc.2 (#15)
+- [580212ae](https://github.com/kubedb/aerospike/commit/580212ae) Prepare for release v0.3.0-rc.1 (#14)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.67.0-rc.2](https://github.com/kubedb/apimachinery/releases/tag/v0.67.0-rc.2)
+
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.52.0-rc.2](https://github.com/kubedb/autoscaler/releases/tag/v0.52.0-rc.2)
+
+- [449258a6](https://github.com/kubedb/autoscaler/commit/449258a6) Prepare for release v0.52.0-rc.2 (#316)
+- [84940b42](https://github.com/kubedb/autoscaler/commit/84940b42) Add Etcd compute/storage autoscaler support (#314)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.20.0-rc.2](https://github.com/kubedb/cassandra/releases/tag/v0.20.0-rc.2)
+
+- [ed7f7fb9](https://github.com/kubedb/cassandra/commit/ed7f7fb9) Prepare for release v0.20.0-rc.2 (#107)
+
+
+
+## [kubedb/cassandra-medusa-plugin](https://github.com/kubedb/cassandra-medusa-plugin)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/cassandra-medusa-plugin/releases/tag/v0.14.0-rc.2)
+
+- [b3e1040f](https://github.com/kubedb/cassandra-medusa-plugin/commit/b3e1040f) Prepare for release v0.14.0-rc.2 (#47)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/clickhouse/releases/tag/v0.22.0-rc.2)
+
+- [044be1f7](https://github.com/kubedb/clickhouse/commit/044be1f7) Prepare for release v0.22.0-rc.2 (#137)
+- [51b3c5f7](https://github.com/kubedb/clickhouse/commit/51b3c5f7) Prepare for release v0.22.0-rc.1 (#136)
+- [ef2a8ceb](https://github.com/kubedb/clickhouse/commit/ef2a8ceb) Fix Shard Scale Fail  for equal no of Shard (#135)
+
+
+
+## [kubedb/clickhouse-backup-plugin](https://github.com/kubedb/clickhouse-backup-plugin)
+
+### [v0.4.0-rc.2](https://github.com/kubedb/clickhouse-backup-plugin/releases/tag/v0.4.0-rc.2)
+
+- [03bdc169](https://github.com/kubedb/clickhouse-backup-plugin/commit/03bdc169) Prepare for release v0.4.0-rc.2 (#34)
+
+
+
+## [kubedb/courier](https://github.com/kubedb/courier)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/courier/releases/tag/v0.7.0-rc.2)
+
+- [85daa1a](https://github.com/kubedb/courier/commit/85daa1a) Prepare for release v0.7.0-rc.2 (#58)
+- [19d7d3c](https://github.com/kubedb/courier/commit/19d7d3c) Clear the VGS group label off source PVCs on teardown (#56)
+- [e92270d](https://github.com/kubedb/courier/commit/e92270d) Cross-cluster Branch (Initiator/Creator) and the hub manager (#29)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/crd-manager/releases/tag/v0.22.0-rc.2)
+
+- [5ff6c69d](https://github.com/kubedb/crd-manager/commit/5ff6c69d) Prepare for release v0.22.0-rc.2 (#154)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.25.0-rc.2](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.25.0-rc.2)
+
+- [b5a775db](https://github.com/kubedb/dashboard-restic-plugin/commit/b5a775db) Prepare for release v0.25.0-rc.2 (#87)
+- [17cbb91d](https://github.com/kubedb/dashboard-restic-plugin/commit/17cbb91d) Prepare for release v0.25.0-rc.1 (#86)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/db-client-go/releases/tag/v0.22.0-rc.2)
+
+- [cfe9ea0b](https://github.com/kubedb/db-client-go/commit/cfe9ea0b) Prepare for release v0.22.0-rc.2 (#265)
+
+
+
+## [kubedb/db2](https://github.com/kubedb/db2)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/db2/releases/tag/v0.8.0-rc.2)
+
+- [c81c1cbd](https://github.com/kubedb/db2/commit/c81c1cbd) Prepare for release v0.8.0-rc.2 (#41)
+
+
+
+## [kubedb/db2-coordinator](https://github.com/kubedb/db2-coordinator)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/db2-coordinator/releases/tag/v0.8.0-rc.2)
+
+- [5a5f946](https://github.com/kubedb/db2-coordinator/commit/5a5f946) Prepare for release v0.8.0-rc.2 (#20)
+- [6f26b16](https://github.com/kubedb/db2-coordinator/commit/6f26b16) Prepare for release v0.8.0-rc.1 (#19)
+
+
+
+## [kubedb/documentdb](https://github.com/kubedb/documentdb)
+
+### [v0.4.0-rc.2](https://github.com/kubedb/documentdb/releases/tag/v0.4.0-rc.2)
+
+- [dd152ae6](https://github.com/kubedb/documentdb/commit/dd152ae6) Prepare for release v0.4.0-rc.2 (#49)
+- [c67ebaf4](https://github.com/kubedb/documentdb/commit/c67ebaf4) Prepare for release v0.4.0-rc.1 (#48)
+
+
+
+## [kubedb/documentdb-coordinator](https://github.com/kubedb/documentdb-coordinator)
+
+### [v0.3.0-rc.2](https://github.com/kubedb/documentdb-coordinator/releases/tag/v0.3.0-rc.2)
+
+- [06c4a7f](https://github.com/kubedb/documentdb-coordinator/commit/06c4a7f) Prepare for release v0.3.0-rc.2 (#14)
+- [40c1429](https://github.com/kubedb/documentdb-coordinator/commit/40c1429) Prepare for release v0.3.0-rc.1 (#13)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/druid/releases/tag/v0.22.0-rc.2)
+
+- [a1b656c8](https://github.com/kubedb/druid/commit/a1b656c8) Prepare for release v0.22.0-rc.2 (#156)
+- [4dfdca51](https://github.com/kubedb/druid/commit/4dfdca51) Fix AppBinding URL Scheme (#154)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.67.0-rc.2](https://github.com/kubedb/elasticsearch/releases/tag/v0.67.0-rc.2)
+
+- [071452f9](https://github.com/kubedb/elasticsearch/commit/071452f95) Prepare for release v0.67.0-rc.2 (#835)
+- [16244d23](https://github.com/kubedb/elasticsearch/commit/16244d23b) Prepare for release v0.67.0-rc.1 (#834)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.30.0-rc.2](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.30.0-rc.2)
+
+- [e46b0c60](https://github.com/kubedb/elasticsearch-restic-plugin/commit/e46b0c60) Prepare for release v0.30.0-rc.2 (#110)
+- [8b2a3fe9](https://github.com/kubedb/elasticsearch-restic-plugin/commit/8b2a3fe9) Prepare for release v0.30.0-rc.1 (#109)
+
+
+
+## [kubedb/etcd](https://github.com/kubedb/etcd)
+
+### [v0.1.0-rc.2](https://github.com/kubedb/etcd/releases/tag/v0.1.0-rc.2)
+
+- [5cb73db9](https://github.com/kubedb/etcd/commit/5cb73db9) Prepare for release v0.1.0-rc.2 (#2)
+- [21238611](https://github.com/kubedb/etcd/commit/21238611) Export SetupControllers so the shared provisioner can host the Etcd reconciler
+- [12810fdd](https://github.com/kubedb/etcd/commit/12810fdd) Fix the 3 golangci-lint findings CI surfaced on the first real lint run
+- [1847985e](https://github.com/kubedb/etcd/commit/1847985e) Bump apimachinery and db-client-go to their merged commits
+- [4566192e](https://github.com/kubedb/etcd/commit/4566192e) Add DESIGN.md
+- [3b8125c2](https://github.com/kubedb/etcd/commit/3b8125c2) rotate_auth: detect auth-enabled state via AuthStatus, not an empty password
+- [cb12031a](https://github.com/kubedb/etcd/commit/cb12031a) vendor: pull in db-client-go's IsQuorumHealthy fixes
+- [a0eb2756](https://github.com/kubedb/etcd/commit/a0eb2756) Fix the bugs a review of the ops engine and the provisioner turned up
+- [1cdbd973](https://github.com/kubedb/etcd/commit/1cdbd973) Add the Restore ops request
+- [a6c6a7b1](https://github.com/kubedb/etcd/commit/a6c6a7b1) Add the RecoverFromQuorumLoss ops request
+- [f813b78f](https://github.com/kubedb/etcd/commit/f813b78f) Honour user supplied etcd flags and extract the pod surgery helper
+- [a8928345](https://github.com/kubedb/etcd/commit/a8928345) Adapt Makefile/hack/docker to etcd and add CI workflows
+- [f60087f6](https://github.com/kubedb/etcd/commit/f60087f6) cert-manager reconciler: watch Secret/Issuer/ClusterIssuer
+- [5bb2ede7](https://github.com/kubedb/etcd/commit/5bb2ede7) Convert the OpsRequest engine to controller-runtime style
+- [8b0daa1c](https://github.com/kubedb/etcd/commit/8b0daa1c) Convert the provisioner to controller-runtime style
+- [9ee15323](https://github.com/kubedb/etcd/commit/9ee15323) Fix stats service metrics port, drop unusable metrics-exporter cert, mark horizontal-scaling direction
+- [0492607e](https://github.com/kubedb/etcd/commit/0492607e) Add README
+- [31869898](https://github.com/kubedb/etcd/commit/31869898) Wire EtcdArchiver snapshot backup/restore (KubeStash)
+- [0984b4d2](https://github.com/kubedb/etcd/commit/0984b4d2) Add etcd OpsRequest execution engine (etcd-ops)
+- [e8557f9f](https://github.com/kubedb/etcd/commit/e8557f9f) Add etcd provisioner: PetSet, membership reconciliation, TLS, AppBinding, monitoring
+
+
+
+## [kubedb/etcd-restic-plugin](https://github.com/kubedb/etcd-restic-plugin)
+
+### [v0.1.0-rc.2](https://github.com/kubedb/etcd-restic-plugin/releases/tag/v0.1.0-rc.2)
+
+- [00faabb](https://github.com/kubedb/etcd-restic-plugin/commit/00faabb) Prepare for release v0.1.0-rc.2 (#2)
+- [ff35eda](https://github.com/kubedb/etcd-restic-plugin/commit/ff35eda) Update deps
+- [f574749](https://github.com/kubedb/etcd-restic-plugin/commit/f574749) Fix snapshot integrity, restore idempotency and space accounting
+- [54c8420](https://github.com/kubedb/etcd-restic-plugin/commit/54c8420) backup: check f.Close() error in sha256File
+- [ecf9140](https://github.com/kubedb/etcd-restic-plugin/commit/ecf9140) Add missing .github CI workflow folder
+- [974b15b](https://github.com/kubedb/etcd-restic-plugin/commit/974b15b) Add README
+
+
+
+## [kubedb/gitops](https://github.com/kubedb/gitops)
+
+### [v0.15.0-rc.2](https://github.com/kubedb/gitops/releases/tag/v0.15.0-rc.2)
+
+- [0e39fe7e](https://github.com/kubedb/gitops/commit/0e39fe7e) Prepare for release v0.15.0-rc.2 (#93)
+- [01a03f3e](https://github.com/kubedb/gitops/commit/01a03f3e) Prepare for release v0.15.0-rc.1 (#92)
+- [6da96309](https://github.com/kubedb/gitops/commit/6da96309) Add Etcd GitOps support (#91)
+
+
+
+## [kubedb/hanadb](https://github.com/kubedb/hanadb)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/hanadb/releases/tag/v0.8.0-rc.2)
+
+- [878f2041](https://github.com/kubedb/hanadb/commit/878f2041) Prepare for release v0.8.0-rc.2 (#62)
+
+
+
+## [kubedb/hanadb-coordinator](https://github.com/kubedb/hanadb-coordinator)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/hanadb-coordinator/releases/tag/v0.7.0-rc.2)
+
+- [83e3f954](https://github.com/kubedb/hanadb-coordinator/commit/83e3f954) Prepare for release v0.7.0-rc.2 (#24)
+- [4946cd74](https://github.com/kubedb/hanadb-coordinator/commit/4946cd74) Prepare for release v0.7.0-rc.1 (#23)
+
+
+
+## [kubedb/hazelcast](https://github.com/kubedb/hazelcast)
+
+### [v0.13.0-rc.2](https://github.com/kubedb/hazelcast/releases/tag/v0.13.0-rc.2)
+
+- [a70a49bc](https://github.com/kubedb/hazelcast/commit/a70a49bc) Prepare for release v0.13.0-rc.2 (#68)
+- [76480d46](https://github.com/kubedb/hazelcast/commit/76480d46) Prepare for release v0.13.0-rc.1 (#67)
+
+
+
+## [kubedb/ignite](https://github.com/kubedb/ignite)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/ignite/releases/tag/v0.14.0-rc.2)
+
+- [d8ffae05](https://github.com/kubedb/ignite/commit/d8ffae05) Prepare for release v0.14.0-rc.2 (#76)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2026.8.26-rc.2](https://github.com/kubedb/installer/releases/tag/v2026.8.26-rc.2)
+
+- [3c68c3b9](https://github.com/kubedb/installer/commit/3c68c3b93) Prepare for release v2026.8.26-rc.2 (#2427)
+- [2aaa9e1d](https://github.com/kubedb/installer/commit/2aaa9e1d5) Add disableVersions to kubedb-catalog (#2426)
+- [7ea6575e](https://github.com/kubedb/installer/commit/7ea6575e3) Fix script
+- [6be4d91d](https://github.com/kubedb/installer/commit/6be4d91d3) Add Postgres Enterprise by AppsCode 16.9 catalog versions (#2425)
+- [24f4e6db](https://github.com/kubedb/installer/commit/24f4e6db3) Add kubedb-courier-addon-manager chart (#2365)
+- [0c6e2459](https://github.com/kubedb/installer/commit/0c6e2459d) Update Neo4j Addon (#2422)
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.38.0-rc.2](https://github.com/kubedb/kafka/releases/tag/v0.38.0-rc.2)
+
+- [877b1bd2](https://github.com/kubedb/kafka/commit/877b1bd2) Prepare for release v0.38.0-rc.2 (#220)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.43.0-rc.2](https://github.com/kubedb/kibana/releases/tag/v0.43.0-rc.2)
+
+- [a686144f](https://github.com/kubedb/kibana/commit/a686144f) Prepare for release v0.43.0-rc.2 (#191)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.30.0-rc.2](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.30.0-rc.2)
+
+- [44572547](https://github.com/kubedb/kubedb-manifest-plugin/commit/44572547) Prepare for release v0.30.0-rc.2 (#144)
+- [3d3ad890](https://github.com/kubedb/kubedb-manifest-plugin/commit/3d3ad890) Prepare for release v0.30.0-rc.1 (#143)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.18.0-rc.2](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.18.0-rc.2)
+
+- [8dd10355](https://github.com/kubedb/kubedb-verifier/commit/8dd10355) Prepare for release v0.18.0-rc.2 (#61)
+- [2f4d0681](https://github.com/kubedb/kubedb-verifier/commit/2f4d0681) Prepare for release v0.18.0-rc.1 (#60)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.51.0-rc.2](https://github.com/kubedb/mariadb/releases/tag/v0.51.0-rc.2)
+
+- [b73865f2](https://github.com/kubedb/mariadb/commit/b73865f24) Prepare for release v0.51.0-rc.2 (#430)
+- [060d3310](https://github.com/kubedb/mariadb/commit/060d33103) Prepare for release v0.51.0-rc.1 (#429)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.27.0-rc.2](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.27.0-rc.2)
+
+- [e8899069](https://github.com/kubedb/mariadb-archiver/commit/e8899069) Prepare for release v0.27.0-rc.2 (#104)
+- [0a816c0e](https://github.com/kubedb/mariadb-archiver/commit/0a816c0e) Prepare for release v0.27.0-rc.1 (#103)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.47.0-rc.2](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.47.0-rc.2)
+
+- [5e21bff3](https://github.com/kubedb/mariadb-coordinator/commit/5e21bff3) Prepare for release v0.47.0-rc.2 (#190)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.27.0-rc.2](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.27.0-rc.2)
+
+- [7af0e9d9](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/7af0e9d9) Prepare for release v0.27.0-rc.2 (#86)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.25.0-rc.2](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.25.0-rc.2)
+
+- [356bcc77](https://github.com/kubedb/mariadb-restic-plugin/commit/356bcc77) Prepare for release v0.25.0-rc.2 (#104)
+
+
+
+## [kubedb/migrator](https://github.com/kubedb/migrator)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/migrator/releases/tag/v0.7.0-rc.2)
+
+- [c6feaa68](https://github.com/kubedb/migrator/commit/c6feaa68) Prepare for release v0.7.0-rc.2 (#54)
+- [5d3b4cca](https://github.com/kubedb/migrator/commit/5d3b4cca) Prepare for release v0.7.0-rc.1 (#53)
+- [90f812e8](https://github.com/kubedb/migrator/commit/90f812e8) fixed patch issue
+- [20d0ec20](https://github.com/kubedb/migrator/commit/20d0ec20) Fix MSSQL snapshot FK disable retries and CDC start LSN validation (#50)
+
+
+
+## [kubedb/milvus](https://github.com/kubedb/milvus)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/milvus/releases/tag/v0.8.0-rc.2)
+
+- [c838b4d9](https://github.com/kubedb/milvus/commit/c838b4d9) Prepare for release v0.8.0-rc.2 (#65)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.60.0-rc.2](https://github.com/kubedb/mongodb/releases/tag/v0.60.0-rc.2)
+
+- [46539ef2](https://github.com/kubedb/mongodb/commit/46539ef20) Prepare for release v0.60.0-rc.2 (#785)
+- [2c3af67f](https://github.com/kubedb/mongodb/commit/2c3af67f2) Prepare for release v0.60.0-rc.1 (#784)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.28.0-rc.2)
+
+- [23358801](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/23358801) Prepare for release v0.28.0-rc.2 (#92)
+- [926b7b03](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/926b7b03) Prepare for release v0.28.0-rc.1 (#91)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.30.0-rc.2](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.30.0-rc.2)
+
+- [4966212d](https://github.com/kubedb/mongodb-restic-plugin/commit/4966212d) Prepare for release v0.30.0-rc.2 (#139)
+- [aa7a7eb6](https://github.com/kubedb/mongodb-restic-plugin/commit/aa7a7eb6) Prepare for release v0.30.0-rc.1 (#138)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.22.0-rc.2)
+
+- [e5df95bf](https://github.com/kubedb/mssql-coordinator/commit/e5df95bf) Prepare for release v0.22.0-rc.2 (#83)
+- [7d190db9](https://github.com/kubedb/mssql-coordinator/commit/7d190db9) Prepare for release v0.22.0-rc.1 (#82)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/mssqlserver/releases/tag/v0.22.0-rc.2)
+
+- [63ce4105](https://github.com/kubedb/mssqlserver/commit/63ce4105) Prepare for release v0.22.0-rc.2 (#159)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.21.0-rc.2](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.21.0-rc.2)
+
+- [e86bac3](https://github.com/kubedb/mssqlserver-archiver/commit/e86bac3) Prepare for release v0.21.0-rc.2 (#37)
+- [c014e1f](https://github.com/kubedb/mssqlserver-archiver/commit/c014e1f) Prepare for release v0.21.0-rc.1 (#36)
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.21.0-rc.2](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.21.0-rc.2)
+
+- [d7e11547](https://github.com/kubedb/mssqlserver-walg-plugin/commit/d7e11547) Prepare for release v0.21.0-rc.2 (#70)
+- [9e36bfed](https://github.com/kubedb/mssqlserver-walg-plugin/commit/9e36bfed) Prepare for release v0.21.0-rc.1 (#69)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/mysql-archiver/releases/tag/v0.28.0-rc.2)
+
+- [82342bcb](https://github.com/kubedb/mysql-archiver/commit/82342bcb) Prepare for release v0.28.0-rc.2 (#117)
+- [d4e1e633](https://github.com/kubedb/mysql-archiver/commit/d4e1e633) Prepare for release v0.28.0-rc.1 (#116)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.45.0-rc.2](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.45.0-rc.2)
+
+- [fc1b0d2c](https://github.com/kubedb/mysql-coordinator/commit/fc1b0d2c) Prepare for release v0.45.0-rc.2 (#193)
+- [9819d7b6](https://github.com/kubedb/mysql-coordinator/commit/9819d7b6) Prepare for release v0.45.0-rc.1 (#192)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.28.0-rc.2)
+
+- [7f1d1457](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/7f1d1457) Prepare for release v0.28.0-rc.2 (#89)
+- [a51d7fa0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/a51d7fa0) Prepare for release v0.28.0-rc.1 (#88)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.30.0-rc.2](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.30.0-rc.2)
+
+- [b5b9f288](https://github.com/kubedb/mysql-restic-plugin/commit/b5b9f288) Prepare for release v0.30.0-rc.2 (#125)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.45.0-rc.2](https://github.com/kubedb/mysql-router-init/releases/tag/v0.45.0-rc.2)
+
+- [2a6cad1](https://github.com/kubedb/mysql-router-init/commit/2a6cad1) Prepare for release v0.45.0-rc.2 (#71)
+- [b195b0d](https://github.com/kubedb/mysql-router-init/commit/b195b0d) Prepare for release v0.45.0-rc.1 (#70)
+
+
+
+## [kubedb/neo4j](https://github.com/kubedb/neo4j)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/neo4j/releases/tag/v0.8.0-rc.2)
+
+- [f4928a76](https://github.com/kubedb/neo4j/commit/f4928a76) Prepare for release v0.8.0-rc.2 (#64)
+- [6a325a04](https://github.com/kubedb/neo4j/commit/6a325a04) Add remoteAliasKeystore Support (#62)
+
+
+
+## [kubedb/neo4j-backup-plugin](https://github.com/kubedb/neo4j-backup-plugin)
+
+### [v0.3.0-rc.2](https://github.com/kubedb/neo4j-backup-plugin/releases/tag/v0.3.0-rc.2)
+
+- [648128c](https://github.com/kubedb/neo4j-backup-plugin/commit/648128c) Prepare for release v0.3.0-rc.2 (#15)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.54.0-rc.2](https://github.com/kubedb/ops-manager/releases/tag/v0.54.0-rc.2)
+
+- [14dae0ce](https://github.com/kubedb/ops-manager/commit/14dae0ce3) Prepare for release v0.54.0-rc.2 (#896)
+- [5be49aad](https://github.com/kubedb/ops-manager/commit/5be49aad6) Wire Etcd into ops-manager (#893)
+
+
+
+## [kubedb/oracle](https://github.com/kubedb/oracle)
+
+### [v0.13.0-rc.2](https://github.com/kubedb/oracle/releases/tag/v0.13.0-rc.2)
+
+- [8fade5e6](https://github.com/kubedb/oracle/commit/8fade5e6) Prepare for release v0.13.0-rc.2 (#85)
+- [43336e9a](https://github.com/kubedb/oracle/commit/43336e9a) Only watch virtual-secrets Secret when the CRD is installed (#83)
+
+
+
+## [kubedb/oracle-coordinator](https://github.com/kubedb/oracle-coordinator)
+
+### [v0.13.0-rc.2](https://github.com/kubedb/oracle-coordinator/releases/tag/v0.13.0-rc.2)
+
+- [4a8e34f](https://github.com/kubedb/oracle-coordinator/commit/4a8e34f) Prepare for release v0.13.0-rc.2 (#47)
+- [bc1a81a](https://github.com/kubedb/oracle-coordinator/commit/bc1a81a) Prepare for release v0.13.0-rc.1 (#46)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.54.0-rc.2](https://github.com/kubedb/percona-xtradb/releases/tag/v0.54.0-rc.2)
+
+- [4053fd3b](https://github.com/kubedb/percona-xtradb/commit/4053fd3b4) Prepare for release v0.54.0-rc.2 (#475)
+- [3713865b](https://github.com/kubedb/percona-xtradb/commit/3713865bd) Prepare for release v0.54.0-rc.1 (#474)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.40.0-rc.2](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.40.0-rc.2)
+
+- [aec6c642](https://github.com/kubedb/percona-xtradb-coordinator/commit/aec6c642) Prepare for release v0.40.0-rc.2 (#137)
+- [4fe082df](https://github.com/kubedb/percona-xtradb-coordinator/commit/4fe082df) Prepare for release v0.40.0-rc.1 (#136)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.51.0-rc.2](https://github.com/kubedb/pg-coordinator/releases/tag/v0.51.0-rc.2)
+
+- [c4078ad7](https://github.com/kubedb/pg-coordinator/commit/c4078ad7) Prepare for release v0.51.0-rc.2 (#277)
+- [afd510df](https://github.com/kubedb/pg-coordinator/commit/afd510df) Prepare for release v0.51.0-rc.1 (#276)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.54.0-rc.2](https://github.com/kubedb/pgbouncer/releases/tag/v0.54.0-rc.2)
+
+- [1e630e73](https://github.com/kubedb/pgbouncer/commit/1e630e738) Prepare for release v0.54.0-rc.2 (#431)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/pgpool/releases/tag/v0.22.0-rc.2)
+
+- [ca61fed3](https://github.com/kubedb/pgpool/commit/ca61fed3) Prepare for release v0.22.0-rc.2 (#146)
+- [8e775fe2](https://github.com/kubedb/pgpool/commit/8e775fe2) Prepare for release v0.22.0-rc.1 (#145)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.67.0-rc.2](https://github.com/kubedb/postgres/releases/tag/v0.67.0-rc.2)
+
+- [2ccb9242](https://github.com/kubedb/postgres/commit/2ccb92429) Prepare for release v0.67.0-rc.2 (#932)
+- [7f83ef35](https://github.com/kubedb/postgres/commit/7f83ef35f) Prepare for release v0.67.0-rc.1 (#931)
+- [52fab24a](https://github.com/kubedb/postgres/commit/52fab24ae) Project configSecret key user_hba.conf into the config volume (#929)
+- [4dde82f7](https://github.com/kubedb/postgres/commit/4dde82f7d) Add Postgres license support for the AppsCode Enterprise distribution (#930)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/postgres-archiver/releases/tag/v0.28.0-rc.2)
+
+- [61113d99](https://github.com/kubedb/postgres-archiver/commit/61113d99) Prepare for release v0.28.0-rc.2 (#120)
+- [9de43b9a](https://github.com/kubedb/postgres-archiver/commit/9de43b9a) Prepare for release v0.28.0-rc.1 (#119)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.28.0-rc.2)
+
+- [96c9afa4](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/96c9afa4) Prepare for release v0.28.0-rc.2 (#98)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.30.0-rc.2](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.30.0-rc.2)
+
+- [1685bd96](https://github.com/kubedb/postgres-restic-plugin/commit/1685bd96) Prepare for release v0.30.0-rc.2 (#125)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/provider-aws/releases/tag/v0.28.0-rc.2)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/provider-azure/releases/tag/v0.28.0-rc.2)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.28.0-rc.2](https://github.com/kubedb/provider-gcp/releases/tag/v0.28.0-rc.2)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.67.0-rc.2](https://github.com/kubedb/provisioner/releases/tag/v0.67.0-rc.2)
+
+- [390c0678](https://github.com/kubedb/provisioner/commit/390c0678c) Prepare for release v0.67.0-rc.2 (#227)
+- [314a0777](https://github.com/kubedb/provisioner/commit/314a07777) Add Etcd to the shared provisioner (#226)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.54.0-rc.2](https://github.com/kubedb/proxysql/releases/tag/v0.54.0-rc.2)
+
+- [da71f7d1](https://github.com/kubedb/proxysql/commit/da71f7d19) Prepare for release v0.54.0-rc.2 (#451)
+
+
+
+## [kubedb/qdrant](https://github.com/kubedb/qdrant)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/qdrant/releases/tag/v0.8.0-rc.2)
+
+- [5ee354a3](https://github.com/kubedb/qdrant/commit/5ee354a3) Prepare for release v0.8.0-rc.2 (#63)
+- [222d8df0](https://github.com/kubedb/qdrant/commit/222d8df0) Prepare for release v0.8.0-rc.1 (#62)
+- [4a96ed61](https://github.com/kubedb/qdrant/commit/4a96ed61) Add JWT RBAC Granular Access Control (#61)
+
+
+
+## [kubedb/qdrant-restic-plugin](https://github.com/kubedb/qdrant-restic-plugin)
+
+### [v0.3.0-rc.2](https://github.com/kubedb/qdrant-restic-plugin/releases/tag/v0.3.0-rc.2)
+
+- [0bc1f5b](https://github.com/kubedb/qdrant-restic-plugin/commit/0bc1f5b) Prepare for release v0.3.0-rc.2 (#12)
+- [0b2e713](https://github.com/kubedb/qdrant-restic-plugin/commit/0b2e713) Prepare for release v0.3.0-rc.1 (#11)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/rabbitmq/releases/tag/v0.22.0-rc.2)
+
+- [1874c2f9](https://github.com/kubedb/rabbitmq/commit/1874c2f9) Prepare for release v0.22.0-rc.2 (#156)
+- [86a6bb4b](https://github.com/kubedb/rabbitmq/commit/86a6bb4b) Prepare for release v0.22.0-rc.1 (#155)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.60.0-rc.2](https://github.com/kubedb/redis/releases/tag/v0.60.0-rc.2)
+
+- [8b388b37](https://github.com/kubedb/redis/commit/8b388b377) Prepare for release v0.60.0-rc.2 (#678)
+- [282f64f7](https://github.com/kubedb/redis/commit/282f64f70) Prepare for release v0.60.0-rc.1 (#677)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.46.0-rc.2](https://github.com/kubedb/redis-coordinator/releases/tag/v0.46.0-rc.2)
+
+- [ff09aab0](https://github.com/kubedb/redis-coordinator/commit/ff09aab0) Prepare for release v0.46.0-rc.2 (#170)
+- [1492448b](https://github.com/kubedb/redis-coordinator/commit/1492448b) Prepare for release v0.46.0-rc.1 (#169)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.30.0-rc.2](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.30.0-rc.2)
+
+- [64b9daf6](https://github.com/kubedb/redis-restic-plugin/commit/64b9daf6) Prepare for release v0.30.0-rc.2 (#117)
+- [16b1a7d9](https://github.com/kubedb/redis-restic-plugin/commit/16b1a7d9) Prepare for release v0.30.0-rc.1 (#116)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.54.0-rc.2](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.54.0-rc.2)
+
+- [a4317b50](https://github.com/kubedb/replication-mode-detector/commit/a4317b50) Prepare for release v0.54.0-rc.2 (#332)
+- [ec8486cf](https://github.com/kubedb/replication-mode-detector/commit/ec8486cf) Prepare for release v0.54.0-rc.1 (#331)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.43.0-rc.2](https://github.com/kubedb/schema-manager/releases/tag/v0.43.0-rc.2)
+
+- [72cd0f46](https://github.com/kubedb/schema-manager/commit/72cd0f46) Prepare for release v0.43.0-rc.2 (#178)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/singlestore/releases/tag/v0.22.0-rc.2)
+
+- [e770aa63](https://github.com/kubedb/singlestore/commit/e770aa63) Prepare for release v0.22.0-rc.2 (#147)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.22.0-rc.2)
+
+- [8b0d0cc7](https://github.com/kubedb/singlestore-coordinator/commit/8b0d0cc7) Prepare for release v0.22.0-rc.2 (#82)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.25.0-rc.2](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.25.0-rc.2)
+
+- [f5db3d86](https://github.com/kubedb/singlestore-restic-plugin/commit/f5db3d86) Prepare for release v0.25.0-rc.2 (#97)
+- [aca72da8](https://github.com/kubedb/singlestore-restic-plugin/commit/aca72da8) Prepare for release v0.25.0-rc.1 (#96)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/solr/releases/tag/v0.22.0-rc.2)
+
+- [e416a480](https://github.com/kubedb/solr/commit/e416a480) Prepare for release v0.22.0-rc.2 (#159)
+- [f6b10d41](https://github.com/kubedb/solr/commit/f6b10d41) Prepare for release v0.22.0-rc.1 (#158)
+- [a49c4523](https://github.com/kubedb/solr/commit/a49c4523) Extend Reconfigure Ops for Backup Creds (#151)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.52.0-rc.2](https://github.com/kubedb/tests/releases/tag/v0.52.0-rc.2)
+
+- [fc7d163f](https://github.com/kubedb/tests/commit/fc7d163f0) Prepare for release v0.52.0-rc.2 (#555)
+- [b5d2167e](https://github.com/kubedb/tests/commit/b5d2167e1) Prepare for release v0.52.0-rc.1 (#554)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.43.0-rc.2](https://github.com/kubedb/ui-server/releases/tag/v0.43.0-rc.2)
+
+- [7cd8d580](https://github.com/kubedb/ui-server/commit/7cd8d5800) Prepare for release v0.43.0-rc.2 (#224)
+
+
+
+## [kubedb/weaviate](https://github.com/kubedb/weaviate)
+
+### [v0.8.0-rc.2](https://github.com/kubedb/weaviate/releases/tag/v0.8.0-rc.2)
+
+- [bdd46c25](https://github.com/kubedb/weaviate/commit/bdd46c25) Prepare for release v0.8.0-rc.2 (#62)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.43.0-rc.2](https://github.com/kubedb/webhook-server/releases/tag/v0.43.0-rc.2)
+
+- [40d19ceb](https://github.com/kubedb/webhook-server/commit/40d19ceb4) Prepare for release v0.43.0-rc.2 (#235)
+
+
+
+## [kubedb/xtrabackup-restic-plugin](https://github.com/kubedb/xtrabackup-restic-plugin)
+
+### [v0.15.0-rc.2](https://github.com/kubedb/xtrabackup-restic-plugin/releases/tag/v0.15.0-rc.2)
+
+- [d68946ba](https://github.com/kubedb/xtrabackup-restic-plugin/commit/d68946ba) Prepare for release v0.15.0-rc.2 (#66)
+- [2f7ff61c](https://github.com/kubedb/xtrabackup-restic-plugin/commit/2f7ff61c) Prepare for release v0.15.0-rc.1 (#65)
+- [0959f5cf](https://github.com/kubedb/xtrabackup-restic-plugin/commit/0959f5cf) Add 9.7.1 version (#64)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/zookeeper/releases/tag/v0.22.0-rc.2)
+
+- [4ef9e89a](https://github.com/kubedb/zookeeper/commit/4ef9e89a) Prepare for release v0.22.0-rc.2 (#142)
+- [c588db00](https://github.com/kubedb/zookeeper/commit/c588db00) Prepare for release v0.22.0-rc.1 (#141)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.22.0-rc.2](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.22.0-rc.2)
+
+- [48526261](https://github.com/kubedb/zookeeper-restic-plugin/commit/48526261) Prepare for release v0.22.0-rc.2 (#81)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.8.26-rc.2
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/144
Signed-off-by: 1gtm <1gtm@appscode.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the KubeDB v2026.8.26-rc.2 changelog page.
  - Documented release metadata, component versions, and release entries.
  - Included updates covering Etcd support, installer and addon improvements, database fixes, backup and restore, scaling, and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->